### PR TITLE
Add Bluebook Law Review Secondary Sources style

### DIFF
--- a/bluebook-law-review-secondary-sources.csl
+++ b/bluebook-law-review-secondary-sources.csl
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<<<<<<< HEAD
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="display-and-sort" default-locale="en-US" delimiter-precedes-last="never">
 
-=======
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="display-and-sort" delimiter-precedes-last="never" default-locale="en-US">
->>>>>>> 907772a46e0899a3367d2b2c2ebf2b39f7b0dce9
   <info>
     <title>Bluebook Law Review Secondary Sources</title>
     <title-short>Bluebook LR Secondary Sources</title-short>
@@ -16,7 +13,8 @@
     </author>
     <category citation-format="note"/>
     <category field="law"/>
-    <summary>Bluebook (22nd ed. 2025) law review footnote citation style covering:
+    <summary>
+      Bluebook (22nd ed. 2025) law review footnote citation style covering:
 
       MONOGRAPHIC SOURCES (Rule 15): books, edited volumes, book chapters,
       theses, dissertations, reports, and government documents.
@@ -30,7 +28,7 @@
 
       INTERNET SOURCES (Rule 18): webpages and web-based sources (R18.2),
       AI-generated content (R18.3), electronic storage media (R18.5),
-      microform &#8212; standalone original collections (R18.6(b)), films and
+      microform — standalone original collections (R18.6(b)), films and
       documentaries (R18.7.1), television series (R18.7.2), web-based
       video (R18.7.4), audio recordings and streaming services including
       podcasts (R18.8), images and photographs (R18.9), social media
@@ -101,7 +99,7 @@
       "Harv. L. Rev." are entered pre-abbreviated; (c) episode names
       (container-title in Broadcast/Audio items) render as entered.
       Rule 8(b) requires internet page titles to follow source capitalization;
-      the CSL applies title case to webpage titles as a practical default &#8212;
+      the CSL applies title case to webpage titles as a practical default —
       editors should verify against the actual source.
 
       INSTITUTIONAL AUTHORS (R15.1(c)): Zotero does not apply
@@ -199,7 +197,7 @@
       the @ symbol) in Zotero's Number field. Enter the platform name
       (e.g. "X", "Instagram", "Facebook") in Publication. Enter the date
       in Date. Enter the time (e.g. "11:04 ET") in Extra as
-      "locator: 11:04 ET" &#8212; the CSL prepends "at". Enter the post URL in
+      "locator: 11:04 ET" — the CSL prepends "at". Enter the post URL in
       URL. Enter a Perma.cc archival URL in Archive (renders in brackets).
       LIMITATION: Visual/audio posts (R18.10(a)) require "Video posted by"
       or "Image posted by" before the name; this prefix cannot be
@@ -234,19 +232,19 @@
       type. Enter the creator in Author (roman type). Enter the title
       or description in Title (renders in italics, title-cased). Enter
       the work type (e.g. "photograph", "painting", "illustration") in
-      Medium &#8212; this renders in the type parenthetical. Enter the year
+      Medium — this renders in the type parenthetical. Enter the year
       in Date. Enter "on file with" location in Archive. Enter a URL
       in URL when the image is publicly hosted. The "reprinted by" form
-      (R18.9) and emoji citations must be added manually &#8212; CSL cannot
+      (R18.9) and emoji citations must be added manually — CSL cannot
       express compound related-authority citations or Unicode code points.
 
-      23. MICROFORM &#8212; STANDALONE (R18.6(b)): Use Zotero's "Standard"
+      23. MICROFORM — STANDALONE (R18.6(b)): Use Zotero's "Standard"
       item type for microform collections containing original materials.
       Enter the collection title in Title (small caps). Enter the
       collection identifier (e.g. "Fiche 143") in Number. Enter the
       publisher of the microform series in Publisher.
       NOTE: R18.6(a) citations to reproduced materials use the form
-      "[original citation], *microformed on* ID (Publisher)" &#8212; generate
+      "[original citation], *microformed on* ID (Publisher)" — generate
       the original citation using the appropriate source type, then add
       the "*microformed on*" clause manually.
 
@@ -267,10 +265,12 @@
       enter the repository URL in URL (presence of URL triggers the
       open-source format) and enter "last accessed" or "last updated"
       in Archive. The emulation form ("*emulated on*") must be added
-      manually &#8212; CSL cannot express compound related-authority citations.</summary>
+      manually — CSL cannot express compound related-authority citations.
+    </summary>
     <updated>2026-04-01T03:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+
   <!-- LOCALE -->
   <locale xml:lang="en">
     <terms>
@@ -290,9 +290,11 @@
       <term name="ordinal-03">d</term>
     </terms>
   </locale>
+
   <!-- ============================================================
        MACROS
        ============================================================ -->
+
   <!--
     AUTHOR-BOOK macro
     Bluebook R15.1: full name in small caps, ampersand between last two.
@@ -307,6 +309,7 @@
       </substitute>
     </names>
   </macro>
+
   <!--
     AUTHOR-ARTICLE macro
     Bluebook R16.2: full name in ordinary roman type (not small caps).
@@ -323,6 +326,7 @@
       <name and="symbol" delimiter=", " delimiter-precedes-last="never" initialize="false"/>
     </names>
   </macro>
+
   <!--
     EDITOR macro
     Bluebook R15.2: roman type, "ed." or "eds." label.
@@ -333,6 +337,7 @@
       <label form="short" prefix=" "/>
     </names>
   </macro>
+
   <!--
     TRANSLATOR macro
     Bluebook R15.2: roman type, "trans." label.
@@ -343,6 +348,7 @@
       <label form="short" prefix=" "/>
     </names>
   </macro>
+
   <!--
     EDITION macro
     Bluebook R15.4: "4th ed." inside the publication parenthetical.
@@ -361,6 +367,7 @@
       </else-if>
     </choose>
   </macro>
+
   <!--
     PUBLISH-DETAILS macro
     Bluebook R15.2 and R15.4: single parenthetical with translator, editor,
@@ -403,6 +410,7 @@
       </choose>
     </group>
   </macro>
+
   <!--
     PUBLISHER-YEAR macro
     Simplified parenthetical for reports, manuscripts, documents.
@@ -415,6 +423,7 @@
       </date>
     </group>
   </macro>
+
   <!--
     JOURNAL-ARTICLE macro
     R16.4 (volume present): Author, Title, Volume Journal Page (Year).
@@ -512,6 +521,7 @@
       </else>
     </choose>
   </macro>
+
   <!--
     NEWSPAPER-ARTICLE macro
     Bluebook R16.6: Author, Title, Newspaper, Month Day, Year, at Page.
@@ -566,6 +576,7 @@
       </choose>
     </group>
   </macro>
+
   <!--
     MANUSCRIPT-DATE macro
     Bluebook R17.2: unpublished materials use full date (Month Day, Year).
@@ -579,6 +590,7 @@
       <date-part name="year"/>
     </date>
   </macro>
+
   <!--
     Bluebook R18.2.2: Author, Title, Site Name (Date), URL.
     - Author in roman type (R18.2.2(a))
@@ -615,6 +627,7 @@
       </choose>
     </group>
   </macro>
+
   <!--
     ARCHIVAL macro
     Bluebook R23: Author, Title, Date (on file with Archive, Collection, Location).
@@ -652,6 +665,7 @@
       </choose>
     </group>
   </macro>
+
   <!--
     FILM macro
     Bluebook R18.7.1: commercial and noncommercial films.
@@ -741,6 +755,7 @@
       </else>
     </choose>
   </macro>
+
   <!--
     TV-SERIES macro
     Bluebook R18.7.2: TITLE: Episode Name (Platform, Date).
@@ -748,12 +763,12 @@
     as broadcast type without URL (e.g. podcast on physical media).
     Zotero field mapping:
       Title           -> title (series name, small caps)
-      container-title -> episode name (italics) &#8212; enter in Extra as
+      container-title -> episode name (italics) — enter in Extra as
                          container-title: Episode Name
       Publisher       -> platform / network / streaming service
       Date            -> broadcast or release date
       Medium          -> access medium (e.g. "NBC television broadcast",
-                         "DVD", "Netflix") &#8212; if blank, publisher is used alone
+                         "DVD", "Netflix") — if blank, publisher is used alone
   -->
   <macro name="tv-series">
     <!--
@@ -818,6 +833,7 @@
       </choose>
     </group>
   </macro>
+
   <!--
     WEB-VIDEO macro
     Bluebook R18.7.4: ACCOUNT, Title of Video, at timestamp
@@ -866,6 +882,7 @@
       </choose>
     </group>
   </macro>
+
   <!--
     AUDIO-RECORDING macro
     Bluebook R18.8: physical recordings, streaming, and podcasts.
@@ -993,6 +1010,7 @@
       </else>
     </choose>
   </macro>
+
   <!--
     SOCIAL-MEDIA macro
     Bluebook R18.10: posts on X (Twitter), Instagram, Facebook, Mastodon, etc.
@@ -1001,7 +1019,7 @@
     - @handle in roman type immediately after name in parentheses
     - Platform name in small caps (R18.10(b))
     - Date and time in parenthetical (R18.10(c)); time entered via locator
-    - URL followed by archival URL in brackets &#8212; archival must be added manually
+    - URL followed by archival URL in brackets — archival must be added manually
     Zotero field mapping:
       Author          -> real name of poster
       number          -> @handle (without the @; CSL will prepend @)
@@ -1009,7 +1027,7 @@
       Date            -> date of post (with time if available)
       locator         -> time of post (e.g. "3:14 PM ET")
       URL             -> URL of the post
-      archive         -> archival (Perma.cc) URL &#8212; enter as "on file with" if institutional
+      archive         -> archival (Perma.cc) URL — enter as "on file with" if institutional
     NOTE: Perma.cc URL should follow the primary URL in brackets per R18.10.
     Enter the Perma.cc link manually in the document, or store it in Zotero
     Extra as a note. The CSL appends the archive field as a second bracketed URL
@@ -1035,7 +1053,7 @@
           </choose>
         </if>
         <else-if variable="number">
-          <!-- No real name &#8212; render @handle alone as identifier -->
+          <!-- No real name — render @handle alone as identifier -->
           <text variable="number" prefix="@" suffix=","/>
         </else-if>
       </choose>
@@ -1081,16 +1099,17 @@
       </choose>
     </group>
   </macro>
+
   <!--
     AI-CONTENT macro
     Bluebook R18.3: citations to AI-generated text, images, and search outputs.
     Format: Author, Model Name, Description of Content (Date)
             (on file with Journal).
     - Author = person who prompted / generated the content (roman type)
-    - Model Name = AI model (e.g., "OpenAI GPT 3.5", "Claude 3 Opus") &#8212; Publisher field
-    - Description = brief description of generated content &#8212; Title field
+    - Model Name = AI model (e.g., "OpenAI GPT 3.5", "Claude 3 Opus") — Publisher field
+    - Description = brief description of generated content — Title field
     - Date = date of generation in parenthetical
-    - "on file with" = journal or institution holding the content &#8212; Archive field
+    - "on file with" = journal or institution holding the content — Archive field
     Zotero field mapping:
       Author    -> person who generated the content
       Publisher -> AI model name (e.g. "OpenAI GPT 3.5")
@@ -1126,11 +1145,12 @@
       </choose>
     </group>
   </macro>
+
   <!--
     ELECTRONIC-MEDIA macro
     Bluebook R18.5: physical electronic storage media and cloud storage.
 
-    (a) Physical media &#8212; R18.5(a):
+    (a) Physical media — R18.5(a):
     Format: Title [filename], Owner (Medium, last modified Date) (on file with Location).
     Example: Bluebook Invitational Schedule 2024 [BBI24_Sch.docx], Columbia Law Review
              (USB Drive, last modified Apr. 13, 2024) (on file with the Columbia Law Review).
@@ -1143,7 +1163,7 @@
       Date            -> last modified date
       Archive         -> "on file with" location
 
-    (b) Cloud storage &#8212; R18.5(b):
+    (b) Cloud storage — R18.5(b):
     Format: Author, Title, URL (Owner, Folder, Platform) (last modified Date) (on file).
     Example: Benjamin Liebman, Empirical Research on Chinese Case Data, g.drv/liebman
              (Colum. L. Rev., Liebman on China, Google Drive) (last modified June 18, 2024)
@@ -1243,6 +1263,7 @@
       </else>
     </choose>
   </macro>
+
   <!--
     IMAGE macro
     Bluebook R18.9: photographs, illustrations, paintings, and other works of art.
@@ -1260,9 +1281,9 @@
       URL     -> URL when image is hosted online (renders after parenthetical)
 
     NOTE: Use Zotero's "Artwork" item type (graphic) for R18.9 images.
-    For the "reprinted by" form, add a manual note &#8212; CSL cannot express
+    For the "reprinted by" form, add a manual note — CSL cannot express
     compound related-authority citations automatically.
-    For emojis (R18.9), cite manually &#8212; no CSL field maps to Unicode code points.
+    For emojis (R18.9), cite manually — no CSL field maps to Unicode code points.
   -->
   <macro name="image">
     <group delimiter=" ">
@@ -1289,13 +1310,14 @@
       </choose>
     </group>
   </macro>
+
   <!--
     MICROFORM macro
     Bluebook R18.6(b): standalone microform collections with original materials.
     Format: Title, Collection ID (Publisher).
     The collection identifier (e.g. "Fiche 143", "CIS No. 89-H523-17") goes in Number.
 
-    R18.6(a) &#8212; microform reproductions of preexisting materials &#8212; uses the
+    R18.6(a) — microform reproductions of preexisting materials — uses the
     "*microformed on*" related-authority form appended to the original citation.
     This cannot be automated in CSL; editors must add the "*microformed on*"
     clause manually after generating the citation for the original source.
@@ -1328,6 +1350,7 @@
       </group>
     </group>
   </macro>
+
   <!--
     HARDWARE macro
     Bluebook R18.11.1: physical hardware devices.
@@ -1355,6 +1378,7 @@
       </if>
     </choose>
   </macro>
+
   <!--
     SOFTWARE macro
     Bluebook R18.11.2: software citations (general, open source, payment software).
@@ -1374,7 +1398,7 @@
       Author  -> developer name (small caps); omit if same as software name
       Title   -> official software name (italics)
       Version -> version string (e.g. "Ver. 16.86.1"); enter in Extra as
-                 "version: Ver. 16.86.1" &#8212; CSL uses the version variable
+                 "version: Ver. 16.86.1" — CSL uses the version variable
       Genre   -> platform (e.g. "Windows", "iOS"); enter in Extra as
                  "genre: iOS"
       Number  -> SKU or build number for optional parenthetical
@@ -1452,12 +1476,14 @@
       </else>
     </choose>
   </macro>
+
   <!-- ============================================================
        CITATION (footnote) element
        ============================================================ -->
   <citation>
     <layout suffix="." delimiter="; ">
       <choose>
+
         <!-- Ibid with locator: Id. at X -->
         <if position="ibid-with-locator">
           <group delimiter=" ">
@@ -1466,23 +1492,28 @@
             <text variable="locator"/>
           </group>
         </if>
-        <!-- Ibid without locator: Id. &#8212; strip-periods removes the term's trailing
+
+        <!-- Ibid without locator: Id. — strip-periods removes the term's trailing
              period so the layout suffix "." supplies the single closing period. -->
         <else-if position="ibid">
           <text term="ibid" font-style="italic" text-case="capitalize-first" strip-periods="true"/>
         </else-if>
+
         <!-- JOURNAL ARTICLE (R16.4 / R16.5) -->
         <else-if type="article-journal">
           <text macro="journal-article"/>
         </else-if>
+
         <!-- MAGAZINE ARTICLE (R16.5) -->
         <else-if type="article-magazine">
           <text macro="journal-article"/>
         </else-if>
+
         <!-- NEWSPAPER ARTICLE (R16.6) -->
         <else-if type="article-newspaper">
           <text macro="newspaper-article"/>
         </else-if>
+
         <!-- WEBPAGE (R18.2.2)
              Author, Title, Site Name (Date), URL.
              Uses Zotero "webpage" item type.
@@ -1490,6 +1521,7 @@
         <else-if type="webpage post-weblog">
           <text macro="webpage"/>
         </else-if>
+
         <!-- FILM (R18.7.1)
              Commercial: TITLE, Medium (Producer Year).
              Noncommercial: Author, TITLE (Year) (on file with ...).
@@ -1498,14 +1530,15 @@
         <else-if type="motion_picture">
           <text macro="film"/>
         </else-if>
+
         <!-- BROADCAST: TV series (R18.7.2) or web video (R18.7.4)
              TV series: TITLE: Episode (Platform, Date).
              Web video: ACCOUNT, Title, at timestamp (Platform, Date), URL.
              Distinguish by URL: web-based videos have a URL; TV series do not.
              Uses Zotero "broadcast" item type.
              Zotero field mapping:
-               TV series  &#8212; Title = series name, Extra: container-title = episode
-               Web video  &#8212; Author = account, Title = video title, URL = URL
+               TV series  — Title = series name, Extra: container-title = episode
+               Web video  — Author = account, Title = video title, URL = URL
         -->
         <else-if type="broadcast">
           <choose>
@@ -1517,6 +1550,7 @@
             </else>
           </choose>
         </else-if>
+
         <!-- AUDIO RECORDING (R18.8)
              Physical / streaming / podcast citations.
              Uses Zotero "song" item type.
@@ -1524,6 +1558,7 @@
         <else-if type="song">
           <text macro="audio-recording"/>
         </else-if>
+
         <!-- BOOK (R15.1-15.4) -->
         <else-if type="book">
           <group delimiter=" ">
@@ -1545,6 +1580,7 @@
             <text macro="publish-details"/>
           </group>
         </else-if>
+
         <!-- CHAPTER IN EDITED VOLUME (R15.5.1(a)) -->
         <else-if type="chapter">
           <group delimiter=" ">
@@ -1565,6 +1601,7 @@
             <text macro="publish-details"/>
           </group>
         </else-if>
+
         <!-- THESIS / DISSERTATION (R17.2.2)
              Author, Title (Month Day, Year)
              (genre, University) (on file with Location).
@@ -1605,6 +1642,7 @@
             </choose>
           </group>
         </else-if>
+
         <!-- REPORT / WORKING PAPER (R17.4, R15.1, R15.4)
              Author, Title pinpoint (Publisher, Working Paper No. X, Year).
              Zotero field mapping:
@@ -1634,6 +1672,7 @@
             </group>
           </group>
         </else-if>
+
         <!-- MANUSCRIPT (unpublished, R17.2.1) and FORTHCOMING (R17.3)
              Unpublished: Author, Title page (Month Day, Year)
                (unpublished manuscript) (on file with Location).
@@ -1673,6 +1712,7 @@
             </choose>
           </group>
         </else-if>
+
         <!-- DOCUMENT
              Used for two purposes:
              (a) Archival sources (R23): documents held in official archives.
@@ -1699,6 +1739,7 @@
             </else>
           </choose>
         </else-if>
+
         <!-- SOCIAL MEDIA POST (R18.10)
              Name (@handle), PLATFORM (Date, Time), URL [Perma.cc].
              Uses Zotero "post" item type.
@@ -1714,6 +1755,7 @@
         <else-if type="post">
           <text macro="social-media"/>
         </else-if>
+
         <!-- AI-GENERATED CONTENT (R18.3)
              Author, Model Name, Description (Date) (on file with Journal).
              Uses Zotero "software" item type.
@@ -1727,6 +1769,7 @@
         <else-if type="software">
           <text macro="ai-content"/>
         </else-if>
+
         <!-- ELECTRONIC STORAGE MEDIA (R18.5)
              Author, TITLE (Medium, Repository Year)
              (on file with Location).
@@ -1742,6 +1785,7 @@
         <else-if type="dataset">
           <text macro="electronic-media"/>
         </else-if>
+
         <!-- IMAGE / ARTWORK (R18.9)
              Author, *Title* (type Year) (on file with Location).
              Uses Zotero "Artwork" item type (graphic).
@@ -1756,11 +1800,12 @@
         <else-if type="graphic">
           <text macro="image"/>
         </else-if>
-        <!-- MICROFORM &#8212; STANDALONE (R18.6(b))
+
+        <!-- MICROFORM — STANDALONE (R18.6(b))
              Title, Collection ID (Publisher Year).
              Uses Zotero "Standard" item type.
              NOTE: R18.6(a) reproduced microforms use "*microformed on*" appended
-             to the original source citation &#8212; add this clause manually.
+             to the original source citation — add this clause manually.
              Zotero field mapping:
                Title     -> microform collection title (small caps)
                Number    -> collection ID or fiche/reel number
@@ -1770,6 +1815,7 @@
         <else-if type="standard">
           <text macro="microform"/>
         </else-if>
+
         <!-- HARDWARE (R18.11.1)
              MANUFACTURER, Model Name, PartNumber (SKU).
              Uses Zotero "Patent" item type.
@@ -1782,6 +1828,7 @@
         <else-if type="patent">
           <text macro="hardware"/>
         </else-if>
+
         <!-- SOFTWARE (R18.11.2)
              General: DEVELOPER, *Name*, Ver. X (Platform, Date).
              Open-source: DEVELOPER, *Name*, URL (last accessed/updated Date).
@@ -1800,6 +1847,7 @@
         <else-if type="entry-encyclopedia">
           <text macro="software"/>
         </else-if>
+
         <!-- FALLBACK -->
         <else>
           <group delimiter=" ">
@@ -1808,9 +1856,11 @@
             <text macro="publisher-year"/>
           </group>
         </else>
+
       </choose>
     </layout>
   </citation>
+
   <!-- ============================================================
        BIBLIOGRAPHY
        ============================================================ -->
@@ -1821,12 +1871,15 @@
     </sort>
     <layout suffix=".">
       <choose>
+
         <if type="article-journal article-magazine" match="any">
           <text macro="journal-article"/>
         </if>
+
         <else-if type="article-newspaper">
           <text macro="newspaper-article"/>
         </else-if>
+
         <else-if type="book">
           <group delimiter=" ">
             <choose>
@@ -1839,6 +1892,7 @@
             <text macro="publish-details"/>
           </group>
         </else-if>
+
         <else-if type="chapter">
           <group delimiter=" ">
             <text macro="author-book" suffix=","/>
@@ -1853,6 +1907,7 @@
             <text macro="publish-details"/>
           </group>
         </else-if>
+
         <else-if type="thesis">
           <group delimiter=" ">
             <text macro="author-book" suffix=","/>
@@ -1886,6 +1941,7 @@
             </choose>
           </group>
         </else-if>
+
         <else-if type="report">
           <group delimiter=" ">
             <text macro="author-book" suffix=","/>
@@ -1903,6 +1959,7 @@
             </group>
           </group>
         </else-if>
+
         <else-if type="manuscript">
           <group delimiter=" ">
             <text macro="author-book" suffix=","/>
@@ -1930,12 +1987,15 @@
             </choose>
           </group>
         </else-if>
+
         <else-if type="webpage post-weblog">
           <text macro="webpage"/>
         </else-if>
+
         <else-if type="motion_picture">
           <text macro="film"/>
         </else-if>
+
         <else-if type="broadcast">
           <choose>
             <if variable="URL">
@@ -1946,9 +2006,11 @@
             </else>
           </choose>
         </else-if>
+
         <else-if type="song">
           <text macro="audio-recording"/>
         </else-if>
+
         <else-if type="document">
           <choose>
             <if variable="archive">
@@ -1963,27 +2025,35 @@
             </else>
           </choose>
         </else-if>
+
         <else-if type="post">
           <text macro="social-media"/>
         </else-if>
+
         <else-if type="software">
           <text macro="ai-content"/>
         </else-if>
+
         <else-if type="dataset">
           <text macro="electronic-media"/>
         </else-if>
+
         <else-if type="graphic">
           <text macro="image"/>
         </else-if>
+
         <else-if type="standard">
           <text macro="microform"/>
         </else-if>
+
         <else-if type="patent">
           <text macro="hardware"/>
         </else-if>
+
         <else-if type="entry-encyclopedia">
           <text macro="software"/>
         </else-if>
+
         <else>
           <group delimiter=" ">
             <text macro="author-book" suffix=","/>
@@ -1991,7 +2061,9 @@
             <text macro="publisher-year"/>
           </group>
         </else>
+
       </choose>
     </layout>
   </bibliography>
+
 </style>

--- a/bluebook-law-review-secondary-sources.csl
+++ b/bluebook-law-review-secondary-sources.csl
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl"
-       class="note"
-       version="1.0"
-       demote-non-dropping-particle="display-and-sort"
-       default-locale="en-US"
-       delimiter-precedes-last="never">
+<<<<<<< HEAD
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="display-and-sort" default-locale="en-US" delimiter-precedes-last="never">
 
+=======
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="display-and-sort" delimiter-precedes-last="never" default-locale="en-US">
+>>>>>>> 907772a46e0899a3367d2b2c2ebf2b39f7b0dce9
   <info>
     <title>Bluebook Law Review Secondary Sources</title>
     <title-short>Bluebook LR Secondary Sources</title-short>
@@ -18,8 +17,7 @@
     </author>
     <category citation-format="note"/>
     <category field="law"/>
-    <summary>
-      Bluebook (22nd ed. 2025) law review footnote citation style covering:
+    <summary>Bluebook (22nd ed. 2025) law review footnote citation style covering:
 
       MONOGRAPHIC SOURCES (Rule 15): books, edited volumes, book chapters,
       theses, dissertations, reports, and government documents.
@@ -33,7 +31,7 @@
 
       INTERNET SOURCES (Rule 18): webpages and web-based sources (R18.2),
       AI-generated content (R18.3), electronic storage media (R18.5),
-      microform — standalone original collections (R18.6(b)), films and
+      microform &#8212; standalone original collections (R18.6(b)), films and
       documentaries (R18.7.1), television series (R18.7.2), web-based
       video (R18.7.4), audio recordings and streaming services including
       podcasts (R18.8), images and photographs (R18.9), social media
@@ -60,8 +58,8 @@
       "Harvard Law Review"). This style uses the Journal Abbreviation field
       (container-title-short) in Zotero when available, falling back to the
       Publication field (container-title) if not. To enable auto-abbreviation:
-      install a Bluebook journal abbreviation list in Zotero via Edit >
-      Preferences > Cite > Style Editor, or use the Juris-M abbreviation
+      install a Bluebook journal abbreviation list in Zotero via Edit &gt;
+      Preferences &gt; Cite &gt; Style Editor, or use the Juris-M abbreviation
       filter. If no abbreviation list is installed, enter the abbreviated
       journal name directly in Zotero's Journal Abbr. field for each item.
 
@@ -104,7 +102,7 @@
       "Harv. L. Rev." are entered pre-abbreviated; (c) episode names
       (container-title in Broadcast/Audio items) render as entered.
       Rule 8(b) requires internet page titles to follow source capitalization;
-      the CSL applies title case to webpage titles as a practical default —
+      the CSL applies title case to webpage titles as a practical default &#8212;
       editors should verify against the actual source.
 
       INSTITUTIONAL AUTHORS (R15.1(c)): Zotero does not apply
@@ -202,7 +200,7 @@
       the @ symbol) in Zotero's Number field. Enter the platform name
       (e.g. "X", "Instagram", "Facebook") in Publication. Enter the date
       in Date. Enter the time (e.g. "11:04 ET") in Extra as
-      "locator: 11:04 ET" — the CSL prepends "at". Enter the post URL in
+      "locator: 11:04 ET" &#8212; the CSL prepends "at". Enter the post URL in
       URL. Enter a Perma.cc archival URL in Archive (renders in brackets).
       LIMITATION: Visual/audio posts (R18.10(a)) require "Video posted by"
       or "Image posted by" before the name; this prefix cannot be
@@ -237,19 +235,19 @@
       type. Enter the creator in Author (roman type). Enter the title
       or description in Title (renders in italics, title-cased). Enter
       the work type (e.g. "photograph", "painting", "illustration") in
-      Medium — this renders in the type parenthetical. Enter the year
+      Medium &#8212; this renders in the type parenthetical. Enter the year
       in Date. Enter "on file with" location in Archive. Enter a URL
       in URL when the image is publicly hosted. The "reprinted by" form
-      (R18.9) and emoji citations must be added manually — CSL cannot
+      (R18.9) and emoji citations must be added manually &#8212; CSL cannot
       express compound related-authority citations or Unicode code points.
 
-      23. MICROFORM — STANDALONE (R18.6(b)): Use Zotero's "Standard"
+      23. MICROFORM &#8212; STANDALONE (R18.6(b)): Use Zotero's "Standard"
       item type for microform collections containing original materials.
       Enter the collection title in Title (small caps). Enter the
       collection identifier (e.g. "Fiche 143") in Number. Enter the
       publisher of the microform series in Publisher.
       NOTE: R18.6(a) citations to reproduced materials use the form
-      "[original citation], *microformed on* ID (Publisher)" — generate
+      "[original citation], *microformed on* ID (Publisher)" &#8212; generate
       the original citation using the appropriate source type, then add
       the "*microformed on*" clause manually.
 
@@ -270,12 +268,10 @@
       enter the repository URL in URL (presence of URL triggers the
       open-source format) and enter "last accessed" or "last updated"
       in Archive. The emulation form ("*emulated on*") must be added
-      manually — CSL cannot express compound related-authority citations.
-    </summary>
+      manually &#8212; CSL cannot express compound related-authority citations.</summary>
     <updated>2026-04-01T03:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-
   <!-- LOCALE -->
   <locale xml:lang="en">
     <terms>
@@ -295,11 +291,9 @@
       <term name="ordinal-03">d</term>
     </terms>
   </locale>
-
   <!-- ============================================================
        MACROS
        ============================================================ -->
-
   <!--
     AUTHOR-BOOK macro
     Bluebook R15.1: full name in small caps, ampersand between last two.
@@ -307,18 +301,13 @@
   -->
   <macro name="author-book">
     <names variable="author">
-      <name and="symbol"
-            delimiter=", "
-            delimiter-precedes-last="never"
-            initialize="false"
-            font-variant="small-caps"/>
+      <name and="symbol" delimiter=", " delimiter-precedes-last="never" initialize="false" font-variant="small-caps"/>
       <substitute>
         <names variable="editor"/>
         <text variable="title" font-variant="small-caps" text-case="title"/>
       </substitute>
     </names>
   </macro>
-
   <!--
     AUTHOR-ARTICLE macro
     Bluebook R16.2: full name in ordinary roman type (not small caps).
@@ -332,41 +321,29 @@
       would cause a double render for authorless items.
     -->
     <names variable="author">
-      <name and="symbol"
-            delimiter=", "
-            delimiter-precedes-last="never"
-            initialize="false"/>
+      <name and="symbol" delimiter=", " delimiter-precedes-last="never" initialize="false"/>
     </names>
   </macro>
-
   <!--
     EDITOR macro
     Bluebook R15.2: roman type, "ed." or "eds." label.
   -->
   <macro name="editor">
     <names variable="editor">
-      <name and="symbol"
-            delimiter=", "
-            delimiter-precedes-last="never"
-            initialize="false"/>
+      <name and="symbol" delimiter=", " delimiter-precedes-last="never" initialize="false"/>
       <label form="short" prefix=" "/>
     </names>
   </macro>
-
   <!--
     TRANSLATOR macro
     Bluebook R15.2: roman type, "trans." label.
   -->
   <macro name="translator">
     <names variable="translator">
-      <name and="symbol"
-            delimiter=", "
-            delimiter-precedes-last="never"
-            initialize="false"/>
+      <name and="symbol" delimiter=", " delimiter-precedes-last="never" initialize="false"/>
       <label form="short" prefix=" "/>
     </names>
   </macro>
-
   <!--
     EDITION macro
     Bluebook R15.4: "4th ed." inside the publication parenthetical.
@@ -385,7 +362,6 @@
       </else-if>
     </choose>
   </macro>
-
   <!--
     PUBLISH-DETAILS macro
     Bluebook R15.2 and R15.4: single parenthetical with translator, editor,
@@ -428,7 +404,6 @@
       </choose>
     </group>
   </macro>
-
   <!--
     PUBLISHER-YEAR macro
     Simplified parenthetical for reports, manuscripts, documents.
@@ -441,7 +416,6 @@
       </date>
     </group>
   </macro>
-
   <!--
     JOURNAL-ARTICLE macro
     R16.4 (volume present): Author, Title, Volume Journal Page (Year).
@@ -539,7 +513,6 @@
       </else>
     </choose>
   </macro>
-
   <!--
     NEWSPAPER-ARTICLE macro
     Bluebook R16.6: Author, Title, Newspaper, Month Day, Year, at Page.
@@ -594,7 +567,6 @@
       </choose>
     </group>
   </macro>
-
   <!--
     MANUSCRIPT-DATE macro
     Bluebook R17.2: unpublished materials use full date (Month Day, Year).
@@ -608,7 +580,6 @@
       <date-part name="year"/>
     </date>
   </macro>
-
   <!--
     Bluebook R18.2.2: Author, Title, Site Name (Date), URL.
     - Author in roman type (R18.2.2(a))
@@ -645,7 +616,6 @@
       </choose>
     </group>
   </macro>
-
   <!--
     ARCHIVAL macro
     Bluebook R23: Author, Title, Date (on file with Archive, Collection, Location).
@@ -683,7 +653,6 @@
       </choose>
     </group>
   </macro>
-
   <!--
     FILM macro
     Bluebook R18.7.1: commercial and noncommercial films.
@@ -773,7 +742,6 @@
       </else>
     </choose>
   </macro>
-
   <!--
     TV-SERIES macro
     Bluebook R18.7.2: TITLE: Episode Name (Platform, Date).
@@ -781,12 +749,12 @@
     as broadcast type without URL (e.g. podcast on physical media).
     Zotero field mapping:
       Title           -> title (series name, small caps)
-      container-title -> episode name (italics) — enter in Extra as
+      container-title -> episode name (italics) &#8212; enter in Extra as
                          container-title: Episode Name
       Publisher       -> platform / network / streaming service
       Date            -> broadcast or release date
       Medium          -> access medium (e.g. "NBC television broadcast",
-                         "DVD", "Netflix") — if blank, publisher is used alone
+                         "DVD", "Netflix") &#8212; if blank, publisher is used alone
   -->
   <macro name="tv-series">
     <!--
@@ -851,7 +819,6 @@
       </choose>
     </group>
   </macro>
-
   <!--
     WEB-VIDEO macro
     Bluebook R18.7.4: ACCOUNT, Title of Video, at timestamp
@@ -900,7 +867,6 @@
       </choose>
     </group>
   </macro>
-
   <!--
     AUDIO-RECORDING macro
     Bluebook R18.8: physical recordings, streaming, and podcasts.
@@ -1028,7 +994,6 @@
       </else>
     </choose>
   </macro>
-
   <!--
     SOCIAL-MEDIA macro
     Bluebook R18.10: posts on X (Twitter), Instagram, Facebook, Mastodon, etc.
@@ -1037,7 +1002,7 @@
     - @handle in roman type immediately after name in parentheses
     - Platform name in small caps (R18.10(b))
     - Date and time in parenthetical (R18.10(c)); time entered via locator
-    - URL followed by archival URL in brackets — archival must be added manually
+    - URL followed by archival URL in brackets &#8212; archival must be added manually
     Zotero field mapping:
       Author          -> real name of poster
       number          -> @handle (without the @; CSL will prepend @)
@@ -1045,7 +1010,7 @@
       Date            -> date of post (with time if available)
       locator         -> time of post (e.g. "3:14 PM ET")
       URL             -> URL of the post
-      archive         -> archival (Perma.cc) URL — enter as "on file with" if institutional
+      archive         -> archival (Perma.cc) URL &#8212; enter as "on file with" if institutional
     NOTE: Perma.cc URL should follow the primary URL in brackets per R18.10.
     Enter the Perma.cc link manually in the document, or store it in Zotero
     Extra as a note. The CSL appends the archive field as a second bracketed URL
@@ -1071,7 +1036,7 @@
           </choose>
         </if>
         <else-if variable="number">
-          <!-- No real name — render @handle alone as identifier -->
+          <!-- No real name &#8212; render @handle alone as identifier -->
           <text variable="number" prefix="@" suffix=","/>
         </else-if>
       </choose>
@@ -1117,17 +1082,16 @@
       </choose>
     </group>
   </macro>
-
   <!--
     AI-CONTENT macro
     Bluebook R18.3: citations to AI-generated text, images, and search outputs.
     Format: Author, Model Name, Description of Content (Date)
             (on file with Journal).
     - Author = person who prompted / generated the content (roman type)
-    - Model Name = AI model (e.g., "OpenAI GPT 3.5", "Claude 3 Opus") — Publisher field
-    - Description = brief description of generated content — Title field
+    - Model Name = AI model (e.g., "OpenAI GPT 3.5", "Claude 3 Opus") &#8212; Publisher field
+    - Description = brief description of generated content &#8212; Title field
     - Date = date of generation in parenthetical
-    - "on file with" = journal or institution holding the content — Archive field
+    - "on file with" = journal or institution holding the content &#8212; Archive field
     Zotero field mapping:
       Author    -> person who generated the content
       Publisher -> AI model name (e.g. "OpenAI GPT 3.5")
@@ -1163,12 +1127,11 @@
       </choose>
     </group>
   </macro>
-
   <!--
     ELECTRONIC-MEDIA macro
     Bluebook R18.5: physical electronic storage media and cloud storage.
 
-    (a) Physical media — R18.5(a):
+    (a) Physical media &#8212; R18.5(a):
     Format: Title [filename], Owner (Medium, last modified Date) (on file with Location).
     Example: Bluebook Invitational Schedule 2024 [BBI24_Sch.docx], Columbia Law Review
              (USB Drive, last modified Apr. 13, 2024) (on file with the Columbia Law Review).
@@ -1181,7 +1144,7 @@
       Date            -> last modified date
       Archive         -> "on file with" location
 
-    (b) Cloud storage — R18.5(b):
+    (b) Cloud storage &#8212; R18.5(b):
     Format: Author, Title, URL (Owner, Folder, Platform) (last modified Date) (on file).
     Example: Benjamin Liebman, Empirical Research on Chinese Case Data, g.drv/liebman
              (Colum. L. Rev., Liebman on China, Google Drive) (last modified June 18, 2024)
@@ -1281,7 +1244,6 @@
       </else>
     </choose>
   </macro>
-
   <!--
     IMAGE macro
     Bluebook R18.9: photographs, illustrations, paintings, and other works of art.
@@ -1299,9 +1261,9 @@
       URL     -> URL when image is hosted online (renders after parenthetical)
 
     NOTE: Use Zotero's "Artwork" item type (graphic) for R18.9 images.
-    For the "reprinted by" form, add a manual note — CSL cannot express
+    For the "reprinted by" form, add a manual note &#8212; CSL cannot express
     compound related-authority citations automatically.
-    For emojis (R18.9), cite manually — no CSL field maps to Unicode code points.
+    For emojis (R18.9), cite manually &#8212; no CSL field maps to Unicode code points.
   -->
   <macro name="image">
     <group delimiter=" ">
@@ -1328,14 +1290,13 @@
       </choose>
     </group>
   </macro>
-
   <!--
     MICROFORM macro
     Bluebook R18.6(b): standalone microform collections with original materials.
     Format: Title, Collection ID (Publisher).
     The collection identifier (e.g. "Fiche 143", "CIS No. 89-H523-17") goes in Number.
 
-    R18.6(a) — microform reproductions of preexisting materials — uses the
+    R18.6(a) &#8212; microform reproductions of preexisting materials &#8212; uses the
     "*microformed on*" related-authority form appended to the original citation.
     This cannot be automated in CSL; editors must add the "*microformed on*"
     clause manually after generating the citation for the original source.
@@ -1368,7 +1329,6 @@
       </group>
     </group>
   </macro>
-
   <!--
     HARDWARE macro
     Bluebook R18.11.1: physical hardware devices.
@@ -1396,7 +1356,6 @@
       </if>
     </choose>
   </macro>
-
   <!--
     SOFTWARE macro
     Bluebook R18.11.2: software citations (general, open source, payment software).
@@ -1416,7 +1375,7 @@
       Author  -> developer name (small caps); omit if same as software name
       Title   -> official software name (italics)
       Version -> version string (e.g. "Ver. 16.86.1"); enter in Extra as
-                 "version: Ver. 16.86.1" — CSL uses the version variable
+                 "version: Ver. 16.86.1" &#8212; CSL uses the version variable
       Genre   -> platform (e.g. "Windows", "iOS"); enter in Extra as
                  "genre: iOS"
       Number  -> SKU or build number for optional parenthetical
@@ -1494,14 +1453,12 @@
       </else>
     </choose>
   </macro>
-
   <!-- ============================================================
        CITATION (footnote) element
        ============================================================ -->
   <citation>
     <layout suffix="." delimiter="; ">
       <choose>
-
         <!-- Ibid with locator: Id. at X -->
         <if position="ibid-with-locator">
           <group delimiter=" ">
@@ -1510,28 +1467,23 @@
             <text variable="locator"/>
           </group>
         </if>
-
-        <!-- Ibid without locator: Id. — strip-periods removes the term's trailing
+        <!-- Ibid without locator: Id. &#8212; strip-periods removes the term's trailing
              period so the layout suffix "." supplies the single closing period. -->
         <else-if position="ibid">
           <text term="ibid" font-style="italic" text-case="capitalize-first" strip-periods="true"/>
         </else-if>
-
         <!-- JOURNAL ARTICLE (R16.4 / R16.5) -->
         <else-if type="article-journal">
           <text macro="journal-article"/>
         </else-if>
-
         <!-- MAGAZINE ARTICLE (R16.5) -->
         <else-if type="article-magazine">
           <text macro="journal-article"/>
         </else-if>
-
         <!-- NEWSPAPER ARTICLE (R16.6) -->
         <else-if type="article-newspaper">
           <text macro="newspaper-article"/>
         </else-if>
-
         <!-- WEBPAGE (R18.2.2)
              Author, Title, Site Name (Date), URL.
              Uses Zotero "webpage" item type.
@@ -1539,7 +1491,6 @@
         <else-if type="webpage post-weblog">
           <text macro="webpage"/>
         </else-if>
-
         <!-- FILM (R18.7.1)
              Commercial: TITLE, Medium (Producer Year).
              Noncommercial: Author, TITLE (Year) (on file with ...).
@@ -1548,15 +1499,14 @@
         <else-if type="motion_picture">
           <text macro="film"/>
         </else-if>
-
         <!-- BROADCAST: TV series (R18.7.2) or web video (R18.7.4)
              TV series: TITLE: Episode (Platform, Date).
              Web video: ACCOUNT, Title, at timestamp (Platform, Date), URL.
              Distinguish by URL: web-based videos have a URL; TV series do not.
              Uses Zotero "broadcast" item type.
              Zotero field mapping:
-               TV series  — Title = series name, Extra: container-title = episode
-               Web video  — Author = account, Title = video title, URL = URL
+               TV series  &#8212; Title = series name, Extra: container-title = episode
+               Web video  &#8212; Author = account, Title = video title, URL = URL
         -->
         <else-if type="broadcast">
           <choose>
@@ -1568,7 +1518,6 @@
             </else>
           </choose>
         </else-if>
-
         <!-- AUDIO RECORDING (R18.8)
              Physical / streaming / podcast citations.
              Uses Zotero "song" item type.
@@ -1576,7 +1525,6 @@
         <else-if type="song">
           <text macro="audio-recording"/>
         </else-if>
-
         <!-- BOOK (R15.1-15.4) -->
         <else-if type="book">
           <group delimiter=" ">
@@ -1598,7 +1546,6 @@
             <text macro="publish-details"/>
           </group>
         </else-if>
-
         <!-- CHAPTER IN EDITED VOLUME (R15.5.1(a)) -->
         <else-if type="chapter">
           <group delimiter=" ">
@@ -1619,7 +1566,6 @@
             <text macro="publish-details"/>
           </group>
         </else-if>
-
         <!-- THESIS / DISSERTATION (R17.2.2)
              Author, Title (Month Day, Year)
              (genre, University) (on file with Location).
@@ -1660,7 +1606,6 @@
             </choose>
           </group>
         </else-if>
-
         <!-- REPORT / WORKING PAPER (R17.4, R15.1, R15.4)
              Author, Title pinpoint (Publisher, Working Paper No. X, Year).
              Zotero field mapping:
@@ -1690,7 +1635,6 @@
             </group>
           </group>
         </else-if>
-
         <!-- MANUSCRIPT (unpublished, R17.2.1) and FORTHCOMING (R17.3)
              Unpublished: Author, Title page (Month Day, Year)
                (unpublished manuscript) (on file with Location).
@@ -1730,7 +1674,6 @@
             </choose>
           </group>
         </else-if>
-
         <!-- DOCUMENT
              Used for two purposes:
              (a) Archival sources (R23): documents held in official archives.
@@ -1757,7 +1700,6 @@
             </else>
           </choose>
         </else-if>
-
         <!-- SOCIAL MEDIA POST (R18.10)
              Name (@handle), PLATFORM (Date, Time), URL [Perma.cc].
              Uses Zotero "post" item type.
@@ -1773,7 +1715,6 @@
         <else-if type="post">
           <text macro="social-media"/>
         </else-if>
-
         <!-- AI-GENERATED CONTENT (R18.3)
              Author, Model Name, Description (Date) (on file with Journal).
              Uses Zotero "software" item type.
@@ -1787,7 +1728,6 @@
         <else-if type="software">
           <text macro="ai-content"/>
         </else-if>
-
         <!-- ELECTRONIC STORAGE MEDIA (R18.5)
              Author, TITLE (Medium, Repository Year)
              (on file with Location).
@@ -1803,7 +1743,6 @@
         <else-if type="dataset">
           <text macro="electronic-media"/>
         </else-if>
-
         <!-- IMAGE / ARTWORK (R18.9)
              Author, *Title* (type Year) (on file with Location).
              Uses Zotero "Artwork" item type (graphic).
@@ -1818,12 +1757,11 @@
         <else-if type="graphic">
           <text macro="image"/>
         </else-if>
-
-        <!-- MICROFORM — STANDALONE (R18.6(b))
+        <!-- MICROFORM &#8212; STANDALONE (R18.6(b))
              Title, Collection ID (Publisher Year).
              Uses Zotero "Standard" item type.
              NOTE: R18.6(a) reproduced microforms use "*microformed on*" appended
-             to the original source citation — add this clause manually.
+             to the original source citation &#8212; add this clause manually.
              Zotero field mapping:
                Title     -> microform collection title (small caps)
                Number    -> collection ID or fiche/reel number
@@ -1833,7 +1771,6 @@
         <else-if type="standard">
           <text macro="microform"/>
         </else-if>
-
         <!-- HARDWARE (R18.11.1)
              MANUFACTURER, Model Name, PartNumber (SKU).
              Uses Zotero "Patent" item type.
@@ -1846,7 +1783,6 @@
         <else-if type="patent">
           <text macro="hardware"/>
         </else-if>
-
         <!-- SOFTWARE (R18.11.2)
              General: DEVELOPER, *Name*, Ver. X (Platform, Date).
              Open-source: DEVELOPER, *Name*, URL (last accessed/updated Date).
@@ -1865,7 +1801,6 @@
         <else-if type="entry-encyclopedia">
           <text macro="software"/>
         </else-if>
-
         <!-- FALLBACK -->
         <else>
           <group delimiter=" ">
@@ -1874,11 +1809,9 @@
             <text macro="publisher-year"/>
           </group>
         </else>
-
       </choose>
     </layout>
   </citation>
-
   <!-- ============================================================
        BIBLIOGRAPHY
        ============================================================ -->
@@ -1889,15 +1822,12 @@
     </sort>
     <layout suffix=".">
       <choose>
-
         <if type="article-journal article-magazine" match="any">
           <text macro="journal-article"/>
         </if>
-
         <else-if type="article-newspaper">
           <text macro="newspaper-article"/>
         </else-if>
-
         <else-if type="book">
           <group delimiter=" ">
             <choose>
@@ -1910,7 +1840,6 @@
             <text macro="publish-details"/>
           </group>
         </else-if>
-
         <else-if type="chapter">
           <group delimiter=" ">
             <text macro="author-book" suffix=","/>
@@ -1925,7 +1854,6 @@
             <text macro="publish-details"/>
           </group>
         </else-if>
-
         <else-if type="thesis">
           <group delimiter=" ">
             <text macro="author-book" suffix=","/>
@@ -1959,7 +1887,6 @@
             </choose>
           </group>
         </else-if>
-
         <else-if type="report">
           <group delimiter=" ">
             <text macro="author-book" suffix=","/>
@@ -1977,7 +1904,6 @@
             </group>
           </group>
         </else-if>
-
         <else-if type="manuscript">
           <group delimiter=" ">
             <text macro="author-book" suffix=","/>
@@ -2005,15 +1931,12 @@
             </choose>
           </group>
         </else-if>
-
         <else-if type="webpage post-weblog">
           <text macro="webpage"/>
         </else-if>
-
         <else-if type="motion_picture">
           <text macro="film"/>
         </else-if>
-
         <else-if type="broadcast">
           <choose>
             <if variable="URL">
@@ -2024,11 +1947,9 @@
             </else>
           </choose>
         </else-if>
-
         <else-if type="song">
           <text macro="audio-recording"/>
         </else-if>
-
         <else-if type="document">
           <choose>
             <if variable="archive">
@@ -2043,35 +1964,27 @@
             </else>
           </choose>
         </else-if>
-
         <else-if type="post">
           <text macro="social-media"/>
         </else-if>
-
         <else-if type="software">
           <text macro="ai-content"/>
         </else-if>
-
         <else-if type="dataset">
           <text macro="electronic-media"/>
         </else-if>
-
         <else-if type="graphic">
           <text macro="image"/>
         </else-if>
-
         <else-if type="standard">
           <text macro="microform"/>
         </else-if>
-
         <else-if type="patent">
           <text macro="hardware"/>
         </else-if>
-
         <else-if type="entry-encyclopedia">
           <text macro="software"/>
         </else-if>
-
         <else>
           <group delimiter=" ">
             <text macro="author-book" suffix=","/>
@@ -2079,9 +1992,7 @@
             <text macro="publisher-year"/>
           </group>
         </else>
-
       </choose>
     </layout>
   </bibliography>
-
 </style>

--- a/bluebook-law-review-secondary-sources.csl
+++ b/bluebook-law-review-secondary-sources.csl
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl"
-       class="note"
-       version="1.0"
-       demote-non-dropping-particle="display-and-sort"
-       default-locale="en-US"
-       delimiter-precedes-last="never">
-
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="display-and-sort" delimiter-precedes-last="never" default-locale="en-US">
   <info>
     <title>Bluebook Law Review Secondary Sources</title>
     <title-short>Bluebook LR Secondary Sources</title-short>
@@ -18,8 +12,7 @@
     </author>
     <category citation-format="note"/>
     <category field="law"/>
-    <summary>
-      Bluebook (22nd ed. 2025) law review footnote citation style covering:
+    <summary>Bluebook (22nd ed. 2025) law review footnote citation style covering:
 
       MONOGRAPHIC SOURCES (Rule 15): books, edited volumes, book chapters,
       theses, dissertations, reports, and government documents.
@@ -33,7 +26,7 @@
 
       INTERNET SOURCES (Rule 18): webpages and web-based sources (R18.2),
       AI-generated content (R18.3), electronic storage media (R18.5),
-      microform — standalone original collections (R18.6(b)), films and
+      microform &#8212; standalone original collections (R18.6(b)), films and
       documentaries (R18.7.1), television series (R18.7.2), web-based
       video (R18.7.4), audio recordings and streaming services including
       podcasts (R18.8), images and photographs (R18.9), social media
@@ -60,8 +53,8 @@
       "Harvard Law Review"). This style uses the Journal Abbreviation field
       (container-title-short) in Zotero when available, falling back to the
       Publication field (container-title) if not. To enable auto-abbreviation:
-      install a Bluebook journal abbreviation list in Zotero via Edit >
-      Preferences > Cite > Style Editor, or use the Juris-M abbreviation
+      install a Bluebook journal abbreviation list in Zotero via Edit &gt;
+      Preferences &gt; Cite &gt; Style Editor, or use the Juris-M abbreviation
       filter. If no abbreviation list is installed, enter the abbreviated
       journal name directly in Zotero's Journal Abbr. field for each item.
 
@@ -104,7 +97,7 @@
       "Harv. L. Rev." are entered pre-abbreviated; (c) episode names
       (container-title in Broadcast/Audio items) render as entered.
       Rule 8(b) requires internet page titles to follow source capitalization;
-      the CSL applies title case to webpage titles as a practical default —
+      the CSL applies title case to webpage titles as a practical default &#8212;
       editors should verify against the actual source.
 
       INSTITUTIONAL AUTHORS (R15.1(c)): Zotero does not apply
@@ -202,7 +195,7 @@
       the @ symbol) in Zotero's Number field. Enter the platform name
       (e.g. "X", "Instagram", "Facebook") in Publication. Enter the date
       in Date. Enter the time (e.g. "11:04 ET") in Extra as
-      "locator: 11:04 ET" — the CSL prepends "at". Enter the post URL in
+      "locator: 11:04 ET" &#8212; the CSL prepends "at". Enter the post URL in
       URL. Enter a Perma.cc archival URL in Archive (renders in brackets).
       LIMITATION: Visual/audio posts (R18.10(a)) require "Video posted by"
       or "Image posted by" before the name; this prefix cannot be
@@ -237,19 +230,19 @@
       type. Enter the creator in Author (roman type). Enter the title
       or description in Title (renders in italics, title-cased). Enter
       the work type (e.g. "photograph", "painting", "illustration") in
-      Medium — this renders in the type parenthetical. Enter the year
+      Medium &#8212; this renders in the type parenthetical. Enter the year
       in Date. Enter "on file with" location in Archive. Enter a URL
       in URL when the image is publicly hosted. The "reprinted by" form
-      (R18.9) and emoji citations must be added manually — CSL cannot
+      (R18.9) and emoji citations must be added manually &#8212; CSL cannot
       express compound related-authority citations or Unicode code points.
 
-      23. MICROFORM — STANDALONE (R18.6(b)): Use Zotero's "Standard"
+      23. MICROFORM &#8212; STANDALONE (R18.6(b)): Use Zotero's "Standard"
       item type for microform collections containing original materials.
       Enter the collection title in Title (small caps). Enter the
       collection identifier (e.g. "Fiche 143") in Number. Enter the
       publisher of the microform series in Publisher.
       NOTE: R18.6(a) citations to reproduced materials use the form
-      "[original citation], *microformed on* ID (Publisher)" — generate
+      "[original citation], *microformed on* ID (Publisher)" &#8212; generate
       the original citation using the appropriate source type, then add
       the "*microformed on*" clause manually.
 
@@ -270,12 +263,10 @@
       enter the repository URL in URL (presence of URL triggers the
       open-source format) and enter "last accessed" or "last updated"
       in Archive. The emulation form ("*emulated on*") must be added
-      manually — CSL cannot express compound related-authority citations.
-    </summary>
+      manually &#8212; CSL cannot express compound related-authority citations.</summary>
     <updated>2026-04-01T03:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-
   <!-- LOCALE -->
   <locale xml:lang="en">
     <terms>
@@ -295,11 +286,9 @@
       <term name="ordinal-03">d</term>
     </terms>
   </locale>
-
   <!-- ============================================================
        MACROS
        ============================================================ -->
-
   <!--
     AUTHOR-BOOK macro
     Bluebook R15.1: full name in small caps, ampersand between last two.
@@ -307,18 +296,13 @@
   -->
   <macro name="author-book">
     <names variable="author">
-      <name and="symbol"
-            delimiter=", "
-            delimiter-precedes-last="never"
-            initialize="false"
-            font-variant="small-caps"/>
+      <name and="symbol" delimiter=", " delimiter-precedes-last="never" initialize="false" font-variant="small-caps"/>
       <substitute>
         <names variable="editor"/>
         <text variable="title" font-variant="small-caps" text-case="title"/>
       </substitute>
     </names>
   </macro>
-
   <!--
     AUTHOR-ARTICLE macro
     Bluebook R16.2: full name in ordinary roman type (not small caps).
@@ -332,41 +316,29 @@
       would cause a double render for authorless items.
     -->
     <names variable="author">
-      <name and="symbol"
-            delimiter=", "
-            delimiter-precedes-last="never"
-            initialize="false"/>
+      <name and="symbol" delimiter=", " delimiter-precedes-last="never" initialize="false"/>
     </names>
   </macro>
-
   <!--
     EDITOR macro
     Bluebook R15.2: roman type, "ed." or "eds." label.
   -->
   <macro name="editor">
     <names variable="editor">
-      <name and="symbol"
-            delimiter=", "
-            delimiter-precedes-last="never"
-            initialize="false"/>
+      <name and="symbol" delimiter=", " delimiter-precedes-last="never" initialize="false"/>
       <label form="short" prefix=" "/>
     </names>
   </macro>
-
   <!--
     TRANSLATOR macro
     Bluebook R15.2: roman type, "trans." label.
   -->
   <macro name="translator">
     <names variable="translator">
-      <name and="symbol"
-            delimiter=", "
-            delimiter-precedes-last="never"
-            initialize="false"/>
+      <name and="symbol" delimiter=", " delimiter-precedes-last="never" initialize="false"/>
       <label form="short" prefix=" "/>
     </names>
   </macro>
-
   <!--
     EDITION macro
     Bluebook R15.4: "4th ed." inside the publication parenthetical.
@@ -385,7 +357,6 @@
       </else-if>
     </choose>
   </macro>
-
   <!--
     PUBLISH-DETAILS macro
     Bluebook R15.2 and R15.4: single parenthetical with translator, editor,
@@ -428,7 +399,6 @@
       </choose>
     </group>
   </macro>
-
   <!--
     PUBLISHER-YEAR macro
     Simplified parenthetical for reports, manuscripts, documents.
@@ -441,7 +411,6 @@
       </date>
     </group>
   </macro>
-
   <!--
     JOURNAL-ARTICLE macro
     R16.4 (volume present): Author, Title, Volume Journal Page (Year).
@@ -539,7 +508,6 @@
       </else>
     </choose>
   </macro>
-
   <!--
     NEWSPAPER-ARTICLE macro
     Bluebook R16.6: Author, Title, Newspaper, Month Day, Year, at Page.
@@ -594,7 +562,6 @@
       </choose>
     </group>
   </macro>
-
   <!--
     MANUSCRIPT-DATE macro
     Bluebook R17.2: unpublished materials use full date (Month Day, Year).
@@ -608,7 +575,6 @@
       <date-part name="year"/>
     </date>
   </macro>
-
   <!--
     Bluebook R18.2.2: Author, Title, Site Name (Date), URL.
     - Author in roman type (R18.2.2(a))
@@ -645,7 +611,6 @@
       </choose>
     </group>
   </macro>
-
   <!--
     ARCHIVAL macro
     Bluebook R23: Author, Title, Date (on file with Archive, Collection, Location).
@@ -683,7 +648,6 @@
       </choose>
     </group>
   </macro>
-
   <!--
     FILM macro
     Bluebook R18.7.1: commercial and noncommercial films.
@@ -773,7 +737,6 @@
       </else>
     </choose>
   </macro>
-
   <!--
     TV-SERIES macro
     Bluebook R18.7.2: TITLE: Episode Name (Platform, Date).
@@ -781,12 +744,12 @@
     as broadcast type without URL (e.g. podcast on physical media).
     Zotero field mapping:
       Title           -> title (series name, small caps)
-      container-title -> episode name (italics) — enter in Extra as
+      container-title -> episode name (italics) &#8212; enter in Extra as
                          container-title: Episode Name
       Publisher       -> platform / network / streaming service
       Date            -> broadcast or release date
       Medium          -> access medium (e.g. "NBC television broadcast",
-                         "DVD", "Netflix") — if blank, publisher is used alone
+                         "DVD", "Netflix") &#8212; if blank, publisher is used alone
   -->
   <macro name="tv-series">
     <!--
@@ -851,7 +814,6 @@
       </choose>
     </group>
   </macro>
-
   <!--
     WEB-VIDEO macro
     Bluebook R18.7.4: ACCOUNT, Title of Video, at timestamp
@@ -900,7 +862,6 @@
       </choose>
     </group>
   </macro>
-
   <!--
     AUDIO-RECORDING macro
     Bluebook R18.8: physical recordings, streaming, and podcasts.
@@ -1028,7 +989,6 @@
       </else>
     </choose>
   </macro>
-
   <!--
     SOCIAL-MEDIA macro
     Bluebook R18.10: posts on X (Twitter), Instagram, Facebook, Mastodon, etc.
@@ -1037,7 +997,7 @@
     - @handle in roman type immediately after name in parentheses
     - Platform name in small caps (R18.10(b))
     - Date and time in parenthetical (R18.10(c)); time entered via locator
-    - URL followed by archival URL in brackets — archival must be added manually
+    - URL followed by archival URL in brackets &#8212; archival must be added manually
     Zotero field mapping:
       Author          -> real name of poster
       number          -> @handle (without the @; CSL will prepend @)
@@ -1045,7 +1005,7 @@
       Date            -> date of post (with time if available)
       locator         -> time of post (e.g. "3:14 PM ET")
       URL             -> URL of the post
-      archive         -> archival (Perma.cc) URL — enter as "on file with" if institutional
+      archive         -> archival (Perma.cc) URL &#8212; enter as "on file with" if institutional
     NOTE: Perma.cc URL should follow the primary URL in brackets per R18.10.
     Enter the Perma.cc link manually in the document, or store it in Zotero
     Extra as a note. The CSL appends the archive field as a second bracketed URL
@@ -1071,7 +1031,7 @@
           </choose>
         </if>
         <else-if variable="number">
-          <!-- No real name — render @handle alone as identifier -->
+          <!-- No real name &#8212; render @handle alone as identifier -->
           <text variable="number" prefix="@" suffix=","/>
         </else-if>
       </choose>
@@ -1117,17 +1077,16 @@
       </choose>
     </group>
   </macro>
-
   <!--
     AI-CONTENT macro
     Bluebook R18.3: citations to AI-generated text, images, and search outputs.
     Format: Author, Model Name, Description of Content (Date)
             (on file with Journal).
     - Author = person who prompted / generated the content (roman type)
-    - Model Name = AI model (e.g., "OpenAI GPT 3.5", "Claude 3 Opus") — Publisher field
-    - Description = brief description of generated content — Title field
+    - Model Name = AI model (e.g., "OpenAI GPT 3.5", "Claude 3 Opus") &#8212; Publisher field
+    - Description = brief description of generated content &#8212; Title field
     - Date = date of generation in parenthetical
-    - "on file with" = journal or institution holding the content — Archive field
+    - "on file with" = journal or institution holding the content &#8212; Archive field
     Zotero field mapping:
       Author    -> person who generated the content
       Publisher -> AI model name (e.g. "OpenAI GPT 3.5")
@@ -1163,12 +1122,11 @@
       </choose>
     </group>
   </macro>
-
   <!--
     ELECTRONIC-MEDIA macro
     Bluebook R18.5: physical electronic storage media and cloud storage.
 
-    (a) Physical media — R18.5(a):
+    (a) Physical media &#8212; R18.5(a):
     Format: Title [filename], Owner (Medium, last modified Date) (on file with Location).
     Example: Bluebook Invitational Schedule 2024 [BBI24_Sch.docx], Columbia Law Review
              (USB Drive, last modified Apr. 13, 2024) (on file with the Columbia Law Review).
@@ -1181,7 +1139,7 @@
       Date            -> last modified date
       Archive         -> "on file with" location
 
-    (b) Cloud storage — R18.5(b):
+    (b) Cloud storage &#8212; R18.5(b):
     Format: Author, Title, URL (Owner, Folder, Platform) (last modified Date) (on file).
     Example: Benjamin Liebman, Empirical Research on Chinese Case Data, g.drv/liebman
              (Colum. L. Rev., Liebman on China, Google Drive) (last modified June 18, 2024)
@@ -1281,7 +1239,6 @@
       </else>
     </choose>
   </macro>
-
   <!--
     IMAGE macro
     Bluebook R18.9: photographs, illustrations, paintings, and other works of art.
@@ -1299,9 +1256,9 @@
       URL     -> URL when image is hosted online (renders after parenthetical)
 
     NOTE: Use Zotero's "Artwork" item type (graphic) for R18.9 images.
-    For the "reprinted by" form, add a manual note — CSL cannot express
+    For the "reprinted by" form, add a manual note &#8212; CSL cannot express
     compound related-authority citations automatically.
-    For emojis (R18.9), cite manually — no CSL field maps to Unicode code points.
+    For emojis (R18.9), cite manually &#8212; no CSL field maps to Unicode code points.
   -->
   <macro name="image">
     <group delimiter=" ">
@@ -1328,14 +1285,13 @@
       </choose>
     </group>
   </macro>
-
   <!--
     MICROFORM macro
     Bluebook R18.6(b): standalone microform collections with original materials.
     Format: Title, Collection ID (Publisher).
     The collection identifier (e.g. "Fiche 143", "CIS No. 89-H523-17") goes in Number.
 
-    R18.6(a) — microform reproductions of preexisting materials — uses the
+    R18.6(a) &#8212; microform reproductions of preexisting materials &#8212; uses the
     "*microformed on*" related-authority form appended to the original citation.
     This cannot be automated in CSL; editors must add the "*microformed on*"
     clause manually after generating the citation for the original source.
@@ -1368,7 +1324,6 @@
       </group>
     </group>
   </macro>
-
   <!--
     HARDWARE macro
     Bluebook R18.11.1: physical hardware devices.
@@ -1396,7 +1351,6 @@
       </if>
     </choose>
   </macro>
-
   <!--
     SOFTWARE macro
     Bluebook R18.11.2: software citations (general, open source, payment software).
@@ -1416,7 +1370,7 @@
       Author  -> developer name (small caps); omit if same as software name
       Title   -> official software name (italics)
       Version -> version string (e.g. "Ver. 16.86.1"); enter in Extra as
-                 "version: Ver. 16.86.1" — CSL uses the version variable
+                 "version: Ver. 16.86.1" &#8212; CSL uses the version variable
       Genre   -> platform (e.g. "Windows", "iOS"); enter in Extra as
                  "genre: iOS"
       Number  -> SKU or build number for optional parenthetical
@@ -1494,14 +1448,12 @@
       </else>
     </choose>
   </macro>
-
   <!-- ============================================================
        CITATION (footnote) element
        ============================================================ -->
   <citation>
     <layout suffix="." delimiter="; ">
       <choose>
-
         <!-- Ibid with locator: Id. at X -->
         <if position="ibid-with-locator">
           <group delimiter=" ">
@@ -1510,28 +1462,23 @@
             <text variable="locator"/>
           </group>
         </if>
-
-        <!-- Ibid without locator: Id. — strip-periods removes the term's trailing
+        <!-- Ibid without locator: Id. &#8212; strip-periods removes the term's trailing
              period so the layout suffix "." supplies the single closing period. -->
         <else-if position="ibid">
           <text term="ibid" font-style="italic" text-case="capitalize-first" strip-periods="true"/>
         </else-if>
-
         <!-- JOURNAL ARTICLE (R16.4 / R16.5) -->
         <else-if type="article-journal">
           <text macro="journal-article"/>
         </else-if>
-
         <!-- MAGAZINE ARTICLE (R16.5) -->
         <else-if type="article-magazine">
           <text macro="journal-article"/>
         </else-if>
-
         <!-- NEWSPAPER ARTICLE (R16.6) -->
         <else-if type="article-newspaper">
           <text macro="newspaper-article"/>
         </else-if>
-
         <!-- WEBPAGE (R18.2.2)
              Author, Title, Site Name (Date), URL.
              Uses Zotero "webpage" item type.
@@ -1539,7 +1486,6 @@
         <else-if type="webpage post-weblog">
           <text macro="webpage"/>
         </else-if>
-
         <!-- FILM (R18.7.1)
              Commercial: TITLE, Medium (Producer Year).
              Noncommercial: Author, TITLE (Year) (on file with ...).
@@ -1548,15 +1494,14 @@
         <else-if type="motion_picture">
           <text macro="film"/>
         </else-if>
-
         <!-- BROADCAST: TV series (R18.7.2) or web video (R18.7.4)
              TV series: TITLE: Episode (Platform, Date).
              Web video: ACCOUNT, Title, at timestamp (Platform, Date), URL.
              Distinguish by URL: web-based videos have a URL; TV series do not.
              Uses Zotero "broadcast" item type.
              Zotero field mapping:
-               TV series  — Title = series name, Extra: container-title = episode
-               Web video  — Author = account, Title = video title, URL = URL
+               TV series  &#8212; Title = series name, Extra: container-title = episode
+               Web video  &#8212; Author = account, Title = video title, URL = URL
         -->
         <else-if type="broadcast">
           <choose>
@@ -1568,7 +1513,6 @@
             </else>
           </choose>
         </else-if>
-
         <!-- AUDIO RECORDING (R18.8)
              Physical / streaming / podcast citations.
              Uses Zotero "song" item type.
@@ -1576,7 +1520,6 @@
         <else-if type="song">
           <text macro="audio-recording"/>
         </else-if>
-
         <!-- BOOK (R15.1-15.4) -->
         <else-if type="book">
           <group delimiter=" ">
@@ -1598,7 +1541,6 @@
             <text macro="publish-details"/>
           </group>
         </else-if>
-
         <!-- CHAPTER IN EDITED VOLUME (R15.5.1(a)) -->
         <else-if type="chapter">
           <group delimiter=" ">
@@ -1619,7 +1561,6 @@
             <text macro="publish-details"/>
           </group>
         </else-if>
-
         <!-- THESIS / DISSERTATION (R17.2.2)
              Author, Title (Month Day, Year)
              (genre, University) (on file with Location).
@@ -1660,7 +1601,6 @@
             </choose>
           </group>
         </else-if>
-
         <!-- REPORT / WORKING PAPER (R17.4, R15.1, R15.4)
              Author, Title pinpoint (Publisher, Working Paper No. X, Year).
              Zotero field mapping:
@@ -1690,7 +1630,6 @@
             </group>
           </group>
         </else-if>
-
         <!-- MANUSCRIPT (unpublished, R17.2.1) and FORTHCOMING (R17.3)
              Unpublished: Author, Title page (Month Day, Year)
                (unpublished manuscript) (on file with Location).
@@ -1730,7 +1669,6 @@
             </choose>
           </group>
         </else-if>
-
         <!-- DOCUMENT
              Used for two purposes:
              (a) Archival sources (R23): documents held in official archives.
@@ -1757,7 +1695,6 @@
             </else>
           </choose>
         </else-if>
-
         <!-- SOCIAL MEDIA POST (R18.10)
              Name (@handle), PLATFORM (Date, Time), URL [Perma.cc].
              Uses Zotero "post" item type.
@@ -1773,7 +1710,6 @@
         <else-if type="post">
           <text macro="social-media"/>
         </else-if>
-
         <!-- AI-GENERATED CONTENT (R18.3)
              Author, Model Name, Description (Date) (on file with Journal).
              Uses Zotero "software" item type.
@@ -1787,7 +1723,6 @@
         <else-if type="software">
           <text macro="ai-content"/>
         </else-if>
-
         <!-- ELECTRONIC STORAGE MEDIA (R18.5)
              Author, TITLE (Medium, Repository Year)
              (on file with Location).
@@ -1803,7 +1738,6 @@
         <else-if type="dataset">
           <text macro="electronic-media"/>
         </else-if>
-
         <!-- IMAGE / ARTWORK (R18.9)
              Author, *Title* (type Year) (on file with Location).
              Uses Zotero "Artwork" item type (graphic).
@@ -1818,12 +1752,11 @@
         <else-if type="graphic">
           <text macro="image"/>
         </else-if>
-
-        <!-- MICROFORM — STANDALONE (R18.6(b))
+        <!-- MICROFORM &#8212; STANDALONE (R18.6(b))
              Title, Collection ID (Publisher Year).
              Uses Zotero "Standard" item type.
              NOTE: R18.6(a) reproduced microforms use "*microformed on*" appended
-             to the original source citation — add this clause manually.
+             to the original source citation &#8212; add this clause manually.
              Zotero field mapping:
                Title     -> microform collection title (small caps)
                Number    -> collection ID or fiche/reel number
@@ -1833,7 +1766,6 @@
         <else-if type="standard">
           <text macro="microform"/>
         </else-if>
-
         <!-- HARDWARE (R18.11.1)
              MANUFACTURER, Model Name, PartNumber (SKU).
              Uses Zotero "Patent" item type.
@@ -1846,7 +1778,6 @@
         <else-if type="patent">
           <text macro="hardware"/>
         </else-if>
-
         <!-- SOFTWARE (R18.11.2)
              General: DEVELOPER, *Name*, Ver. X (Platform, Date).
              Open-source: DEVELOPER, *Name*, URL (last accessed/updated Date).
@@ -1865,7 +1796,6 @@
         <else-if type="entry-encyclopedia">
           <text macro="software"/>
         </else-if>
-
         <!-- FALLBACK -->
         <else>
           <group delimiter=" ">
@@ -1874,11 +1804,9 @@
             <text macro="publisher-year"/>
           </group>
         </else>
-
       </choose>
     </layout>
   </citation>
-
   <!-- ============================================================
        BIBLIOGRAPHY
        ============================================================ -->
@@ -1889,15 +1817,12 @@
     </sort>
     <layout suffix=".">
       <choose>
-
         <if type="article-journal article-magazine" match="any">
           <text macro="journal-article"/>
         </if>
-
         <else-if type="article-newspaper">
           <text macro="newspaper-article"/>
         </else-if>
-
         <else-if type="book">
           <group delimiter=" ">
             <choose>
@@ -1910,7 +1835,6 @@
             <text macro="publish-details"/>
           </group>
         </else-if>
-
         <else-if type="chapter">
           <group delimiter=" ">
             <text macro="author-book" suffix=","/>
@@ -1925,7 +1849,6 @@
             <text macro="publish-details"/>
           </group>
         </else-if>
-
         <else-if type="thesis">
           <group delimiter=" ">
             <text macro="author-book" suffix=","/>
@@ -1959,7 +1882,6 @@
             </choose>
           </group>
         </else-if>
-
         <else-if type="report">
           <group delimiter=" ">
             <text macro="author-book" suffix=","/>
@@ -1977,7 +1899,6 @@
             </group>
           </group>
         </else-if>
-
         <else-if type="manuscript">
           <group delimiter=" ">
             <text macro="author-book" suffix=","/>
@@ -2005,15 +1926,12 @@
             </choose>
           </group>
         </else-if>
-
         <else-if type="webpage post-weblog">
           <text macro="webpage"/>
         </else-if>
-
         <else-if type="motion_picture">
           <text macro="film"/>
         </else-if>
-
         <else-if type="broadcast">
           <choose>
             <if variable="URL">
@@ -2024,11 +1942,9 @@
             </else>
           </choose>
         </else-if>
-
         <else-if type="song">
           <text macro="audio-recording"/>
         </else-if>
-
         <else-if type="document">
           <choose>
             <if variable="archive">
@@ -2043,35 +1959,27 @@
             </else>
           </choose>
         </else-if>
-
         <else-if type="post">
           <text macro="social-media"/>
         </else-if>
-
         <else-if type="software">
           <text macro="ai-content"/>
         </else-if>
-
         <else-if type="dataset">
           <text macro="electronic-media"/>
         </else-if>
-
         <else-if type="graphic">
           <text macro="image"/>
         </else-if>
-
         <else-if type="standard">
           <text macro="microform"/>
         </else-if>
-
         <else-if type="patent">
           <text macro="hardware"/>
         </else-if>
-
         <else-if type="entry-encyclopedia">
           <text macro="software"/>
         </else-if>
-
         <else>
           <group delimiter=" ">
             <text macro="author-book" suffix=","/>
@@ -2079,9 +1987,7 @@
             <text macro="publisher-year"/>
           </group>
         </else>
-
       </choose>
     </layout>
   </bibliography>
-
 </style>

--- a/bluebook-law-review-secondary-sources.csl
+++ b/bluebook-law-review-secondary-sources.csl
@@ -1,0 +1,2089 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl"
+       class="note"
+       version="1.0"
+       demote-non-dropping-particle="display-and-sort"
+       default-locale="en-US"
+       delimiter-precedes-last="never">
+
+  <info>
+    <title>Bluebook Law Review Secondary Sources</title>
+    <title-short>Bluebook LR Secondary Sources</title-short>
+    <id>http://www.zotero.org/styles/bluebook-law-review-secondary-sources</id>
+    <link href="http://www.zotero.org/styles/bluebook-law-review-secondary-sources" rel="self"/>
+    <link href="https://www.legalbluebook.com/" rel="documentation"/>
+    <author>
+      <name>Step Schmitt</name>
+      <uri>http://www.stepschmitt.com</uri>
+    </author>
+    <category citation-format="note"/>
+    <category field="law"/>
+    <summary>
+      Bluebook (22nd ed. 2025) law review footnote citation style covering:
+
+      MONOGRAPHIC SOURCES (Rule 15): books, edited volumes, book chapters,
+      theses, dissertations, reports, and government documents.
+
+      PERIODICAL SOURCES (Rule 16): law review and journal articles
+      (consecutively paginated, R16.4), magazine articles (nonconsecutively
+      paginated, R16.5), and newspaper articles (R16.6).
+
+      UNPUBLISHED AND FORTHCOMING SOURCES (Rule 17): unpublished manuscripts,
+      theses, dissertations, working papers, and forthcoming publications.
+
+      INTERNET SOURCES (Rule 18): webpages and web-based sources (R18.2),
+      AI-generated content (R18.3), electronic storage media (R18.5),
+      microform — standalone original collections (R18.6(b)), films and
+      documentaries (R18.7.1), television series (R18.7.2), web-based
+      video (R18.7.4), audio recordings and streaming services including
+      podcasts (R18.8), images and photographs (R18.9), social media
+      posts (R18.10), and hardware and software (R18.11).
+
+      ARCHIVAL SOURCES (Rule 23): documents held in official archives,
+      including pre-1900 newspapers in archival databases (R23.8).
+
+      Cases, statutes, regulations, services, international materials,
+      and tribal materials are out of scope.
+
+      KNOWN LIMITATIONS:
+
+      1. SMALL CAPS: Bluebook R15.1, R15.3, and R16.1 require author names
+      (books only) and periodical/book titles in small caps. This style applies
+      font-variant="small-caps" to book/report titles and periodical names per
+      the CSL 1.0 specification. Small caps WILL render in Zotero with
+      LibreOffice. Rendering in Microsoft Word may vary. Editors should verify
+      and correct manually if needed. Note: per R16.2, journal article authors
+      are in roman type, not small caps.
+
+      2. JOURNAL ABBREVIATIONS: Bluebook R16.1 requires periodical names to be
+      abbreviated per tables T6, T10, and T13 (e.g., "Harv. L. Rev." not
+      "Harvard Law Review"). This style uses the Journal Abbreviation field
+      (container-title-short) in Zotero when available, falling back to the
+      Publication field (container-title) if not. To enable auto-abbreviation:
+      install a Bluebook journal abbreviation list in Zotero via Edit >
+      Preferences > Cite > Style Editor, or use the Juris-M abbreviation
+      filter. If no abbreviation list is installed, enter the abbreviated
+      journal name directly in Zotero's Journal Abbr. field for each item.
+
+      3. CONSECUTIVE vs. NONCONSECUTIVE PAGINATION (R16.4 vs R16.5): This
+      style uses the presence of a volume number to distinguish consecutively
+      paginated journals (R16.4) from nonconsecutively paginated magazines
+      (R16.5). Ensure volume number is entered in Zotero for law reviews and
+      journals, and left blank for magazines.
+
+      4. SUPRA/HEREINAFTER: CSL cannot track prior footnote numbers, so the
+      Bluebook short-form repeat citation system using "supra note X" (R15.10,
+      R16.9) cannot be automated. This style outputs full citations each time.
+      Editors must manually convert repeated citations to supra form.
+
+      5. IBID: Standard CSL ibid handling approximates Bluebook R4.1 for
+      immediately repeated citations but may not cover all edge cases.
+
+      6. EDITION ORDINALS: Bluebook R6.2(b)(ii) and R15.4 require ordinal
+      edition numbers in the form "2d ed." and "3d ed." This style overrides
+      the CSL locale for ordinals ending in 2 and 3 to render "2d" and "3d"
+      correctly. Ordinals ending in 1 (1st, 21st, etc.) and 4+ (4th, etc.)
+      follow standard English form, which matches Bluebook usage.
+
+      7. ET AL.: For works with more than three authors, Bluebook R15.1(b)
+      and R16.2 permit "First Author et al." CSL lists all author names by
+      default. Editors should manually apply et al. where desired.
+
+      8. UNPUBLISHED/FORTHCOMING DATES (R17): Bluebook requires full dates
+      (e.g., "June 22, 2007") for unpublished manuscripts and theses. CSL
+      renders month-year for these types. Editors should verify date format.
+
+      CAPITALIZATION (Rule 8): All titles in this style apply Rule 8(a)
+      title case (text-case="title") via CSL, matching Bluebook's instruction
+      to "capitalize according to rule 8." This applies to: books (R15.3),
+      chapters (R15.5), articles (R16.3), newspapers (R16.6), webpages
+      (R18.2.2), films, video, TV series, and audio titles. Exceptions:
+      (a) AI-generated content titles/prompts (R18.3) render verbatim to
+      preserve exact prompt text; (b) journal/newspaper abbreviations
+      (container-title fields) are not recased since abbreviations like
+      "Harv. L. Rev." are entered pre-abbreviated; (c) episode names
+      (container-title in Broadcast/Audio items) render as entered.
+      Rule 8(b) requires internet page titles to follow source capitalization;
+      the CSL applies title case to webpage titles as a practical default —
+      editors should verify against the actual source.
+
+      INSTITUTIONAL AUTHORS (R15.1(c)): Zotero does not apply
+      font-variant="small-caps" from the CSL name element to
+      institutional or literal author name strings (e.g. "U.S.
+      Senate Comm. on Fin."). Personal name authors render
+      correctly in small caps. Institutional authors will appear
+      in roman type and must be manually set to small caps after
+      generating citations. Confirmed in Zotero test v.13.
+
+      NON-ENGLISH TITLES (R15.3, R20.2.2(b)): The CSL
+      text-case="title" attribute applies English title-case rules
+      to all languages. For non-English titles, R15.3 directs
+      editors to follow R20.2.2(b), requiring the capitalization
+      conventions of the source language (e.g., German capitalizes
+      all nouns but not prepositions like "von"). Editors must
+      manually correct title case for non-English titles after
+      generating citations.
+
+      9. WEBPAGE ARCHIVAL URLS (R18.2.1(d)): Bluebook requires a Perma.cc
+      or equivalent archival URL in brackets after the primary URL. CSL has
+      no second URL field. Enter the archival URL manually after generation,
+      or store it in the Extra field in Zotero as a note.
+
+      10. ARCHIVAL LOCATION (R23): Full archival location (archive owner,
+      collection name, box, folder) should be entered in Zotero's Archive
+      and Loc. in Archive fields. The CSL renders these in the "on file with"
+      parenthetical.
+
+      11. ORIGINAL PUBLICATION DATE (R15.4(a)(iii)): For works published
+      by someone other than the original publisher (e.g., modern editions
+      of classic works), enter the original year in Zotero's Extra field
+      as "original-date: YYYY". This renders as a second parenthetical
+      after the publication details, e.g., "(Penguin Books 1971) (1853)".
+
+      12. STUDENT-WRITTEN DESIGNATION (R16.7.1): For student notes,
+      comments, and other designated pieces, enter the designation
+      (e.g., "Note", "Comment", "Recent Case") in Zotero's Type field.
+      This renders between the author name and article title per R16.7.1.
+
+      13. DOI (R16.8(b)): If a DOI is entered in Zotero's DOI field,
+      it will be appended in brackets at the end of journal article
+      citations per R16.8(b). This is optional per the 22nd edition.
+
+      14. WORKING PAPERS (R17.4): Use Zotero's Report item type.
+      Enter the sponsoring organization in Publisher, the paper number
+      in Report Number, and the year in Date. The CSL renders these
+      in the correct parenthetical format: (Org. Name, Working Paper
+      No. X, Year).
+
+      15. PRE-1900 NEWSPAPERS (R23.8): For newspaper articles in
+      archival databases (e.g. Chronicling America), use Zotero's
+      Newspaper Article item type and populate the Archive field with
+      the archive owner and collection (e.g. "Libr. of Cong.,
+      Chronicling America"). Enter any relevant sub-location in the
+      Loc. in Archive field. Enter the URL of the exact image in
+      Zotero's URL field. When the Archive field is populated, the CSL
+      appends the standard archival parenthetical after the page
+      citation, including the URL if present.
+
+      16. FILMS (R18.7.1): Use Zotero's "Film" item type (motion_picture).
+      Commercial films have no author; enter the studio in Publisher and
+      the access medium (e.g. "Blu-ray", "Amazon Prime") in Medium.
+      For noncommercial films, enter the director in Author; if no
+      public access medium exists, leave Medium blank and populate
+      Archive with the on-file location.
+
+      17. TV SERIES AND WEB VIDEO (R18.7.2, R18.7.4): Use Zotero's
+      "Broadcast" item type. For TV series, enter the series name in
+      Title (small caps) and the episode name via Extra field as
+      "container-title: Episode Name" (italics). Enter the platform or
+      broadcast network in Publisher. The date qualifier ("accessed",
+      "aired", or "released") should be entered in Zotero's Extra field
+      as "genre: aired" (or "accessed" or "released"); it defaults to
+      "accessed" when omitted. For web-based video, enter the account
+      name in Author (renders in small caps), the video title in Title
+      (italics), and the URL in the URL field. The CSL distinguishes TV
+      series from web video by presence of URL. Timestamps should be
+      entered in Zotero's Extra field as "locator: XX:XX" at cite time.
+
+      18. AUDIO RECORDINGS AND PODCASTS (R18.8): Use Zotero's "Audio
+      Recording" item type (song). Enter the creator/performer in
+      Author (renders in small caps). For the access medium use Medium
+      (e.g. "CD", "Vinyl Record") for physical; for streaming services
+      leave Medium blank and enter the platform in Publisher. For
+      episodic formats (podcasts), enter the show title in Title and
+      the episode name via Extra as "container-title: Episode Name".
+      For a specific song on an album, enter the song in container-title
+      and the album in Title.
+
+      19. SOCIAL MEDIA POSTS (R18.10): Use Zotero's "Post" item type.
+      This style implements textual post citations per R18.10(b):
+      Name (@handle), PLATFORM (Date, at Time TZ), URL [Perma.cc].
+      Enter the poster's real name in Author. Enter the @handle (without
+      the @ symbol) in Zotero's Number field. Enter the platform name
+      (e.g. "X", "Instagram", "Facebook") in Publication. Enter the date
+      in Date. Enter the time (e.g. "11:04 ET") in Extra as
+      "locator: 11:04 ET" — the CSL prepends "at". Enter the post URL in
+      URL. Enter a Perma.cc archival URL in Archive (renders in brackets).
+      LIMITATION: Visual/audio posts (R18.10(a)) require "Video posted by"
+      or "Image posted by" before the name; this prefix cannot be
+      automated in CSL and must be added manually. Profile citations
+      (R18.10(c)) should also be adjusted manually.
+
+      20. AI-GENERATED CONTENT (R18.3): Use Zotero's "Software" item
+      type. This style implements R18.3(a) LLM prompt citations:
+      Author, Model Name, Description (Date) (on file with Journal).
+      Enter the prompter's name in Author. Enter the AI model name
+      (e.g. "Google Gemini Advanced") in Publisher. Enter the prompt
+      text or description in Title. Enter the date in Date. Enter the
+      archive location in Archive. LIMITATION: Per R18.3(a), the prompt
+      text should appear in roman type within quotation marks, not
+      italics. CSL 1.0 cannot apply quotation-mark formatting; editors
+      should manually add quotes and remove italics after generation.
+
+      21. ELECTRONIC STORAGE MEDIA (R18.5): Use Zotero's "Dataset" item
+      type. The CSL distinguishes physical from cloud by URL presence.
+      Physical (R18.5(a)): enter the media title in Title (small caps);
+      the filename in Loc. in Archive (renders in brackets after title);
+      the owner/institution in Author; the storage medium (e.g. "USB
+      Drive", "microSD") in Medium; and the on-file location in Archive.
+      Date renders as "last modified [Date]". Cloud (R18.5(b)): enter
+      the file author in Author; the file title in Title; the URL/path
+      in URL; the folder owner in Publisher; the folder name via Extra
+      as "container-title: FolderName"; the cloud service in Medium;
+      and the on-file location in Archive. Date renders as
+      "last modified [Date]".
+
+      22. IMAGES AND PHOTOGRAPHS (R18.9): Use Zotero's "Artwork" item
+      type. Enter the creator in Author (roman type). Enter the title
+      or description in Title (renders in italics, title-cased). Enter
+      the work type (e.g. "photograph", "painting", "illustration") in
+      Medium — this renders in the type parenthetical. Enter the year
+      in Date. Enter "on file with" location in Archive. Enter a URL
+      in URL when the image is publicly hosted. The "reprinted by" form
+      (R18.9) and emoji citations must be added manually — CSL cannot
+      express compound related-authority citations or Unicode code points.
+
+      23. MICROFORM — STANDALONE (R18.6(b)): Use Zotero's "Standard"
+      item type for microform collections containing original materials.
+      Enter the collection title in Title (small caps). Enter the
+      collection identifier (e.g. "Fiche 143") in Number. Enter the
+      publisher of the microform series in Publisher.
+      NOTE: R18.6(a) citations to reproduced materials use the form
+      "[original citation], *microformed on* ID (Publisher)" — generate
+      the original citation using the appropriate source type, then add
+      the "*microformed on*" clause manually.
+
+      24. HARDWARE (R18.11.1): Use Zotero's "Patent" item type. Enter
+      the manufacturer in Author (small caps). Enter the full official
+      model name in Title (roman type). Enter the part/model number in
+      Patent Number. Enter the SKU number in Archive (renders in
+      parentheses after the model number).
+
+      25. SOFTWARE (R18.11.2): Use Zotero's "Encyclopedia Article" item
+      type. Enter the developer in Author (small caps); omit if the
+      developer name is identical to the software name. Enter the
+      software name in Title (italics). Enter the version string (e.g.
+      "Ver. 16.86.1") in Extra as "version: Ver. 16.86.1". Enter the
+      platform (e.g. "iOS") in Extra as "genre: iOS". Enter a build
+      number or SKU in Number (renders in parentheses). Enter the
+      release date in Date. For open-source repository citations,
+      enter the repository URL in URL (presence of URL triggers the
+      open-source format) and enter "last accessed" or "last updated"
+      in Archive. The emulation form ("*emulated on*") must be added
+      manually — CSL cannot express compound related-authority citations.
+    </summary>
+    <updated>2026-04-01T03:00:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">
+      This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License
+    </rights>
+  </info>
+
+  <!-- LOCALE -->
+  <locale xml:lang="en">
+    <terms>
+      <term name="editor" form="short">
+        <single>ed.</single>
+        <multiple>eds.</multiple>
+      </term>
+      <term name="translator" form="short">
+        <single>trans.</single>
+        <multiple>trans.</multiple>
+      </term>
+      <term name="edition" form="short">ed.</term>
+      <term name="ibid">id.</term>
+      <!-- Bluebook R6.2(b)(ii): ordinals ending in 2 or 3 use
+           "2d" and "3d" in citations, not "2nd" and "3rd" -->
+      <term name="ordinal-02">d</term>
+      <term name="ordinal-03">d</term>
+    </terms>
+  </locale>
+
+  <!-- ============================================================
+       MACROS
+       ============================================================ -->
+
+  <!--
+    AUTHOR-BOOK macro
+    Bluebook R15.1: full name in small caps, ampersand between last two.
+    Used for books, reports, chapters, theses, manuscripts, documents.
+  -->
+  <macro name="author-book">
+    <names variable="author">
+      <name and="symbol"
+            delimiter=", "
+            delimiter-precedes-last="never"
+            initialize="false"
+            font-variant="small-caps"/>
+      <substitute>
+        <names variable="editor"/>
+        <text variable="title" font-variant="small-caps" text-case="title"/>
+      </substitute>
+    </names>
+  </macro>
+
+  <!--
+    AUTHOR-ARTICLE macro
+    Bluebook R16.2: full name in ordinary roman type (not small caps).
+    Used for journal, magazine, and newspaper articles.
+  -->
+  <macro name="author-article">
+    <!--
+      No <substitute> here. When no author is present this macro renders nothing,
+      and the suffix comma on the call site is suppressed by CSL. The title is
+      always rendered explicitly at each call site, so a substitute title here
+      would cause a double render for authorless items.
+    -->
+    <names variable="author">
+      <name and="symbol"
+            delimiter=", "
+            delimiter-precedes-last="never"
+            initialize="false"/>
+    </names>
+  </macro>
+
+  <!--
+    EDITOR macro
+    Bluebook R15.2: roman type, "ed." or "eds." label.
+  -->
+  <macro name="editor">
+    <names variable="editor">
+      <name and="symbol"
+            delimiter=", "
+            delimiter-precedes-last="never"
+            initialize="false"/>
+      <label form="short" prefix=" "/>
+    </names>
+  </macro>
+
+  <!--
+    TRANSLATOR macro
+    Bluebook R15.2: roman type, "trans." label.
+  -->
+  <macro name="translator">
+    <names variable="translator">
+      <name and="symbol"
+            delimiter=", "
+            delimiter-precedes-last="never"
+            initialize="false"/>
+      <label form="short" prefix=" "/>
+    </names>
+  </macro>
+
+  <!--
+    EDITION macro
+    Bluebook R15.4: "4th ed." inside the publication parenthetical.
+    Ordinals ending in 2 and 3 render as "2d" and "3d" via locale override (R6.2(b)(ii)).
+  -->
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text value="ed."/>
+        </group>
+      </if>
+      <else-if variable="edition">
+        <text variable="edition"/>
+      </else-if>
+    </choose>
+  </macro>
+
+  <!--
+    PUBLISH-DETAILS macro
+    Bluebook R15.2 and R15.4: single parenthetical with translator, editor,
+    edition, publisher, and year.
+  -->
+  <macro name="publish-details">
+    <group delimiter=" ">
+      <group prefix="(" suffix=")" delimiter=", ">
+        <text macro="translator"/>
+        <text macro="editor"/>
+        <choose>
+          <if variable="edition">
+            <group delimiter=" ">
+              <text macro="edition"/>
+              <text variable="publisher"/>
+              <date variable="issued">
+                <date-part name="year"/>
+              </date>
+            </group>
+          </if>
+          <else>
+            <group delimiter=" ">
+              <text variable="publisher"/>
+              <date variable="issued">
+                <date-part name="year"/>
+              </date>
+            </group>
+          </else>
+        </choose>
+      </group>
+      <!-- R15.4(a)(iii): original publication date for reprints/modern editions -->
+      <choose>
+        <if variable="original-date">
+          <group prefix="(" suffix=")">
+            <date variable="original-date">
+              <date-part name="year"/>
+            </date>
+          </group>
+        </if>
+      </choose>
+    </group>
+  </macro>
+
+  <!--
+    PUBLISHER-YEAR macro
+    Simplified parenthetical for reports, manuscripts, documents.
+  -->
+  <macro name="publisher-year">
+    <group prefix="(" suffix=")" delimiter=" ">
+      <text variable="publisher"/>
+      <date variable="issued">
+        <date-part name="year"/>
+      </date>
+    </group>
+  </macro>
+
+  <!--
+    JOURNAL-ARTICLE macro
+    R16.4 (volume present): Author, Title, Volume Journal Page (Year).
+    R16.5 (no volume): Author, Title, Journal, Month Year, at Page.
+    NOTE: Journal name must be pre-abbreviated in Zotero. See limitation #2.
+  -->
+  <!--
+    JOURNAL-ARTICLE macro
+    R16.4 (volume present): Author, [Designation,] Title, Volume Journal Page (Year) [DOI].
+    R16.5 (no volume): Author, [Designation,] Title, Journal, Month Year, at Page.
+    R16.7.1: Student designation (e.g. "Note", "Comment") from Zotero Type field
+             renders between author and title if present.
+    R16.8(b): DOI appended in brackets if present in Zotero DOI field.
+  -->
+  <macro name="journal-article">
+    <choose>
+      <if variable="volume">
+        <!-- Consecutively paginated (R16.4) -->
+        <group delimiter=" ">
+          <text macro="author-article" suffix=","/>
+          <!-- R16.7.1: student designation before title -->
+          <choose>
+            <if variable="genre">
+              <text variable="genre" suffix=","/>
+            </if>
+          </choose>
+          <text variable="title" font-style="italic" text-case="title" suffix=","/>
+          <number variable="volume"/>
+          <choose>
+            <if variable="container-title-short">
+              <text variable="container-title-short" font-variant="small-caps"/>
+            </if>
+            <else>
+              <text variable="container-title" font-variant="small-caps"/>
+            </else>
+          </choose>
+          <choose>
+            <if variable="locator">
+              <group delimiter=", ">
+                <text variable="page"/>
+                <text variable="locator"/>
+              </group>
+            </if>
+            <else>
+              <text variable="page"/>
+            </else>
+          </choose>
+          <group prefix="(" suffix=")">
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+          </group>
+          <!-- R16.8(b): optional DOI in brackets -->
+          <choose>
+            <if variable="DOI">
+              <text variable="DOI" prefix="[https://doi.org/" suffix="]"/>
+            </if>
+          </choose>
+        </group>
+      </if>
+      <else>
+        <!-- Nonconsecutively paginated (R16.5) -->
+        <group delimiter=" ">
+          <text macro="author-article" suffix=","/>
+          <choose>
+            <if variable="genre">
+              <text variable="genre" suffix=","/>
+            </if>
+          </choose>
+          <text variable="title" font-style="italic" text-case="title" suffix=","/>
+          <choose>
+            <if variable="container-title-short">
+              <text variable="container-title-short" font-variant="small-caps" suffix=","/>
+            </if>
+            <else>
+              <text variable="container-title" font-variant="small-caps" suffix=","/>
+            </else>
+          </choose>
+          <date variable="issued" delimiter=" ">
+            <date-part name="month" form="short" strip-periods="false"/>
+            <date-part name="year"/>
+          </date>
+          <choose>
+            <if variable="locator">
+              <group delimiter=", ">
+                <text variable="page" prefix="at "/>
+                <text variable="locator"/>
+              </group>
+            </if>
+            <else>
+              <text variable="page" prefix="at "/>
+            </else>
+          </choose>
+        </group>
+      </else>
+    </choose>
+  </macro>
+
+  <!--
+    NEWSPAPER-ARTICLE macro
+    Bluebook R16.6: Author, Title, Newspaper, Month Day, Year, at Page.
+    R23.8: For pre-1900 newspapers in archival databases, appends the
+    standard archival parenthetical after the page citation when the
+    Archive field is populated in Zotero. If a URL is also present, it
+    is included as the archival location per R23.8 ("may use the URL of
+    the exact image for the archival location").
+    NOTE: Newspaper name must be pre-abbreviated in Zotero. See limitation #2.
+  -->
+  <macro name="newspaper-article">
+    <group delimiter=" ">
+      <text macro="author-article" suffix=","/>
+      <text variable="title" font-style="italic" text-case="title" suffix=","/>
+      <choose>
+        <if variable="container-title-short">
+          <text variable="container-title-short" font-variant="small-caps" suffix=","/>
+        </if>
+        <else>
+          <text variable="container-title" font-variant="small-caps" suffix=","/>
+        </else>
+      </choose>
+      <date variable="issued" delimiter=" ">
+        <date-part name="month" form="long"/>
+        <date-part name="day" suffix=","/>
+        <date-part name="year"/>
+      </date>
+      <choose>
+        <if variable="page">
+          <text variable="page" prefix="at "/>
+        </if>
+      </choose>
+      <!-- R23.8: archival parenthetical for pre-1900 newspapers in databases -->
+      <choose>
+        <if variable="archive">
+          <choose>
+            <if variable="URL">
+              <group prefix="(on file with " suffix=")" delimiter=", ">
+                <text variable="archive"/>
+                <text variable="archive-place"/>
+                <text variable="URL"/>
+              </group>
+            </if>
+            <else>
+              <group prefix="(on file with " suffix=")" delimiter=", ">
+                <text variable="archive"/>
+                <text variable="archive-place"/>
+              </group>
+            </else>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+
+  <!--
+    MANUSCRIPT-DATE macro
+    Bluebook R17.2: unpublished materials use full date (Month Day, Year).
+    CSL can render month + year but not full day-level dates for issued.
+    This renders the best available date from the issued variable.
+  -->
+  <macro name="manuscript-date">
+    <date variable="issued" delimiter=" ">
+      <date-part name="month" form="short" strip-periods="false"/>
+      <date-part name="day" suffix=","/>
+      <date-part name="year"/>
+    </date>
+  </macro>
+
+  <!--
+    Bluebook R18.2.2: Author, Title, Site Name (Date), URL.
+    - Author in roman type (R18.2.2(a))
+    - Title in italics (R18.2.2(b))
+    - Site/container name in small caps (R18.2.1(b)(i))
+    - Date in parenthetical (R18.2.2(c))
+    - URL appended (R18.2.2(d)); archival URL must be added manually
+    NOTE: Enter URL in Zotero URL field. Archival URL (Perma.cc) must
+    be added manually per known limitation #9.
+  -->
+  <macro name="webpage">
+    <group delimiter=" ">
+      <text macro="author-article" suffix=","/>
+      <text variable="title" font-style="italic" text-case="title" suffix=","/>
+      <choose>
+        <if variable="container-title-short">
+          <text variable="container-title-short" font-variant="small-caps"/>
+        </if>
+        <else>
+          <text variable="container-title" font-variant="small-caps"/>
+        </else>
+      </choose>
+      <group prefix="(" suffix=")">
+        <date variable="issued" delimiter=" ">
+          <date-part name="month" form="short" strip-periods="false"/>
+          <date-part name="day" suffix=","/>
+          <date-part name="year"/>
+        </date>
+      </group>
+      <choose>
+        <if variable="URL">
+          <text variable="URL"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+
+  <!--
+    ARCHIVAL macro
+    Bluebook R23: Author, Title, Date (on file with Archive, Collection, Location).
+    - Author in roman type (R23.2)
+    - Title in roman type (R23.3)
+    - Date in parenthetical (R23.5): full date preferred
+    - Archival info in "on file with" parenthetical (R23.6)
+    Zotero field mapping:
+      Archive field      -> archive owner + collection
+      Loc. in Archive    -> box, folder, reel, record group
+  -->
+  <macro name="archival">
+    <group delimiter=" ">
+      <text macro="author-article" suffix=","/>
+      <text variable="title"/>
+      <choose>
+        <if variable="locator">
+          <text variable="locator"/>
+        </if>
+      </choose>
+      <group prefix="(" suffix=")">
+        <date variable="issued" delimiter=" ">
+          <date-part name="month" form="short" strip-periods="false"/>
+          <date-part name="day" suffix=","/>
+          <date-part name="year"/>
+        </date>
+      </group>
+      <choose>
+        <if variable="archive">
+          <group prefix="(on file with " suffix=")" delimiter=", ">
+            <text variable="archive"/>
+            <text variable="archive-place"/>
+          </group>
+        </if>
+      </choose>
+    </group>
+  </macro>
+
+  <!--
+    FILM macro
+    Bluebook R18.7.1: commercial and noncommercial films.
+    Commercial: TITLE, Medium, at timestamp (Producer Year).
+    Noncommercial: Creator, TITLE, Medium (Year) (on file with ...).
+    Distinguish commercial from noncommercial by presence of author:
+      - no author = commercial (title in small caps leads)
+      - author present = noncommercial (author name leads, then title)
+    Zotero field mapping:
+      Title     -> title (rendered in small caps)
+      Director  -> author (present for noncommercial only)
+      Publisher -> production company / studio
+      Date      -> year of release
+      Medium    -> medium (e.g. "Blu-ray", "DVD", "Amazon Prime")
+      Archive   -> "on file with" location (noncommercial)
+  -->
+  <macro name="film">
+    <choose>
+      <if variable="author">
+        <!-- Noncommercial: Author, TITLE, at timestamp (Year) (on file). -->
+        <group delimiter=" ">
+          <text macro="author-article" suffix=","/>
+          <choose>
+            <if variable="locator">
+              <text variable="title" font-variant="small-caps" text-case="title" suffix=","/>
+              <text variable="locator" prefix=" at "/>
+            </if>
+            <else>
+              <text variable="title" font-variant="small-caps" text-case="title"/>
+            </else>
+          </choose>
+          <choose>
+            <if variable="medium">
+              <group prefix="(" suffix=")" delimiter=" ">
+                <text variable="medium" suffix=","/>
+                <date variable="issued">
+                  <date-part name="year"/>
+                </date>
+              </group>
+            </if>
+            <else>
+              <group prefix="(" suffix=")">
+                <date variable="issued">
+                  <date-part name="year"/>
+                </date>
+              </group>
+            </else>
+          </choose>
+          <choose>
+            <if variable="archive">
+              <group prefix="(on file with " suffix=")" delimiter=", ">
+                <text variable="archive"/>
+                <text variable="archive-place"/>
+              </group>
+            </if>
+          </choose>
+        </group>
+      </if>
+      <else>
+        <!-- Commercial: TITLE, Medium, at timestamp (Producer Year). -->
+        <group delimiter=", ">
+          <text variable="title" font-variant="small-caps" text-case="title"/>
+          <text variable="medium"/>
+        </group>
+        <choose>
+          <if variable="locator">
+            <text variable="locator" prefix=", at "/>
+          </if>
+        </choose>
+        <group prefix=" (" suffix=")">
+          <choose>
+            <if variable="publisher">
+              <group delimiter=" ">
+                <text variable="publisher"/>
+                <date variable="issued">
+                  <date-part name="year"/>
+                </date>
+              </group>
+            </if>
+            <else>
+              <date variable="issued">
+                <date-part name="year"/>
+              </date>
+            </else>
+          </choose>
+        </group>
+      </else>
+    </choose>
+  </macro>
+
+  <!--
+    TV-SERIES macro
+    Bluebook R18.7.2: TITLE: Episode Name (Platform, Date).
+    Also handles episodic audio recordings (R18.8.1(c)) when used
+    as broadcast type without URL (e.g. podcast on physical media).
+    Zotero field mapping:
+      Title           -> title (series name, small caps)
+      container-title -> episode name (italics) — enter in Extra as
+                         container-title: Episode Name
+      Publisher       -> platform / network / streaming service
+      Date            -> broadcast or release date
+      Medium          -> access medium (e.g. "NBC television broadcast",
+                         "DVD", "Netflix") — if blank, publisher is used alone
+  -->
+  <macro name="tv-series">
+    <!--
+      R18.7.2: TITLE: *Episode* (Platform, accessed/aired/released Date).
+      The date qualifier ("accessed", "aired", "released") precedes the date.
+      Enter the qualifier in Zotero's Extra field as "genre: aired" (or "accessed"
+      or "released"). Defaults to "accessed" when no genre is supplied.
+    -->
+    <group delimiter=" ">
+      <choose>
+        <if variable="container-title">
+          <group>
+            <text variable="title" font-variant="small-caps" text-case="title" suffix=":"/>
+            <text variable="container-title" font-style="italic" prefix=" "/>
+          </group>
+        </if>
+        <else>
+          <text variable="title" font-variant="small-caps" text-case="title"/>
+        </else>
+      </choose>
+      <choose>
+        <if variable="locator">
+          <text variable="locator" prefix="at "/>
+        </if>
+      </choose>
+      <group prefix="(" suffix=")" delimiter=", ">
+        <choose>
+          <if variable="medium">
+            <text variable="medium"/>
+          </if>
+          <else>
+            <text variable="publisher"/>
+          </else>
+        </choose>
+        <choose>
+          <if variable="issued">
+            <group delimiter=" ">
+              <choose>
+                <if variable="genre">
+                  <text variable="genre"/>
+                </if>
+                <else>
+                  <text value="accessed"/>
+                </else>
+              </choose>
+              <date variable="issued" delimiter=" ">
+                <date-part name="month" form="short" strip-periods="false"/>
+                <date-part name="day" suffix=","/>
+                <date-part name="year"/>
+              </date>
+            </group>
+          </if>
+        </choose>
+      </group>
+      <choose>
+        <if variable="archive">
+          <group prefix="(on file with " suffix=")" delimiter=", ">
+            <text variable="archive"/>
+            <text variable="archive-place"/>
+          </group>
+        </if>
+      </choose>
+    </group>
+  </macro>
+
+  <!--
+    WEB-VIDEO macro
+    Bluebook R18.7.4: ACCOUNT, Title of Video, at timestamp
+    (Platform, Date), URL (on file with ...).
+    Web-based videos are distinguished from TV series by presence of URL.
+    Zotero field mapping:
+      Author    -> account name (small caps via author-book macro)
+      Title     -> title of video (italics)
+      Publisher -> platform (e.g. "YouTube", "Vimeo")
+      Date      -> upload date (with time if available)
+      URL       -> URL of the video
+      Archive   -> "on file with" location
+  -->
+  <macro name="web-video">
+    <group delimiter=" ">
+      <text macro="author-book" suffix=","/>
+      <choose>
+        <if variable="locator">
+          <text variable="title" font-style="italic" text-case="title" suffix=","/>
+          <text variable="locator" prefix=" at "/>
+        </if>
+        <else>
+          <text variable="title" font-style="italic" text-case="title"/>
+        </else>
+      </choose>
+      <group prefix="(" suffix=")" delimiter=", ">
+        <text variable="publisher"/>
+        <date variable="issued" delimiter=" ">
+          <date-part name="month" form="short" strip-periods="false"/>
+          <date-part name="day" suffix=","/>
+          <date-part name="year"/>
+        </date>
+      </group>
+      <choose>
+        <if variable="URL">
+          <text variable="URL"/>
+        </if>
+      </choose>
+      <choose>
+        <if variable="archive">
+          <group prefix="(on file with " suffix=")" delimiter=", ">
+            <text variable="archive"/>
+            <text variable="archive-place"/>
+          </group>
+        </if>
+      </choose>
+    </group>
+  </macro>
+
+  <!--
+    AUDIO-RECORDING macro
+    Bluebook R18.8: physical recordings, streaming, and podcasts.
+    R18.8.1(a) Commercial: CREATOR, Title (Medium, Label Date).
+    R18.8.1(b) Noncommercial: Creator, Title, at timestamp (Medium, Date)
+                               (on file with ...).
+    R18.8.1(c) Episodic (physical): TITLE: Episode (Medium, Date).
+    R18.8.2    Streaming / podcast: CREATOR, Title (Platform, Label Date).
+    Distinguish by:
+      - author present + medium present = commercial physical (R18.8.1(a))
+      - author present + no medium = streaming/podcast (R18.8.2)
+      - no author + container-title = episodic (R18.8.1(c))
+      - archive present = noncommercial (append "on file with")
+    Zotero field mapping:
+      Author          -> creator / performer (small caps for commercial)
+      Title           -> album / show title (small caps)
+      container-title -> episode/song/segment title (italics)
+      Publisher       -> record label / streaming platform
+      Date            -> release date
+      Medium          -> physical medium (CD, Vinyl Record, Spotify, etc.)
+      Archive         -> "on file with" location
+  -->
+  <macro name="audio-recording">
+    <choose>
+      <if variable="author">
+        <group delimiter=" ">
+          <text macro="author-book" suffix=","/>
+          <!-- If container-title present: Song, in ALBUM -->
+          <choose>
+            <if variable="container-title">
+              <group delimiter=" ">
+                <text variable="container-title" font-style="italic" suffix=","/>
+                <text term="in" font-style="italic"/>
+              </group>
+            </if>
+          </choose>
+          <choose>
+            <if variable="locator">
+              <text variable="title" font-variant="small-caps" text-case="title" suffix=","/>
+              <text variable="locator" prefix=" at "/>
+            </if>
+            <else>
+              <text variable="title" font-variant="small-caps" text-case="title"/>
+            </else>
+          </choose>
+          <group prefix="(" suffix=")" delimiter=", ">
+            <choose>
+              <if variable="medium">
+                <text variable="medium"/>
+              </if>
+            </choose>
+            <choose>
+              <if variable="publisher">
+                <group delimiter=" ">
+                  <text variable="publisher"/>
+                  <date variable="issued" delimiter=" ">
+                    <date-part name="month" form="short" strip-periods="false"/>
+                    <date-part name="day" suffix=","/>
+                    <date-part name="year"/>
+                  </date>
+                </group>
+              </if>
+              <else>
+                <date variable="issued" delimiter=" ">
+                  <date-part name="month" form="short" strip-periods="false"/>
+                  <date-part name="day" suffix=","/>
+                  <date-part name="year"/>
+                </date>
+              </else>
+            </choose>
+          </group>
+          <choose>
+            <if variable="archive">
+              <group prefix="(on file with " suffix=")" delimiter=", ">
+                <text variable="archive"/>
+                <text variable="archive-place"/>
+              </group>
+            </if>
+          </choose>
+        </group>
+      </if>
+      <else>
+        <!-- No author: episodic format TITLE: Episode (Medium, Date) -->
+        <group delimiter=" ">
+          <choose>
+            <if variable="container-title">
+              <group>
+                <text variable="title" font-variant="small-caps" text-case="title" suffix=":"/>
+                <text variable="container-title" font-style="italic" prefix=" "/>
+              </group>
+            </if>
+            <else>
+              <text variable="title" font-variant="small-caps" text-case="title"/>
+            </else>
+          </choose>
+          <choose>
+            <if variable="locator">
+              <text variable="locator" prefix="at "/>
+            </if>
+          </choose>
+          <group prefix="(" suffix=")" delimiter=", ">
+            <choose>
+              <if variable="medium">
+                <text variable="medium"/>
+              </if>
+              <else>
+                <text variable="publisher"/>
+              </else>
+            </choose>
+            <date variable="issued" delimiter=" ">
+              <date-part name="month" form="short" strip-periods="false"/>
+              <date-part name="day" suffix=","/>
+              <date-part name="year"/>
+            </date>
+          </group>
+          <choose>
+            <if variable="archive">
+              <group prefix="(on file with " suffix=")" delimiter=", ">
+                <text variable="archive"/>
+                <text variable="archive-place"/>
+              </group>
+            </if>
+          </choose>
+        </group>
+      </else>
+    </choose>
+  </macro>
+
+  <!--
+    SOCIAL-MEDIA macro
+    Bluebook R18.10: posts on X (Twitter), Instagram, Facebook, Mastodon, etc.
+    Format: Name (@handle), PLATFORM (Date, Time TZ), URL [Perma.cc].
+    - Author real name in roman type (R18.10(a))
+    - @handle in roman type immediately after name in parentheses
+    - Platform name in small caps (R18.10(b))
+    - Date and time in parenthetical (R18.10(c)); time entered via locator
+    - URL followed by archival URL in brackets — archival must be added manually
+    Zotero field mapping:
+      Author          -> real name of poster
+      number          -> @handle (without the @; CSL will prepend @)
+      container-title -> platform name (e.g. "X", "Instagram", "Facebook")
+      Date            -> date of post (with time if available)
+      locator         -> time of post (e.g. "3:14 PM ET")
+      URL             -> URL of the post
+      archive         -> archival (Perma.cc) URL — enter as "on file with" if institutional
+    NOTE: Perma.cc URL should follow the primary URL in brackets per R18.10.
+    Enter the Perma.cc link manually in the document, or store it in Zotero
+    Extra as a note. The CSL appends the archive field as a second bracketed URL
+    when populated.
+  -->
+  <macro name="social-media">
+    <group delimiter=" ">
+      <!-- Author identifier: real name + (@handle), or @handle alone, or name alone -->
+      <choose>
+        <if variable="author">
+          <choose>
+            <if variable="number">
+              <!-- Name (@handle), -->
+              <group delimiter=" ">
+                <text macro="author-article"/>
+                <text variable="number" prefix="(@" suffix="),"/>
+              </group>
+            </if>
+            <else>
+              <!-- Name, (no handle available) -->
+              <text macro="author-article" suffix=","/>
+            </else>
+          </choose>
+        </if>
+        <else-if variable="number">
+          <!-- No real name — render @handle alone as identifier -->
+          <text variable="number" prefix="@" suffix=","/>
+        </else-if>
+      </choose>
+      <!-- Post title or description (italics), per R18.10 -->
+      <choose>
+        <if variable="title">
+          <text variable="title" font-style="italic" text-case="title" suffix=","/>
+        </if>
+      </choose>
+      <!-- Platform name in small caps -->
+      <choose>
+        <if variable="container-title-short">
+          <text variable="container-title-short" font-variant="small-caps"/>
+        </if>
+        <else>
+          <text variable="container-title" font-variant="small-caps"/>
+        </else>
+      </choose>
+      <!-- (Date, at Time TZ) per R18.10 -->
+      <group prefix="(" suffix=")" delimiter=", ">
+        <date variable="issued" delimiter=" ">
+          <date-part name="month" form="short" strip-periods="false"/>
+          <date-part name="day" suffix=","/>
+          <date-part name="year"/>
+        </date>
+        <choose>
+          <if variable="locator">
+            <text variable="locator" prefix="at "/>
+          </if>
+        </choose>
+      </group>
+      <!-- Primary URL -->
+      <choose>
+        <if variable="URL">
+          <text variable="URL"/>
+        </if>
+      </choose>
+      <!-- Perma.cc or archival URL in brackets per R18.10 -->
+      <choose>
+        <if variable="archive">
+          <text variable="archive" prefix="[" suffix="]"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+
+  <!--
+    AI-CONTENT macro
+    Bluebook R18.3: citations to AI-generated text, images, and search outputs.
+    Format: Author, Model Name, Description of Content (Date)
+            (on file with Journal).
+    - Author = person who prompted / generated the content (roman type)
+    - Model Name = AI model (e.g., "OpenAI GPT 3.5", "Claude 3 Opus") — Publisher field
+    - Description = brief description of generated content — Title field
+    - Date = date of generation in parenthetical
+    - "on file with" = journal or institution holding the content — Archive field
+    Zotero field mapping:
+      Author    -> person who generated the content
+      Publisher -> AI model name (e.g. "OpenAI GPT 3.5")
+      Title     -> description of generated content
+      Date      -> date of generation
+      Archive   -> journal or location "on file with"
+    NOTE: Use Zotero's "Software" item type for R18.3 AI-generated content.
+    This type is not used for any other Bluebook rule in this style.
+  -->
+  <macro name="ai-content">
+    <group delimiter=" ">
+      <text macro="author-article" suffix=","/>
+      <choose>
+        <if variable="publisher">
+          <text variable="publisher" suffix=","/>
+        </if>
+      </choose>
+      <text variable="title" font-style="italic"/>
+      <group prefix="(" suffix=")">
+        <date variable="issued" delimiter=" ">
+          <date-part name="month" form="short" strip-periods="false"/>
+          <date-part name="day" suffix=","/>
+          <date-part name="year"/>
+        </date>
+      </group>
+      <choose>
+        <if variable="archive">
+          <group prefix="(on file with " suffix=")" delimiter=", ">
+            <text variable="archive"/>
+            <text variable="archive-place"/>
+          </group>
+        </if>
+      </choose>
+    </group>
+  </macro>
+
+  <!--
+    ELECTRONIC-MEDIA macro
+    Bluebook R18.5: physical electronic storage media and cloud storage.
+
+    (a) Physical media — R18.5(a):
+    Format: Title [filename], Owner (Medium, last modified Date) (on file with Location).
+    Example: Bluebook Invitational Schedule 2024 [BBI24_Sch.docx], Columbia Law Review
+             (USB Drive, last modified Apr. 13, 2024) (on file with the Columbia Law Review).
+
+    Zotero field mapping (physical):
+      Title           -> title of the media (small caps)
+      Loc. in Archive -> filename in brackets (e.g. "BBI24_Sch.docx")
+      Author          -> owner/institution (roman type)
+      Medium          -> storage medium (e.g. "USB Drive", "microSD")
+      Date            -> last modified date
+      Archive         -> "on file with" location
+
+    (b) Cloud storage — R18.5(b):
+    Format: Author, Title, URL (Owner, Folder, Platform) (last modified Date) (on file).
+    Example: Benjamin Liebman, Empirical Research on Chinese Case Data, g.drv/liebman
+             (Colum. L. Rev., Liebman on China, Google Drive) (last modified June 18, 2024)
+             (on file with the Columbia Law Review).
+
+    Distinguish cloud from physical by presence of URL: cloud sources have a URL.
+
+    Zotero field mapping (cloud):
+      Author          -> file author (roman type)
+      Title           -> file title (roman type)
+      URL             -> URL or abbreviated path to the file
+      Publisher       -> folder owner/institution name
+      container-title -> folder name (Extra: container-title: FolderName)
+      Medium          -> cloud service name (e.g. "Google Drive", "iCloud")
+      Date            -> last modified date
+      Archive         -> "on file with" location
+
+    NOTE: Use Zotero's "Dataset" item type for R18.5 electronic storage media.
+  -->
+  <macro name="electronic-media">
+    <choose>
+      <if variable="URL">
+        <!-- Cloud storage (R18.5(b)): Author, Title, URL (Owner, Folder, Platform)
+             (last modified Date) (on file with Location). -->
+        <group delimiter=" ">
+          <text macro="author-article" suffix=","/>
+          <text variable="title"/>
+          <text variable="URL" suffix=","/>
+          <group prefix="(" suffix=")" delimiter=", ">
+            <text variable="publisher"/>
+            <choose>
+              <if variable="container-title">
+                <text variable="container-title"/>
+              </if>
+            </choose>
+            <text variable="medium"/>
+          </group>
+          <group prefix="(last modified " suffix=")">
+            <date variable="issued" delimiter=" ">
+              <date-part name="month" form="short" strip-periods="false"/>
+              <date-part name="day" suffix=","/>
+              <date-part name="year"/>
+            </date>
+          </group>
+          <choose>
+            <if variable="archive">
+              <group prefix="(on file with " suffix=")" delimiter=", ">
+                <text variable="archive"/>
+              </group>
+            </if>
+          </choose>
+        </group>
+      </if>
+      <else>
+        <!-- Physical media (R18.5(a)): Title [filename], Owner
+             (Medium, last modified Date) (on file with Location). -->
+        <group delimiter=" ">
+          <!-- Title, with optional [filename] appended -->
+          <choose>
+            <if variable="archive-place">
+              <group>
+                <text variable="title" font-variant="small-caps" text-case="title"/>
+                <text variable="archive-place" prefix=" [" suffix="]"/>
+              </group>
+            </if>
+            <else>
+              <text variable="title" font-variant="small-caps" text-case="title"/>
+            </else>
+          </choose>
+          <!-- Owner (roman type) -->
+          <choose>
+            <if variable="author">
+              <text macro="author-article" prefix=", "/>
+            </if>
+          </choose>
+          <!-- (Medium, last modified Date) -->
+          <group prefix="(" suffix=")" delimiter=", ">
+            <text variable="medium"/>
+            <group delimiter=" ">
+              <text value="last modified"/>
+              <date variable="issued" delimiter=" ">
+                <date-part name="month" form="short" strip-periods="false"/>
+                <date-part name="day" suffix=","/>
+                <date-part name="year"/>
+              </date>
+            </group>
+          </group>
+          <!-- (on file with Location) -->
+          <choose>
+            <if variable="archive">
+              <group prefix="(on file with " suffix=")" delimiter=", ">
+                <text variable="archive"/>
+              </group>
+            </if>
+          </choose>
+        </group>
+      </else>
+    </choose>
+  </macro>
+
+  <!--
+    IMAGE macro
+    Bluebook R18.9: photographs, illustrations, paintings, and other works of art.
+    Format: Author, *Title* (type Year).
+    Optional "on file with" parenthetical when not publicly available.
+    The work type (e.g. "photograph", "painting", "illustration") goes in Medium.
+    Untitled works: omit title; use descriptive text as title (entered in Title field).
+
+    Zotero field mapping:
+      Author  -> artist/creator (roman type)
+      Title   -> title of the work (italics); use description for untitled works
+      Medium  -> type of work (e.g. "photograph", "painting", "illustration")
+      Date    -> year of creation
+      Archive -> "on file with" location when not publicly available
+      URL     -> URL when image is hosted online (renders after parenthetical)
+
+    NOTE: Use Zotero's "Artwork" item type (graphic) for R18.9 images.
+    For the "reprinted by" form, add a manual note — CSL cannot express
+    compound related-authority citations automatically.
+    For emojis (R18.9), cite manually — no CSL field maps to Unicode code points.
+  -->
+  <macro name="image">
+    <group delimiter=" ">
+      <text macro="author-article" suffix=","/>
+      <text variable="title" font-style="italic" text-case="title"/>
+      <group prefix="(" suffix=")" delimiter=" ">
+        <text variable="medium"/>
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </group>
+      <choose>
+        <if variable="archive">
+          <group prefix="(on file with " suffix=")" delimiter=", ">
+            <text variable="archive"/>
+            <text variable="archive-place"/>
+          </group>
+        </if>
+      </choose>
+      <choose>
+        <if variable="URL">
+          <text variable="URL"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+
+  <!--
+    MICROFORM macro
+    Bluebook R18.6(b): standalone microform collections with original materials.
+    Format: Title, Collection ID (Publisher).
+    The collection identifier (e.g. "Fiche 143", "CIS No. 89-H523-17") goes in Number.
+
+    R18.6(a) — microform reproductions of preexisting materials — uses the
+    "*microformed on*" related-authority form appended to the original citation.
+    This cannot be automated in CSL; editors must add the "*microformed on*"
+    clause manually after generating the citation for the original source.
+
+    Zotero field mapping:
+      Title     -> title of the microform collection (small caps)
+      Number    -> collection identifier or fiche/reel number
+      Publisher -> publisher of the microform series (in parenthetical)
+      Date      -> year (optional)
+
+    NOTE: Use Zotero's "Standard" item type for R18.6 standalone microform.
+  -->
+  <macro name="microform">
+    <group delimiter=" ">
+      <text variable="title" font-variant="small-caps" text-case="title"/>
+      <choose>
+        <if variable="number">
+          <text variable="number" suffix=","/>
+        </if>
+      </choose>
+      <group prefix="(" suffix=")" delimiter=" ">
+        <text variable="publisher"/>
+        <choose>
+          <if variable="issued">
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+          </if>
+        </choose>
+      </group>
+    </group>
+  </macro>
+
+  <!--
+    HARDWARE macro
+    Bluebook R18.11.1: physical hardware devices.
+    Format: MANUFACTURER, Model Name, PartNumber (SKU).
+    The part/model number goes in Patent Number; the SKU goes in Extra as
+    "number: SKU" or in the locator at cite time.
+
+    Zotero field mapping:
+      Author        -> manufacturer name (small caps)
+      Title         -> full official model name (roman type)
+      Number        -> manufacturer part number or model number
+      Archive       -> SKU number if present (renders in parentheses)
+
+    NOTE: Use Zotero's "Patent" item type for R18.11.1 hardware.
+  -->
+  <macro name="hardware">
+    <group delimiter=", ">
+      <text macro="author-book"/>
+      <text variable="title"/>
+      <text variable="number"/>
+    </group>
+    <choose>
+      <if variable="archive">
+        <text variable="archive" prefix=" (" suffix=")"/>
+      </if>
+    </choose>
+  </macro>
+
+  <!--
+    SOFTWARE macro
+    Bluebook R18.11.2: software citations (general, open source, payment software).
+
+    (a) General software:
+    DEVELOPER, *Software Name*, Ver./Rel./Patch X (Platform, Date).
+    When developer name = software name, omit developer.
+
+    (b) Open-source software (repository citation):
+    DEVELOPER, *Software Name*, URL (last accessed/updated Date).
+
+    Distinguish general from open-source by URL presence (open-source has URL).
+    The version/release string goes in Version Number (Zotero "Extra: version: X").
+    The platform goes in Extra as "genre: Platform" (e.g. "genre: Windows").
+
+    Zotero field mapping (general):
+      Author  -> developer name (small caps); omit if same as software name
+      Title   -> official software name (italics)
+      Version -> version string (e.g. "Ver. 16.86.1"); enter in Extra as
+                 "version: Ver. 16.86.1" — CSL uses the version variable
+      Genre   -> platform (e.g. "Windows", "iOS"); enter in Extra as
+                 "genre: iOS"
+      Number  -> SKU or build number for optional parenthetical
+      Date    -> release date of the cited version
+
+    Zotero field mapping (open-source repository):
+      Author  -> repository owner (small caps)
+      Title   -> software name (italics)
+      URL     -> repository or file URL
+      Archive -> "last accessed" or "last updated" label (enter as
+                 "last accessed" or "last updated")
+      Date    -> access or last-updated date
+
+    NOTE: Use Zotero's "Encyclopedia Article" item type for R18.11.2 software.
+  -->
+  <macro name="software">
+    <choose>
+      <if variable="URL">
+        <!-- Open-source repository: DEVELOPER, *Software*, URL (last Date). -->
+        <group delimiter=" ">
+          <text macro="author-book" suffix=","/>
+          <text variable="title" font-style="italic" text-case="title" suffix=","/>
+          <text variable="URL" suffix=","/>
+          <group prefix="(" suffix=")">
+            <choose>
+              <if variable="archive">
+                <text variable="archive" suffix=" "/>
+              </if>
+              <else>
+                <text value="last accessed "/>
+              </else>
+            </choose>
+            <date variable="issued" delimiter=" ">
+              <date-part name="month" form="short" strip-periods="false"/>
+              <date-part name="day" suffix=","/>
+              <date-part name="year"/>
+            </date>
+          </group>
+        </group>
+      </if>
+      <else>
+        <!-- General software: DEVELOPER, *Software*, Ver. X (Platform, Date). -->
+        <group delimiter=" ">
+          <text macro="author-book" suffix=","/>
+          <text variable="title" font-style="italic" text-case="title" suffix=","/>
+          <text variable="version" suffix=","/>
+          <!-- SKU / build number in parentheses when present -->
+          <choose>
+            <if variable="number">
+              <text variable="number" prefix="(" suffix="),"/>
+            </if>
+          </choose>
+          <group prefix="(" suffix=")">
+            <choose>
+              <if variable="genre">
+                <group delimiter=", ">
+                  <text variable="genre"/>
+                  <date variable="issued" delimiter=" ">
+                    <date-part name="month" form="short" strip-periods="false"/>
+                    <date-part name="day" suffix=","/>
+                    <date-part name="year"/>
+                  </date>
+                </group>
+              </if>
+              <else>
+                <date variable="issued" delimiter=" ">
+                  <date-part name="month" form="short" strip-periods="false"/>
+                  <date-part name="day" suffix=","/>
+                  <date-part name="year"/>
+                </date>
+              </else>
+            </choose>
+          </group>
+        </group>
+      </else>
+    </choose>
+  </macro>
+
+  <!-- ============================================================
+       CITATION (footnote) element
+       ============================================================ -->
+  <citation>
+    <layout suffix="." delimiter="; ">
+      <choose>
+
+        <!-- Ibid with locator: Id. at X -->
+        <if position="ibid-with-locator">
+          <group delimiter=" ">
+            <text term="ibid" font-style="italic" text-case="capitalize-first"/>
+            <text value="at"/>
+            <text variable="locator"/>
+          </group>
+        </if>
+
+        <!-- Ibid without locator: Id. — strip-periods removes the term's trailing
+             period so the layout suffix "." supplies the single closing period. -->
+        <else-if position="ibid">
+          <text term="ibid" font-style="italic" text-case="capitalize-first" strip-periods="true"/>
+        </else-if>
+
+        <!-- JOURNAL ARTICLE (R16.4 / R16.5) -->
+        <else-if type="article-journal">
+          <text macro="journal-article"/>
+        </else-if>
+
+        <!-- MAGAZINE ARTICLE (R16.5) -->
+        <else-if type="article-magazine">
+          <text macro="journal-article"/>
+        </else-if>
+
+        <!-- NEWSPAPER ARTICLE (R16.6) -->
+        <else-if type="article-newspaper">
+          <text macro="newspaper-article"/>
+        </else-if>
+
+        <!-- WEBPAGE (R18.2.2)
+             Author, Title, Site Name (Date), URL.
+             Uses Zotero "webpage" item type.
+        -->
+        <else-if type="webpage post-weblog">
+          <text macro="webpage"/>
+        </else-if>
+
+        <!-- FILM (R18.7.1)
+             Commercial: TITLE, Medium (Producer Year).
+             Noncommercial: Author, TITLE (Year) (on file with ...).
+             Uses Zotero "motion_picture" item type.
+        -->
+        <else-if type="motion_picture">
+          <text macro="film"/>
+        </else-if>
+
+        <!-- BROADCAST: TV series (R18.7.2) or web video (R18.7.4)
+             TV series: TITLE: Episode (Platform, Date).
+             Web video: ACCOUNT, Title, at timestamp (Platform, Date), URL.
+             Distinguish by URL: web-based videos have a URL; TV series do not.
+             Uses Zotero "broadcast" item type.
+             Zotero field mapping:
+               TV series  — Title = series name, Extra: container-title = episode
+               Web video  — Author = account, Title = video title, URL = URL
+        -->
+        <else-if type="broadcast">
+          <choose>
+            <if variable="URL">
+              <text macro="web-video"/>
+            </if>
+            <else>
+              <text macro="tv-series"/>
+            </else>
+          </choose>
+        </else-if>
+
+        <!-- AUDIO RECORDING (R18.8)
+             Physical / streaming / podcast citations.
+             Uses Zotero "song" item type.
+        -->
+        <else-if type="song">
+          <text macro="audio-recording"/>
+        </else-if>
+
+        <!-- BOOK (R15.1-15.4) -->
+        <else-if type="book">
+          <group delimiter=" ">
+            <choose>
+              <if variable="volume">
+                <number variable="volume"/>
+              </if>
+            </choose>
+            <text macro="author-book" suffix=","/>
+            <text variable="title" font-variant="small-caps" text-case="title"/>
+            <choose>
+              <if variable="locator">
+                <group delimiter=", ">
+                  <text variable="page-first"/>
+                  <text variable="locator"/>
+                </group>
+              </if>
+            </choose>
+            <text macro="publish-details"/>
+          </group>
+        </else-if>
+
+        <!-- CHAPTER IN EDITED VOLUME (R15.5.1(a)) -->
+        <else-if type="chapter">
+          <group delimiter=" ">
+            <text macro="author-book" suffix=","/>
+            <text variable="title" font-style="italic" text-case="title" suffix=","/>
+            <text term="in" font-style="italic"/>
+            <text variable="container-title" font-variant="small-caps"/>
+            <choose>
+              <if variable="page">
+                <text variable="page"/>
+              </if>
+            </choose>
+            <choose>
+              <if variable="locator">
+                <text variable="locator" prefix=", "/>
+              </if>
+            </choose>
+            <text macro="publish-details"/>
+          </group>
+        </else-if>
+
+        <!-- THESIS / DISSERTATION (R17.2.2)
+             Author, Title (Month Day, Year)
+             (genre, University) (on file with Location).
+             Enter degree type in Zotero's Type field (e.g., "Ph.D.
+             dissertation") and university in Publisher field.
+             Enter archive/repository in Extra field if applicable.
+        -->
+        <else-if type="thesis">
+          <group delimiter=" ">
+            <text macro="author-book" suffix=","/>
+            <text variable="title" font-variant="small-caps" text-case="title"/>
+            <choose>
+              <if variable="locator">
+                <text variable="locator"/>
+              </if>
+            </choose>
+            <group prefix="(" suffix=")">
+              <text macro="manuscript-date"/>
+            </group>
+            <group prefix="(" suffix=")" delimiter=", ">
+              <choose>
+                <if variable="genre">
+                  <text variable="genre"/>
+                </if>
+                <else>
+                  <text value="unpublished manuscript"/>
+                </else>
+              </choose>
+              <text variable="publisher"/>
+            </group>
+            <choose>
+              <if variable="archive">
+                <group prefix="(on file with " suffix=")" delimiter=", ">
+                  <text variable="archive"/>
+                  <text variable="archive-place"/>
+                </group>
+              </if>
+            </choose>
+          </group>
+        </else-if>
+
+        <!-- REPORT / WORKING PAPER (R17.4, R15.1, R15.4)
+             Author, Title pinpoint (Publisher, Working Paper No. X, Year).
+             Zotero field mapping:
+               Publisher  -> sponsoring organization
+               Report No. -> paper number (e.g. "Working Paper No. 729")
+               Date       -> year
+        -->
+        <else-if type="report">
+          <group delimiter=" ">
+            <text macro="author-book" suffix=","/>
+            <text variable="title" font-variant="small-caps" text-case="title"/>
+            <choose>
+              <if variable="locator">
+                <text variable="locator"/>
+              </if>
+            </choose>
+            <group prefix="(" suffix=")" delimiter=", ">
+              <text variable="publisher"/>
+              <choose>
+                <if variable="number">
+                  <text variable="number"/>
+                </if>
+              </choose>
+              <date variable="issued">
+                <date-part name="year"/>
+              </date>
+            </group>
+          </group>
+        </else-if>
+
+        <!-- MANUSCRIPT (unpublished, R17.2.1) and FORTHCOMING (R17.3)
+             Unpublished: Author, Title page (Month Day, Year)
+               (unpublished manuscript) (on file with Location).
+             Forthcoming: Author, Title, Volume Journal
+               (forthcoming Month Year).
+             Distinguish by entering "forthcoming" in Zotero's Extra
+             field or by using the genre field.
+             Archival manuscripts: use the "document" type instead
+             to invoke the archival macro (R23).
+        -->
+        <else-if type="manuscript">
+          <group delimiter=" ">
+            <text macro="author-book" suffix=","/>
+            <text variable="title" font-variant="small-caps" text-case="title"/>
+            <choose>
+              <if variable="locator">
+                <text variable="locator"/>
+              </if>
+            </choose>
+            <group prefix="(" suffix=")">
+              <text macro="manuscript-date"/>
+            </group>
+            <choose>
+              <if variable="genre">
+                <!-- genre field: e.g. "forthcoming May 2025",
+                     "unpublished manuscript", "unpublished comment" -->
+                <text variable="genre" prefix="(" suffix=")"/>
+              </if>
+              <else>
+                <text value="(unpublished manuscript)"/>
+              </else>
+            </choose>
+            <choose>
+              <if variable="publisher">
+                <text variable="publisher" prefix="(on file with " suffix=")"/>
+              </if>
+            </choose>
+          </group>
+        </else-if>
+
+        <!-- DOCUMENT
+             Used for two purposes:
+             (a) Archival sources (R23): documents held in official archives.
+                 Enter archive in Zotero's Archive field.
+             (b) Government/institutional publications (R15.1(c)):
+                 rendered with publisher and year.
+        -->
+        <else-if type="document">
+          <choose>
+            <if variable="archive">
+              <text macro="archival"/>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text macro="author-book" suffix=","/>
+                <text variable="title" font-variant="small-caps" text-case="title"/>
+                <choose>
+                  <if variable="locator">
+                    <text variable="locator" prefix=", "/>
+                  </if>
+                </choose>
+                <text macro="publisher-year"/>
+              </group>
+            </else>
+          </choose>
+        </else-if>
+
+        <!-- SOCIAL MEDIA POST (R18.10)
+             Name (@handle), PLATFORM (Date, Time), URL [Perma.cc].
+             Uses Zotero "post" item type.
+             Zotero field mapping:
+               Author          -> poster's real name
+               Number          -> @handle (without @; CSL prepends @)
+               container-title -> platform name (e.g. "X", "Instagram")
+               Date            -> date of post
+               locator         -> time of post (e.g. "3:14 PM ET")
+               URL             -> post URL
+               Archive         -> Perma.cc or archival URL in brackets
+        -->
+        <else-if type="post">
+          <text macro="social-media"/>
+        </else-if>
+
+        <!-- AI-GENERATED CONTENT (R18.3)
+             Author, Model Name, Description (Date) (on file with Journal).
+             Uses Zotero "software" item type.
+             Zotero field mapping:
+               Author    -> person who generated the content
+               Publisher -> AI model (e.g. "OpenAI GPT 3.5")
+               Title     -> description of the generated content
+               Date      -> date of generation
+               Archive   -> journal or institution holding the content
+        -->
+        <else-if type="software">
+          <text macro="ai-content"/>
+        </else-if>
+
+        <!-- ELECTRONIC STORAGE MEDIA (R18.5)
+             Author, TITLE (Medium, Repository Year)
+             (on file with Location).
+             Uses Zotero "dataset" item type.
+             Zotero field mapping:
+               Author    -> content creator
+               Title     -> title of content (small caps)
+               Medium    -> storage medium (e.g. "microSD Card", "USB Drive")
+               Publisher -> repository or platform
+               Date      -> year of deposit
+               Archive   -> "on file with" location
+        -->
+        <else-if type="dataset">
+          <text macro="electronic-media"/>
+        </else-if>
+
+        <!-- IMAGE / ARTWORK (R18.9)
+             Author, *Title* (type Year) (on file with Location).
+             Uses Zotero "Artwork" item type (graphic).
+             Zotero field mapping:
+               Author  -> artist/creator
+               Title   -> title or description of work (italics, title-cased)
+               Medium  -> work type (e.g. "photograph", "painting")
+               Date    -> year of creation
+               Archive -> "on file with" location
+               URL     -> URL when hosted online
+        -->
+        <else-if type="graphic">
+          <text macro="image"/>
+        </else-if>
+
+        <!-- MICROFORM — STANDALONE (R18.6(b))
+             Title, Collection ID (Publisher Year).
+             Uses Zotero "Standard" item type.
+             NOTE: R18.6(a) reproduced microforms use "*microformed on*" appended
+             to the original source citation — add this clause manually.
+             Zotero field mapping:
+               Title     -> microform collection title (small caps)
+               Number    -> collection ID or fiche/reel number
+               Publisher -> publisher of the microform series
+               Date      -> year (optional)
+        -->
+        <else-if type="standard">
+          <text macro="microform"/>
+        </else-if>
+
+        <!-- HARDWARE (R18.11.1)
+             MANUFACTURER, Model Name, PartNumber (SKU).
+             Uses Zotero "Patent" item type.
+             Zotero field mapping:
+               Author  -> manufacturer (small caps)
+               Title   -> full model name (roman)
+               Number  -> part/model number
+               Archive -> SKU number (renders in parentheses)
+        -->
+        <else-if type="patent">
+          <text macro="hardware"/>
+        </else-if>
+
+        <!-- SOFTWARE (R18.11.2)
+             General: DEVELOPER, *Name*, Ver. X (Platform, Date).
+             Open-source: DEVELOPER, *Name*, URL (last accessed/updated Date).
+             Distinguish by URL presence (open-source has URL).
+             Uses Zotero "Encyclopedia Article" item type (entry-encyclopedia).
+             Zotero field mapping:
+               Author   -> developer (small caps); omit if same as software name
+               Title    -> software name (italics)
+               Version  -> version string (Extra: version: Ver. 16.86.1)
+               Genre    -> platform (Extra: genre: Windows)
+               Number   -> SKU or build number
+               Date     -> release date
+               URL      -> repository URL (open-source only)
+               Archive  -> "last accessed" or "last updated" (open-source)
+        -->
+        <else-if type="entry-encyclopedia">
+          <text macro="software"/>
+        </else-if>
+
+        <!-- FALLBACK -->
+        <else>
+          <group delimiter=" ">
+            <text macro="author-book" suffix=","/>
+            <text variable="title" font-variant="small-caps" text-case="title"/>
+            <text macro="publisher-year"/>
+          </group>
+        </else>
+
+      </choose>
+    </layout>
+  </citation>
+
+  <!-- ============================================================
+       BIBLIOGRAPHY
+       ============================================================ -->
+  <bibliography hanging-indent="false" entry-spacing="1">
+    <sort>
+      <key macro="author-book"/>
+      <key variable="title"/>
+    </sort>
+    <layout suffix=".">
+      <choose>
+
+        <if type="article-journal article-magazine" match="any">
+          <text macro="journal-article"/>
+        </if>
+
+        <else-if type="article-newspaper">
+          <text macro="newspaper-article"/>
+        </else-if>
+
+        <else-if type="book">
+          <group delimiter=" ">
+            <choose>
+              <if variable="volume">
+                <number variable="volume"/>
+              </if>
+            </choose>
+            <text macro="author-book" suffix=","/>
+            <text variable="title" font-variant="small-caps" text-case="title"/>
+            <text macro="publish-details"/>
+          </group>
+        </else-if>
+
+        <else-if type="chapter">
+          <group delimiter=" ">
+            <text macro="author-book" suffix=","/>
+            <text variable="title" font-style="italic" text-case="title" suffix=","/>
+            <text term="in" font-style="italic"/>
+            <text variable="container-title" font-variant="small-caps"/>
+            <choose>
+              <if variable="page">
+                <text variable="page"/>
+              </if>
+            </choose>
+            <text macro="publish-details"/>
+          </group>
+        </else-if>
+
+        <else-if type="thesis">
+          <group delimiter=" ">
+            <text macro="author-book" suffix=","/>
+            <text variable="title" font-variant="small-caps" text-case="title"/>
+            <choose>
+              <if variable="locator">
+                <text variable="locator"/>
+              </if>
+            </choose>
+            <group prefix="(" suffix=")">
+              <text macro="manuscript-date"/>
+            </group>
+            <group prefix="(" suffix=")" delimiter=", ">
+              <choose>
+                <if variable="genre">
+                  <text variable="genre"/>
+                </if>
+                <else>
+                  <text value="unpublished manuscript"/>
+                </else>
+              </choose>
+              <text variable="publisher"/>
+            </group>
+            <choose>
+              <if variable="archive">
+                <group prefix="(on file with " suffix=")" delimiter=", ">
+                  <text variable="archive"/>
+                  <text variable="archive-place"/>
+                </group>
+              </if>
+            </choose>
+          </group>
+        </else-if>
+
+        <else-if type="report">
+          <group delimiter=" ">
+            <text macro="author-book" suffix=","/>
+            <text variable="title" font-variant="small-caps" text-case="title"/>
+            <group prefix="(" suffix=")" delimiter=", ">
+              <text variable="publisher"/>
+              <choose>
+                <if variable="number">
+                  <text variable="number"/>
+                </if>
+              </choose>
+              <date variable="issued">
+                <date-part name="year"/>
+              </date>
+            </group>
+          </group>
+        </else-if>
+
+        <else-if type="manuscript">
+          <group delimiter=" ">
+            <text macro="author-book" suffix=","/>
+            <text variable="title" font-variant="small-caps" text-case="title"/>
+            <choose>
+              <if variable="locator">
+                <text variable="locator"/>
+              </if>
+            </choose>
+            <group prefix="(" suffix=")">
+              <text macro="manuscript-date"/>
+            </group>
+            <choose>
+              <if variable="genre">
+                <text variable="genre" prefix="(" suffix=")"/>
+              </if>
+              <else>
+                <text value="(unpublished manuscript)"/>
+              </else>
+            </choose>
+            <choose>
+              <if variable="publisher">
+                <text variable="publisher" prefix="(on file with " suffix=")"/>
+              </if>
+            </choose>
+          </group>
+        </else-if>
+
+        <else-if type="webpage post-weblog">
+          <text macro="webpage"/>
+        </else-if>
+
+        <else-if type="motion_picture">
+          <text macro="film"/>
+        </else-if>
+
+        <else-if type="broadcast">
+          <choose>
+            <if variable="URL">
+              <text macro="web-video"/>
+            </if>
+            <else>
+              <text macro="tv-series"/>
+            </else>
+          </choose>
+        </else-if>
+
+        <else-if type="song">
+          <text macro="audio-recording"/>
+        </else-if>
+
+        <else-if type="document">
+          <choose>
+            <if variable="archive">
+              <text macro="archival"/>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text macro="author-book" suffix=","/>
+                <text variable="title" font-variant="small-caps" text-case="title"/>
+                <text macro="publisher-year"/>
+              </group>
+            </else>
+          </choose>
+        </else-if>
+
+        <else-if type="post">
+          <text macro="social-media"/>
+        </else-if>
+
+        <else-if type="software">
+          <text macro="ai-content"/>
+        </else-if>
+
+        <else-if type="dataset">
+          <text macro="electronic-media"/>
+        </else-if>
+
+        <else-if type="graphic">
+          <text macro="image"/>
+        </else-if>
+
+        <else-if type="standard">
+          <text macro="microform"/>
+        </else-if>
+
+        <else-if type="patent">
+          <text macro="hardware"/>
+        </else-if>
+
+        <else-if type="entry-encyclopedia">
+          <text macro="software"/>
+        </else-if>
+
+        <else>
+          <group delimiter=" ">
+            <text macro="author-book" suffix=","/>
+            <text variable="title" font-variant="small-caps" text-case="title"/>
+            <text macro="publisher-year"/>
+          </group>
+        </else>
+
+      </choose>
+    </layout>
+  </bibliography>
+
+</style>

--- a/bluebook-law-review-secondary-sources.csl
+++ b/bluebook-law-review-secondary-sources.csl
@@ -273,9 +273,7 @@
       manually — CSL cannot express compound related-authority citations.
     </summary>
     <updated>2026-04-01T03:00:00+00:00</updated>
-    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">
-      This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License
-    </rights>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
 
   <!-- LOCALE -->

--- a/bluebook-law-review-secondary-sources.csl
+++ b/bluebook-law-review-secondary-sources.csl
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="display-and-sort" default-locale="en-US" delimiter-precedes-last="never">
-
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="display-and-sort" delimiter-precedes-last="never" default-locale="en-US">
   <info>
     <title>Bluebook Law Review Secondary Sources</title>
     <title-short>Bluebook LR Secondary Sources</title-short>
@@ -13,8 +12,7 @@
     </author>
     <category citation-format="note"/>
     <category field="law"/>
-    <summary>
-      Bluebook (22nd ed. 2025) law review footnote citation style covering:
+    <summary>Bluebook (22nd ed. 2025) law review footnote citation style covering:
 
       MONOGRAPHIC SOURCES (Rule 15): books, edited volumes, book chapters,
       theses, dissertations, reports, and government documents.
@@ -28,7 +26,7 @@
 
       INTERNET SOURCES (Rule 18): webpages and web-based sources (R18.2),
       AI-generated content (R18.3), electronic storage media (R18.5),
-      microform — standalone original collections (R18.6(b)), films and
+      microform &#8212; standalone original collections (R18.6(b)), films and
       documentaries (R18.7.1), television series (R18.7.2), web-based
       video (R18.7.4), audio recordings and streaming services including
       podcasts (R18.8), images and photographs (R18.9), social media
@@ -99,7 +97,7 @@
       "Harv. L. Rev." are entered pre-abbreviated; (c) episode names
       (container-title in Broadcast/Audio items) render as entered.
       Rule 8(b) requires internet page titles to follow source capitalization;
-      the CSL applies title case to webpage titles as a practical default —
+      the CSL applies title case to webpage titles as a practical default &#8212;
       editors should verify against the actual source.
 
       INSTITUTIONAL AUTHORS (R15.1(c)): Zotero does not apply
@@ -197,7 +195,7 @@
       the @ symbol) in Zotero's Number field. Enter the platform name
       (e.g. "X", "Instagram", "Facebook") in Publication. Enter the date
       in Date. Enter the time (e.g. "11:04 ET") in Extra as
-      "locator: 11:04 ET" — the CSL prepends "at". Enter the post URL in
+      "locator: 11:04 ET" &#8212; the CSL prepends "at". Enter the post URL in
       URL. Enter a Perma.cc archival URL in Archive (renders in brackets).
       LIMITATION: Visual/audio posts (R18.10(a)) require "Video posted by"
       or "Image posted by" before the name; this prefix cannot be
@@ -232,19 +230,19 @@
       type. Enter the creator in Author (roman type). Enter the title
       or description in Title (renders in italics, title-cased). Enter
       the work type (e.g. "photograph", "painting", "illustration") in
-      Medium — this renders in the type parenthetical. Enter the year
+      Medium &#8212; this renders in the type parenthetical. Enter the year
       in Date. Enter "on file with" location in Archive. Enter a URL
       in URL when the image is publicly hosted. The "reprinted by" form
-      (R18.9) and emoji citations must be added manually — CSL cannot
+      (R18.9) and emoji citations must be added manually &#8212; CSL cannot
       express compound related-authority citations or Unicode code points.
 
-      23. MICROFORM — STANDALONE (R18.6(b)): Use Zotero's "Standard"
+      23. MICROFORM &#8212; STANDALONE (R18.6(b)): Use Zotero's "Standard"
       item type for microform collections containing original materials.
       Enter the collection title in Title (small caps). Enter the
       collection identifier (e.g. "Fiche 143") in Number. Enter the
       publisher of the microform series in Publisher.
       NOTE: R18.6(a) citations to reproduced materials use the form
-      "[original citation], *microformed on* ID (Publisher)" — generate
+      "[original citation], *microformed on* ID (Publisher)" &#8212; generate
       the original citation using the appropriate source type, then add
       the "*microformed on*" clause manually.
 
@@ -265,12 +263,10 @@
       enter the repository URL in URL (presence of URL triggers the
       open-source format) and enter "last accessed" or "last updated"
       in Archive. The emulation form ("*emulated on*") must be added
-      manually — CSL cannot express compound related-authority citations.
-    </summary>
+      manually &#8212; CSL cannot express compound related-authority citations.</summary>
     <updated>2026-04-01T03:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-
   <!-- LOCALE -->
   <locale xml:lang="en">
     <terms>
@@ -290,11 +286,9 @@
       <term name="ordinal-03">d</term>
     </terms>
   </locale>
-
   <!-- ============================================================
        MACROS
        ============================================================ -->
-
   <!--
     AUTHOR-BOOK macro
     Bluebook R15.1: full name in small caps, ampersand between last two.
@@ -309,7 +303,6 @@
       </substitute>
     </names>
   </macro>
-
   <!--
     AUTHOR-ARTICLE macro
     Bluebook R16.2: full name in ordinary roman type (not small caps).
@@ -326,7 +319,6 @@
       <name and="symbol" delimiter=", " delimiter-precedes-last="never" initialize="false"/>
     </names>
   </macro>
-
   <!--
     EDITOR macro
     Bluebook R15.2: roman type, "ed." or "eds." label.
@@ -337,7 +329,6 @@
       <label form="short" prefix=" "/>
     </names>
   </macro>
-
   <!--
     TRANSLATOR macro
     Bluebook R15.2: roman type, "trans." label.
@@ -348,7 +339,6 @@
       <label form="short" prefix=" "/>
     </names>
   </macro>
-
   <!--
     EDITION macro
     Bluebook R15.4: "4th ed." inside the publication parenthetical.
@@ -367,7 +357,6 @@
       </else-if>
     </choose>
   </macro>
-
   <!--
     PUBLISH-DETAILS macro
     Bluebook R15.2 and R15.4: single parenthetical with translator, editor,
@@ -410,7 +399,6 @@
       </choose>
     </group>
   </macro>
-
   <!--
     PUBLISHER-YEAR macro
     Simplified parenthetical for reports, manuscripts, documents.
@@ -423,7 +411,6 @@
       </date>
     </group>
   </macro>
-
   <!--
     JOURNAL-ARTICLE macro
     R16.4 (volume present): Author, Title, Volume Journal Page (Year).
@@ -521,7 +508,6 @@
       </else>
     </choose>
   </macro>
-
   <!--
     NEWSPAPER-ARTICLE macro
     Bluebook R16.6: Author, Title, Newspaper, Month Day, Year, at Page.
@@ -576,7 +562,6 @@
       </choose>
     </group>
   </macro>
-
   <!--
     MANUSCRIPT-DATE macro
     Bluebook R17.2: unpublished materials use full date (Month Day, Year).
@@ -590,7 +575,6 @@
       <date-part name="year"/>
     </date>
   </macro>
-
   <!--
     Bluebook R18.2.2: Author, Title, Site Name (Date), URL.
     - Author in roman type (R18.2.2(a))
@@ -627,7 +611,6 @@
       </choose>
     </group>
   </macro>
-
   <!--
     ARCHIVAL macro
     Bluebook R23: Author, Title, Date (on file with Archive, Collection, Location).
@@ -665,7 +648,6 @@
       </choose>
     </group>
   </macro>
-
   <!--
     FILM macro
     Bluebook R18.7.1: commercial and noncommercial films.
@@ -755,7 +737,6 @@
       </else>
     </choose>
   </macro>
-
   <!--
     TV-SERIES macro
     Bluebook R18.7.2: TITLE: Episode Name (Platform, Date).
@@ -763,12 +744,12 @@
     as broadcast type without URL (e.g. podcast on physical media).
     Zotero field mapping:
       Title           -> title (series name, small caps)
-      container-title -> episode name (italics) — enter in Extra as
+      container-title -> episode name (italics) &#8212; enter in Extra as
                          container-title: Episode Name
       Publisher       -> platform / network / streaming service
       Date            -> broadcast or release date
       Medium          -> access medium (e.g. "NBC television broadcast",
-                         "DVD", "Netflix") — if blank, publisher is used alone
+                         "DVD", "Netflix") &#8212; if blank, publisher is used alone
   -->
   <macro name="tv-series">
     <!--
@@ -833,7 +814,6 @@
       </choose>
     </group>
   </macro>
-
   <!--
     WEB-VIDEO macro
     Bluebook R18.7.4: ACCOUNT, Title of Video, at timestamp
@@ -882,7 +862,6 @@
       </choose>
     </group>
   </macro>
-
   <!--
     AUDIO-RECORDING macro
     Bluebook R18.8: physical recordings, streaming, and podcasts.
@@ -1010,7 +989,6 @@
       </else>
     </choose>
   </macro>
-
   <!--
     SOCIAL-MEDIA macro
     Bluebook R18.10: posts on X (Twitter), Instagram, Facebook, Mastodon, etc.
@@ -1019,7 +997,7 @@
     - @handle in roman type immediately after name in parentheses
     - Platform name in small caps (R18.10(b))
     - Date and time in parenthetical (R18.10(c)); time entered via locator
-    - URL followed by archival URL in brackets — archival must be added manually
+    - URL followed by archival URL in brackets &#8212; archival must be added manually
     Zotero field mapping:
       Author          -> real name of poster
       number          -> @handle (without the @; CSL will prepend @)
@@ -1027,7 +1005,7 @@
       Date            -> date of post (with time if available)
       locator         -> time of post (e.g. "3:14 PM ET")
       URL             -> URL of the post
-      archive         -> archival (Perma.cc) URL — enter as "on file with" if institutional
+      archive         -> archival (Perma.cc) URL &#8212; enter as "on file with" if institutional
     NOTE: Perma.cc URL should follow the primary URL in brackets per R18.10.
     Enter the Perma.cc link manually in the document, or store it in Zotero
     Extra as a note. The CSL appends the archive field as a second bracketed URL
@@ -1053,7 +1031,7 @@
           </choose>
         </if>
         <else-if variable="number">
-          <!-- No real name — render @handle alone as identifier -->
+          <!-- No real name &#8212; render @handle alone as identifier -->
           <text variable="number" prefix="@" suffix=","/>
         </else-if>
       </choose>
@@ -1099,17 +1077,16 @@
       </choose>
     </group>
   </macro>
-
   <!--
     AI-CONTENT macro
     Bluebook R18.3: citations to AI-generated text, images, and search outputs.
     Format: Author, Model Name, Description of Content (Date)
             (on file with Journal).
     - Author = person who prompted / generated the content (roman type)
-    - Model Name = AI model (e.g., "OpenAI GPT 3.5", "Claude 3 Opus") — Publisher field
-    - Description = brief description of generated content — Title field
+    - Model Name = AI model (e.g., "OpenAI GPT 3.5", "Claude 3 Opus") &#8212; Publisher field
+    - Description = brief description of generated content &#8212; Title field
     - Date = date of generation in parenthetical
-    - "on file with" = journal or institution holding the content — Archive field
+    - "on file with" = journal or institution holding the content &#8212; Archive field
     Zotero field mapping:
       Author    -> person who generated the content
       Publisher -> AI model name (e.g. "OpenAI GPT 3.5")
@@ -1145,12 +1122,11 @@
       </choose>
     </group>
   </macro>
-
   <!--
     ELECTRONIC-MEDIA macro
     Bluebook R18.5: physical electronic storage media and cloud storage.
 
-    (a) Physical media — R18.5(a):
+    (a) Physical media &#8212; R18.5(a):
     Format: Title [filename], Owner (Medium, last modified Date) (on file with Location).
     Example: Bluebook Invitational Schedule 2024 [BBI24_Sch.docx], Columbia Law Review
              (USB Drive, last modified Apr. 13, 2024) (on file with the Columbia Law Review).
@@ -1163,7 +1139,7 @@
       Date            -> last modified date
       Archive         -> "on file with" location
 
-    (b) Cloud storage — R18.5(b):
+    (b) Cloud storage &#8212; R18.5(b):
     Format: Author, Title, URL (Owner, Folder, Platform) (last modified Date) (on file).
     Example: Benjamin Liebman, Empirical Research on Chinese Case Data, g.drv/liebman
              (Colum. L. Rev., Liebman on China, Google Drive) (last modified June 18, 2024)
@@ -1263,7 +1239,6 @@
       </else>
     </choose>
   </macro>
-
   <!--
     IMAGE macro
     Bluebook R18.9: photographs, illustrations, paintings, and other works of art.
@@ -1281,9 +1256,9 @@
       URL     -> URL when image is hosted online (renders after parenthetical)
 
     NOTE: Use Zotero's "Artwork" item type (graphic) for R18.9 images.
-    For the "reprinted by" form, add a manual note — CSL cannot express
+    For the "reprinted by" form, add a manual note &#8212; CSL cannot express
     compound related-authority citations automatically.
-    For emojis (R18.9), cite manually — no CSL field maps to Unicode code points.
+    For emojis (R18.9), cite manually &#8212; no CSL field maps to Unicode code points.
   -->
   <macro name="image">
     <group delimiter=" ">
@@ -1310,14 +1285,13 @@
       </choose>
     </group>
   </macro>
-
   <!--
     MICROFORM macro
     Bluebook R18.6(b): standalone microform collections with original materials.
     Format: Title, Collection ID (Publisher).
     The collection identifier (e.g. "Fiche 143", "CIS No. 89-H523-17") goes in Number.
 
-    R18.6(a) — microform reproductions of preexisting materials — uses the
+    R18.6(a) &#8212; microform reproductions of preexisting materials &#8212; uses the
     "*microformed on*" related-authority form appended to the original citation.
     This cannot be automated in CSL; editors must add the "*microformed on*"
     clause manually after generating the citation for the original source.
@@ -1350,7 +1324,6 @@
       </group>
     </group>
   </macro>
-
   <!--
     HARDWARE macro
     Bluebook R18.11.1: physical hardware devices.
@@ -1378,7 +1351,6 @@
       </if>
     </choose>
   </macro>
-
   <!--
     SOFTWARE macro
     Bluebook R18.11.2: software citations (general, open source, payment software).
@@ -1398,7 +1370,7 @@
       Author  -> developer name (small caps); omit if same as software name
       Title   -> official software name (italics)
       Version -> version string (e.g. "Ver. 16.86.1"); enter in Extra as
-                 "version: Ver. 16.86.1" — CSL uses the version variable
+                 "version: Ver. 16.86.1" &#8212; CSL uses the version variable
       Genre   -> platform (e.g. "Windows", "iOS"); enter in Extra as
                  "genre: iOS"
       Number  -> SKU or build number for optional parenthetical
@@ -1476,14 +1448,12 @@
       </else>
     </choose>
   </macro>
-
   <!-- ============================================================
        CITATION (footnote) element
        ============================================================ -->
   <citation>
     <layout suffix="." delimiter="; ">
       <choose>
-
         <!-- Ibid with locator: Id. at X -->
         <if position="ibid-with-locator">
           <group delimiter=" ">
@@ -1492,28 +1462,23 @@
             <text variable="locator"/>
           </group>
         </if>
-
-        <!-- Ibid without locator: Id. — strip-periods removes the term's trailing
+        <!-- Ibid without locator: Id. &#8212; strip-periods removes the term's trailing
              period so the layout suffix "." supplies the single closing period. -->
         <else-if position="ibid">
           <text term="ibid" font-style="italic" text-case="capitalize-first" strip-periods="true"/>
         </else-if>
-
         <!-- JOURNAL ARTICLE (R16.4 / R16.5) -->
         <else-if type="article-journal">
           <text macro="journal-article"/>
         </else-if>
-
         <!-- MAGAZINE ARTICLE (R16.5) -->
         <else-if type="article-magazine">
           <text macro="journal-article"/>
         </else-if>
-
         <!-- NEWSPAPER ARTICLE (R16.6) -->
         <else-if type="article-newspaper">
           <text macro="newspaper-article"/>
         </else-if>
-
         <!-- WEBPAGE (R18.2.2)
              Author, Title, Site Name (Date), URL.
              Uses Zotero "webpage" item type.
@@ -1521,7 +1486,6 @@
         <else-if type="webpage post-weblog">
           <text macro="webpage"/>
         </else-if>
-
         <!-- FILM (R18.7.1)
              Commercial: TITLE, Medium (Producer Year).
              Noncommercial: Author, TITLE (Year) (on file with ...).
@@ -1530,15 +1494,14 @@
         <else-if type="motion_picture">
           <text macro="film"/>
         </else-if>
-
         <!-- BROADCAST: TV series (R18.7.2) or web video (R18.7.4)
              TV series: TITLE: Episode (Platform, Date).
              Web video: ACCOUNT, Title, at timestamp (Platform, Date), URL.
              Distinguish by URL: web-based videos have a URL; TV series do not.
              Uses Zotero "broadcast" item type.
              Zotero field mapping:
-               TV series  — Title = series name, Extra: container-title = episode
-               Web video  — Author = account, Title = video title, URL = URL
+               TV series  &#8212; Title = series name, Extra: container-title = episode
+               Web video  &#8212; Author = account, Title = video title, URL = URL
         -->
         <else-if type="broadcast">
           <choose>
@@ -1550,7 +1513,6 @@
             </else>
           </choose>
         </else-if>
-
         <!-- AUDIO RECORDING (R18.8)
              Physical / streaming / podcast citations.
              Uses Zotero "song" item type.
@@ -1558,7 +1520,6 @@
         <else-if type="song">
           <text macro="audio-recording"/>
         </else-if>
-
         <!-- BOOK (R15.1-15.4) -->
         <else-if type="book">
           <group delimiter=" ">
@@ -1580,7 +1541,6 @@
             <text macro="publish-details"/>
           </group>
         </else-if>
-
         <!-- CHAPTER IN EDITED VOLUME (R15.5.1(a)) -->
         <else-if type="chapter">
           <group delimiter=" ">
@@ -1601,7 +1561,6 @@
             <text macro="publish-details"/>
           </group>
         </else-if>
-
         <!-- THESIS / DISSERTATION (R17.2.2)
              Author, Title (Month Day, Year)
              (genre, University) (on file with Location).
@@ -1642,7 +1601,6 @@
             </choose>
           </group>
         </else-if>
-
         <!-- REPORT / WORKING PAPER (R17.4, R15.1, R15.4)
              Author, Title pinpoint (Publisher, Working Paper No. X, Year).
              Zotero field mapping:
@@ -1672,7 +1630,6 @@
             </group>
           </group>
         </else-if>
-
         <!-- MANUSCRIPT (unpublished, R17.2.1) and FORTHCOMING (R17.3)
              Unpublished: Author, Title page (Month Day, Year)
                (unpublished manuscript) (on file with Location).
@@ -1712,7 +1669,6 @@
             </choose>
           </group>
         </else-if>
-
         <!-- DOCUMENT
              Used for two purposes:
              (a) Archival sources (R23): documents held in official archives.
@@ -1739,7 +1695,6 @@
             </else>
           </choose>
         </else-if>
-
         <!-- SOCIAL MEDIA POST (R18.10)
              Name (@handle), PLATFORM (Date, Time), URL [Perma.cc].
              Uses Zotero "post" item type.
@@ -1755,7 +1710,6 @@
         <else-if type="post">
           <text macro="social-media"/>
         </else-if>
-
         <!-- AI-GENERATED CONTENT (R18.3)
              Author, Model Name, Description (Date) (on file with Journal).
              Uses Zotero "software" item type.
@@ -1769,7 +1723,6 @@
         <else-if type="software">
           <text macro="ai-content"/>
         </else-if>
-
         <!-- ELECTRONIC STORAGE MEDIA (R18.5)
              Author, TITLE (Medium, Repository Year)
              (on file with Location).
@@ -1785,7 +1738,6 @@
         <else-if type="dataset">
           <text macro="electronic-media"/>
         </else-if>
-
         <!-- IMAGE / ARTWORK (R18.9)
              Author, *Title* (type Year) (on file with Location).
              Uses Zotero "Artwork" item type (graphic).
@@ -1800,12 +1752,11 @@
         <else-if type="graphic">
           <text macro="image"/>
         </else-if>
-
-        <!-- MICROFORM — STANDALONE (R18.6(b))
+        <!-- MICROFORM &#8212; STANDALONE (R18.6(b))
              Title, Collection ID (Publisher Year).
              Uses Zotero "Standard" item type.
              NOTE: R18.6(a) reproduced microforms use "*microformed on*" appended
-             to the original source citation — add this clause manually.
+             to the original source citation &#8212; add this clause manually.
              Zotero field mapping:
                Title     -> microform collection title (small caps)
                Number    -> collection ID or fiche/reel number
@@ -1815,7 +1766,6 @@
         <else-if type="standard">
           <text macro="microform"/>
         </else-if>
-
         <!-- HARDWARE (R18.11.1)
              MANUFACTURER, Model Name, PartNumber (SKU).
              Uses Zotero "Patent" item type.
@@ -1828,7 +1778,6 @@
         <else-if type="patent">
           <text macro="hardware"/>
         </else-if>
-
         <!-- SOFTWARE (R18.11.2)
              General: DEVELOPER, *Name*, Ver. X (Platform, Date).
              Open-source: DEVELOPER, *Name*, URL (last accessed/updated Date).
@@ -1847,7 +1796,6 @@
         <else-if type="entry-encyclopedia">
           <text macro="software"/>
         </else-if>
-
         <!-- FALLBACK -->
         <else>
           <group delimiter=" ">
@@ -1856,11 +1804,9 @@
             <text macro="publisher-year"/>
           </group>
         </else>
-
       </choose>
     </layout>
   </citation>
-
   <!-- ============================================================
        BIBLIOGRAPHY
        ============================================================ -->
@@ -1871,15 +1817,12 @@
     </sort>
     <layout suffix=".">
       <choose>
-
         <if type="article-journal article-magazine" match="any">
           <text macro="journal-article"/>
         </if>
-
         <else-if type="article-newspaper">
           <text macro="newspaper-article"/>
         </else-if>
-
         <else-if type="book">
           <group delimiter=" ">
             <choose>
@@ -1892,7 +1835,6 @@
             <text macro="publish-details"/>
           </group>
         </else-if>
-
         <else-if type="chapter">
           <group delimiter=" ">
             <text macro="author-book" suffix=","/>
@@ -1907,7 +1849,6 @@
             <text macro="publish-details"/>
           </group>
         </else-if>
-
         <else-if type="thesis">
           <group delimiter=" ">
             <text macro="author-book" suffix=","/>
@@ -1941,7 +1882,6 @@
             </choose>
           </group>
         </else-if>
-
         <else-if type="report">
           <group delimiter=" ">
             <text macro="author-book" suffix=","/>
@@ -1959,7 +1899,6 @@
             </group>
           </group>
         </else-if>
-
         <else-if type="manuscript">
           <group delimiter=" ">
             <text macro="author-book" suffix=","/>
@@ -1987,15 +1926,12 @@
             </choose>
           </group>
         </else-if>
-
         <else-if type="webpage post-weblog">
           <text macro="webpage"/>
         </else-if>
-
         <else-if type="motion_picture">
           <text macro="film"/>
         </else-if>
-
         <else-if type="broadcast">
           <choose>
             <if variable="URL">
@@ -2006,11 +1942,9 @@
             </else>
           </choose>
         </else-if>
-
         <else-if type="song">
           <text macro="audio-recording"/>
         </else-if>
-
         <else-if type="document">
           <choose>
             <if variable="archive">
@@ -2025,35 +1959,27 @@
             </else>
           </choose>
         </else-if>
-
         <else-if type="post">
           <text macro="social-media"/>
         </else-if>
-
         <else-if type="software">
           <text macro="ai-content"/>
         </else-if>
-
         <else-if type="dataset">
           <text macro="electronic-media"/>
         </else-if>
-
         <else-if type="graphic">
           <text macro="image"/>
         </else-if>
-
         <else-if type="standard">
           <text macro="microform"/>
         </else-if>
-
         <else-if type="patent">
           <text macro="hardware"/>
         </else-if>
-
         <else-if type="entry-encyclopedia">
           <text macro="software"/>
         </else-if>
-
         <else>
           <group delimiter=" ">
             <text macro="author-book" suffix=","/>
@@ -2061,9 +1987,7 @@
             <text macro="publisher-year"/>
           </group>
         </else>
-
       </choose>
     </layout>
   </bibliography>
-
 </style>


### PR DESCRIPTION
Implements Bluebook 22nd edition (2025) law review footnote citations for secondary sources (Rules 15-23). Covers books, articles, newspapers, webpages, AI content, electronic media, films, TV, audio, social media, images, hardware, software, and archival sources. Passes citationstyles.org validation and Zotero functional testing.

## CSL Styles Pull Request Template
You're about to create a pull request to the CSL **styles** repository.  
If you haven't done so already, see <https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md> for instructions on how to contribute, and <https://github.com/citation-style-language/styles/blob/master/STYLE_REQUIREMENTS.md> for the requirements a style must meet before acceptance.  
In addition, please fill out the pull request template below.


### Description
(Briefly describe the style or changes you're proposing.)


### Checklist
- [x] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  Style built from scratch against the Bluebook 22nd edition text; no template style was used.
- [x] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [x] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [x] Check that you've not used `<text value="...` if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.
