### PR TITLE
SBL: volume-title variable support and revised handling of multivolume works

### DIFF
--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="chicago" default-locale="en-US">
   <info>
-    <title>SBL Handbook of Style 2nd edition (notes)</title>
-    <title-short>Society of Biblical Literature (SBLHS)</title-short>
-    <id>http://www.zotero.org/styles/society-of-biblical-literature-fullnote-bibliography</id>
+    <title>SBL Handbook of Style 2nd edition (notes)-xyz</title>
+    <title-short>Society of Biblical Literature (SBLHS)-xyz</title-short>
+    <id>http://www.zotero.org/styles/society-of-biblical-literature-fullnote-bibliography-xyz</id>
     <link href="http://www.zotero.org/styles/society-of-biblical-literature-fullnote-bibliography" rel="self"/>
     <link href="http://www.zotero.org/styles/chicago-notes-bibliography" rel="template"/>
     <link href="https://sblhs2.com" rel="documentation"/>
@@ -38,11 +38,12 @@
     </contributor>
     <contributor>
       <name>Matthew B. Quintana</name>
+      <email>matt.quintana7@gmail.com</email>
     </contributor>
     <category citation-format="note"/>
     <category field="theology"/>
     <summary>Society of Biblical Literature format with full notes and bibliography</summary>
-    <updated>2026-04-01T12:00:00+00:00</updated>
+    <updated>2026-04-21T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-US">
@@ -153,18 +154,32 @@
     </names>
   </macro>
   <macro name="collection-editor-note">
-    <names variable="collection-editor">
-      <label form="verb-short" suffix=" "/>
-      <name and="text" sort-separator=", " delimiter=", "/>
-    </names>
+    <choose>
+      <if type="book chapter" variable="volume-title collection-editor" match="all">
+        <!-- Suppress here: for book + volume-title cases, collection-editor is emitted inside locators-note -->
+      </if>
+      <else>
+        <names variable="collection-editor">
+          <label form="verb-short" suffix=" "/>
+          <name and="text" sort-separator=", " delimiter=", "/>
+        </names>
+      </else>
+    </choose>
   </macro>
   <macro name="collection-editor">
-    <group delimiter=", " prefix=". ">
-      <names variable="collection-editor" delimiter=", ">
-        <label form="verb" prefix=" " text-case="capitalize-first" suffix=" "/>
-        <name and="text" delimiter=", "/>
-      </names>
-    </group>
+    <choose>
+      <if type="book chapter" variable="volume-title collection-editor" match="all">
+        <!-- Suppress here: for book + volume-title cases, collection-editor is emitted inside locators -->
+      </if>
+      <else>
+        <group delimiter=", " prefix=". ">
+          <names variable="collection-editor" delimiter=", ">
+            <label form="verb" prefix=" " text-case="capitalize-first" suffix=" "/>
+            <name and="text" delimiter=", "/>
+          </names>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="translator-note">
     <names variable="translator">
@@ -453,10 +468,10 @@
           </if>
           <else-if type="chapter" variable="collection-title" match="all">
             <!--Filter SBL 6.2.22-->
-            <group>
-              <text term="volume" form="short" suffix=" "/>
+            <group delimiter=" ">
+              <label variable="volume" form="short"/>
               <number variable="volume" form="numeric"/>
-              <text value=" of "/>
+              <text value="of"/>
             </group>
           </else-if>
         </choose>
@@ -495,33 +510,39 @@
       </else>
     </choose>
   </macro>
-  <macro name="container-title">
+<macro name="container-title">
     <choose>
       <!-- Added dictionary and encyclopedia to get page and volume information-->
       <if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
         <group delimiter=" " suffix=" ">
-          <label variable="page" form="long" text-case="capitalize-first"/>
-          <text variable="page"/>
+          <group delimiter=" ">
+            <label variable="page" form="long" text-case="capitalize-first"/>
+            <text variable="page"/>
+          </group>
           <text term="in"/>
           <choose>
             <!-- Added dictionary and encyclopedia to get volume information-->
             <if type="entry-dictionary entry-encyclopedia" match="any">
               <choose>
                 <if match="any" variable="volume">
-                  <label suffix=" " variable="volume" form="short"/>
-                  <number variable="volume"/>
-                  <text value="of" suffix=" "/>
+                  <group delimiter=" ">
+                    <label variable="volume" form="short"/>
+                    <number variable="volume"/>
+                    <text value="of"/>
+                  </group>
                 </if>
               </choose>
             </if>
-            <!-- Scenario B: chapter in multivolume container, no volume-title. 
+            <!-- Scenario B: chapter in multivolume container, no volume-title.
             Prepend "vol. N of" before the italic container title in the bibliography. See SBLHS 6.2.22 -->
             <else-if type="chapter" variable="volume container-title" match="all">
               <choose>
                 <if variable="volume-title" match="none">
-                  <text term="volume" form="short" suffix=" "/>
-                  <number variable="volume"/>
-                  <text value="of" suffix=" "/>
+                  <group delimiter=" ">
+                    <label variable="volume" form="short"/>
+                    <number variable="volume"/>
+                    <text value="of"/>
+                  </group>
                 </if>
               </choose>
             </else-if>
@@ -582,46 +603,59 @@
               <choose>
                 <if type="book" variable="volume-title" match="all">
                   <!-- Scenario A: book with individual volume title in a multivolume set.
-                      Render: vol. N of *Volume Title* &#8212; series follows separately via collection-title-note. -->
-                  <group>
-                    <text term="volume" form="short" suffix=" "/>
-                    <number variable="volume" form="numeric"/>
-                    <text value=" of "/>
-                    <text variable="volume-title" font-style="italic" text-case="title"/>
+                      Render: vol. N of *Volume Title*; if present, collection-editor follows here;
+                      total number of volumes follows after that. -->
+                  <group delimiter=", ">
+                    <group delimiter=" ">
+                      <label variable="volume" form="short"/>
+                      <number variable="volume" form="numeric"/>
+                      <text value="of"/>
+                      <text variable="volume-title" font-style="italic" text-case="title"/>
+                    </group>
+                    <names variable="collection-editor">
+                      <label form="verb-short" suffix=" "/>
+                      <name and="text" sort-separator=", " delimiter=", "/>
+                    </names>
                   </group>
                 </if>
                 <else-if type="book" variable="collection-title" match="all">
-                  <!--SBL 6.2.21: book vol. N of *Series* &#8212; now series is plain, emitted by collection-title-note -->
-                  <group>
-                    <text term="volume" form="short" suffix=" "/>
+                  <!--SBL 6.2.21: book vol. N of *Series* — series is plain, emitted by collection-title-note -->
+                  <group delimiter=" ">
+                    <label variable="volume" form="short"/>
                     <number variable="volume" form="numeric"/>
-                    <text value=" of"/>
+                    <text value="of"/>
                   </group>
                 </else-if>
                 <else-if type="chapter" variable="volume-title" match="all">
                   <!-- Scenario A variant for chapter: vol. N of *Volume Title* -->
-                  <group>
-                    <text term="volume" form="short" suffix=" "/>
-                    <number variable="volume" form="numeric"/>
-                    <text value=" of "/>
-                    <text variable="volume-title" font-style="italic" text-case="title"/>
+                  <group delimiter=", ">
+                    <group delimiter=" ">
+                      <label variable="volume" form="short"/>
+                      <number variable="volume" form="numeric"/>
+                      <text value="of"/>
+                      <text variable="volume-title" font-style="italic" text-case="title"/>
+                    </group>
+                    <names variable="collection-editor">
+                      <label form="verb-short" suffix=" "/>
+                      <name and="text" sort-separator=", " delimiter=", "/>
+                    </names>
                   </group>
                 </else-if>
                 <else-if type="chapter" variable="container-title" match="all">
                   <!-- Scenario B: chapter in a multivolume container, no volume-title.
-                      Suppress "vol. N of" here &#8212; volume number moves to paginate pages. -->
+                      Suppress "vol. N of" here — volume number moves to paginate pages. -->
                 </else-if>
                 <else-if type="chapter" variable="collection-title" match="all">
                   <!--SBL 6.2.23-->
-                  <group>
-                    <text term="volume" form="short" suffix=" "/>
+                  <group delimiter=" ">
+                    <label variable="volume" form="short"/>
                     <number variable="volume" form="numeric"/>
-                    <text value=" of"/>
+                    <text value="of"/>
                   </group>
                 </else-if>
                 <else-if variable="locator page" match="none">
-                  <group>
-                    <text term="volume" form="short" suffix=" "/>
+                  <group delimiter=" ">
+                    <label variable="volume" form="short"/>
                     <number variable="volume" form="numeric"/>
                   </group>
                 </else-if>
@@ -633,15 +667,15 @@
             <if variable="number-of-volumes">
               <choose>
                 <if variable="volume" match="none">
-                  <group>
+                  <group delimiter=" ">
                     <number variable="number-of-volumes" form="numeric"/>
-                    <text term="volume" form="short" prefix=" " plural="true"/>
+                    <label variable="number-of-volumes" form="short" plural="always"/>
                   </group>
                 </if>
                 <else-if type="book" variable="volume-title" match="all">
-                  <group>
+                  <group delimiter=" ">
                     <number variable="number-of-volumes" form="numeric"/>
-                    <text term="volume" form="short" prefix=" " plural="true"/>
+                    <label variable="number-of-volumes" form="short" plural="always"/>
                   </group>
                 </else-if>
               </choose>
@@ -667,46 +701,61 @@
               <choose>
                 <if type="book" variable="volume-title" match="all">
                   <!-- Scenario A: book with individual volume title.
-                      Render: Vol. N of *Volume Title* &#8212; series follows separately. -->
-                  <group>
-                    <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
-                    <number variable="volume" form="numeric"/>
-                    <text value=" of "/>
-                    <text variable="volume-title" font-style="italic" text-case="title"/>
+                      Render: Vol. N of *Volume Title*; if present, collection-editor follows here;
+                      total number of volumes follows after that. -->
+                  <group delimiter=". ">
+                    <group delimiter=". ">
+                      <group delimiter=" ">
+                        <label variable="volume" form="short" text-case="capitalize-first"/>
+                        <number variable="volume" form="numeric"/>
+                        <text value="of"/>
+                        <text variable="volume-title" font-style="italic" text-case="title"/>
+                      </group>
+                      <names variable="collection-editor">
+                        <label form="verb" text-case="capitalize-first" suffix=" "/>
+                        <name and="text" delimiter=", "/>
+                      </names>
+                    </group>
                   </group>
                 </if>
                 <else-if type="book" variable="collection-title" match="all">
-                  <!--SBL 6.2.21: book vol. N of *Series* &#8212; series now plain, emitted by collection-title -->
-                  <group>
-                    <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+                  <!--SBL 6.2.21: book vol. N of *Series* — series now plain, emitted by collection-title -->
+                  <group delimiter=" ">
+                    <label variable="volume" form="short" text-case="capitalize-first"/>
                     <number variable="volume" form="numeric"/>
-                    <text value=" of"/>
+                    <text value="of"/>
                   </group>
                 </else-if>
                 <else-if type="chapter" variable="volume-title" match="all">
                   <!-- Scenario A variant for chapter: Vol. N of *Volume Title* -->
-                  <group>
-                    <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
-                    <number variable="volume" form="numeric"/>
-                    <text value=" of "/>
-                    <text variable="volume-title" font-style="italic" text-case="title"/>
+                  <group delimiter=". ">
+                    <group delimiter=" ">
+                      <label variable="volume" form="short" text-case="capitalize-first"/>
+                      <number variable="volume" form="numeric"/>
+                      <text value="of"/>
+                      <text variable="volume-title" font-style="italic" text-case="title"/>
+                    </group>
+                    <names variable="collection-editor">
+                      <label form="verb" text-case="capitalize-first" suffix=" "/>
+                      <name and="text" delimiter=", "/>
+                    </names>
                   </group>
                 </else-if>
                 <else-if type="chapter" variable="container-title" match="all">
                   <!-- Scenario B: chapter in multivolume container, no volume-title.
-                      Suppress here &#8212; "vol. N of" is prepended to container-title in the bib layout. -->
+                      Suppress here — "vol. N of" is prepended to container-title in the bib layout. -->
                 </else-if>
                 <else-if type="chapter" variable="collection-title" match="all">
                   <!--SBL 6.2.23-->
-                  <group>
-                    <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+                  <group delimiter=" ">
+                    <label variable="volume" form="short" text-case="capitalize-first"/>
                     <number variable="volume" form="numeric"/>
-                    <text value=" of"/>
+                    <text value="of"/>
                   </group>
                 </else-if>
                 <else-if variable="locator page" match="none">
-                  <group>
-                    <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+                  <group delimiter=" ">
+                    <label variable="volume" form="short" text-case="capitalize-first"/>
                     <number variable="volume" form="numeric"/>
                   </group>
                 </else-if>
@@ -718,15 +767,15 @@
             <if variable="number-of-volumes">
               <choose>
                 <if variable="volume" match="none">
-                  <group>
+                  <group delimiter=" ">
                     <number variable="number-of-volumes" form="numeric"/>
-                    <text term="volume" form="short" prefix=" " plural="true"/>
+                    <label variable="number-of-volumes" form="short" plural="always"/>
                   </group>
                 </if>
                 <else-if type="book" variable="volume-title" match="all">
-                  <group>
+                  <group delimiter=" ">
                     <number variable="number-of-volumes" form="numeric"/>
-                    <text term="volume" form="short" prefix=" " plural="true"/>
+                    <label variable="number-of-volumes" form="short" plural="always"/>
                   </group>
                 </else-if>
               </choose>
@@ -736,9 +785,9 @@
       </else-if>
       <!-- Added dictionary and encyclopedia to properly display volume information-->
       <else-if type="entry-dictionary entry-encyclopedia" match="any">
-        <group prefix=". ">
+        <group prefix=". " delimiter=" ">
           <number variable="number-of-volumes" form="numeric"/>
-          <text term="volume" form="short" prefix=" " plural="true"/>
+          <label variable="number-of-volumes" form="short" plural="always"/>
         </group>
       </else-if>
     </choose>

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -619,11 +619,10 @@
                   </group>
                 </if>
                 <else-if type="book" variable="collection-title" match="all">
-                  <!--SBL 6.2.21: book vol. N of *Series* &#8212; series is plain, emitted by collection-title-note -->
+                  <!--SBL 6.2.21: A single volume of a multivolume work that also belongs to a series should not be conjoined by "of"; volume is distinct from collection-title -->
                   <group delimiter=" ">
                     <label variable="volume" form="short"/>
                     <number variable="volume" form="numeric"/>
-                    <text value="of"/>
                   </group>
                 </else-if>
                 <else-if type="chapter" variable="volume-title" match="all">
@@ -719,11 +718,10 @@
                   </group>
                 </if>
                 <else-if type="book" variable="collection-title" match="all">
-                  <!--SBL 6.2.21: book vol. N of *Series* &#8212; series now plain, emitted by collection-title -->
+                  <!--SBL 6.2.21: A single volume of a multivolume work that also belongs to a series should not be conjoined by "of"; volume is distinct from collection-title -->
                   <group delimiter=" ">
                     <label variable="volume" form="short" text-case="capitalize-first"/>
                     <number variable="volume" form="numeric"/>
-                    <text value="of"/>
                   </group>
                 </else-if>
                 <else-if type="chapter" variable="volume-title" match="all">

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -945,7 +945,7 @@
       <choose>
         <if locator="page" match="none">
           <choose>
-            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+            <if type="bill graphic legal_case legislation motion_picture report song" match="any">
               <group delimiter=", ">
                 <group delimiter=" ">
                   <text term="volume" form="short"/>

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -582,7 +582,7 @@
               <choose>
                 <if type="book" variable="volume-title" match="all">
                   <!-- Scenario A: book with individual volume title in a multivolume set.
-                      Render: vol. N of *Volume Title* — series follows separately via collection-title-note. -->
+                      Render: vol. N of *Volume Title* &#8212; series follows separately via collection-title-note. -->
                   <group>
                     <text term="volume" form="short" suffix=" "/>
                     <number variable="volume" form="numeric"/>
@@ -591,7 +591,7 @@
                   </group>
                 </if>
                 <else-if type="book" variable="collection-title" match="all">
-                  <!--SBL 6.2.21: book vol. N of *Series* — now series is plain, emitted by collection-title-note -->
+                  <!--SBL 6.2.21: book vol. N of *Series* &#8212; now series is plain, emitted by collection-title-note -->
                   <group>
                     <text term="volume" form="short" suffix=" "/>
                     <number variable="volume" form="numeric"/>
@@ -609,7 +609,7 @@
                 </else-if>
                 <else-if type="chapter" variable="container-title" match="all">
                   <!-- Scenario B: chapter in a multivolume container, no volume-title.
-                      Suppress "vol. N of" here — volume number moves to paginate pages. -->
+                      Suppress "vol. N of" here &#8212; volume number moves to paginate pages. -->
                 </else-if>
                 <else-if type="chapter" variable="collection-title" match="all">
                   <!--SBL 6.2.23-->
@@ -667,7 +667,7 @@
               <choose>
                 <if type="book" variable="volume-title" match="all">
                   <!-- Scenario A: book with individual volume title.
-                      Render: Vol. N of *Volume Title* — series follows separately. -->
+                      Render: Vol. N of *Volume Title* &#8212; series follows separately. -->
                   <group>
                     <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
                     <number variable="volume" form="numeric"/>
@@ -676,7 +676,7 @@
                   </group>
                 </if>
                 <else-if type="book" variable="collection-title" match="all">
-                  <!--SBL 6.2.21: book vol. N of *Series* — series now plain, emitted by collection-title -->
+                  <!--SBL 6.2.21: book vol. N of *Series* &#8212; series now plain, emitted by collection-title -->
                   <group>
                     <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
                     <number variable="volume" form="numeric"/>
@@ -694,7 +694,7 @@
                 </else-if>
                 <else-if type="chapter" variable="container-title" match="all">
                   <!-- Scenario B: chapter in multivolume container, no volume-title.
-                      Suppress here — "vol. N of" is prepended to container-title in the bib layout. -->
+                      Suppress here &#8212; "vol. N of" is prepended to container-title in the bib layout. -->
                 </else-if>
                 <else-if type="chapter" variable="collection-title" match="all">
                   <!--SBL 6.2.23-->

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="chicago" default-locale="en-US">
   <info>
-    <title>SBL Handbook of Style 2nd edition (notes)-xyz</title>
-    <title-short>Society of Biblical Literature (SBLHS)-xyz</title-short>
-    <id>http://www.zotero.org/styles/society-of-biblical-literature-fullnote-bibliography-xyz</id>
+    <title>SBL Handbook of Style 2nd edition (notes)</title>
+    <title-short>Society of Biblical Literature (SBLHS)</title-short>
+    <id>http://www.zotero.org/styles/society-of-biblical-literature-fullnote-bibliography</id>
     <link href="http://www.zotero.org/styles/society-of-biblical-literature-fullnote-bibliography" rel="self"/>
     <link href="http://www.zotero.org/styles/chicago-notes-bibliography" rel="template"/>
     <link href="https://sblhs2.com" rel="documentation"/>

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -43,7 +43,7 @@
     <category citation-format="note"/>
     <category field="theology"/>
     <summary>Society of Biblical Literature format with full notes and bibliography</summary>
-    <updated>2026-04-21T12:00:00+00:00</updated>
+    <updated>2026-04-30T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-US">
@@ -982,17 +982,27 @@
         </if>
         <else-if variable="volume">
           <choose>
-            <if type="book" variable="collection-title" match="all">
+            <if type="book" variable="volume-title" match="all">
               <!--Filter SBL 6.2.21-->
               <text variable="locator"/>
             </if>
-            <else-if type="chapter" variable="container-title" match="all">
+            <else-if type="chapter" variable="volume-title" match="all">
               <!--Filter SBL 6.2.23-->
               <text variable="locator"/>
             </else-if>
-            <else-if type="chapter" variable="collection-title" position="subsequent" match="all">
+            <else-if type="chapter" variable="container-title" match="all">
               <!--Filter SBL 6.2.22-->
-              <text variable="locator"/>
+              <choose>
+                <if position="first">
+                  <group delimiter=":">
+                    <number variable="volume" form="numeric"/>
+                    <text variable="locator"/>
+                  </group>
+                </if>
+                <else>
+                  <text variable="locator"/>
+                </else>
+              </choose>
             </else-if>
             <else-if type="article-journal">
               <!--Filter SBL 6.3.1-->

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -510,7 +510,7 @@
       </else>
     </choose>
   </macro>
-<macro name="container-title">
+  <macro name="container-title">
     <choose>
       <!-- Added dictionary and encyclopedia to get page and volume information-->
       <if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
@@ -619,7 +619,7 @@
                   </group>
                 </if>
                 <else-if type="book" variable="collection-title" match="all">
-                  <!--SBL 6.2.21: book vol. N of *Series* — series is plain, emitted by collection-title-note -->
+                  <!--SBL 6.2.21: book vol. N of *Series* &#8212; series is plain, emitted by collection-title-note -->
                   <group delimiter=" ">
                     <label variable="volume" form="short"/>
                     <number variable="volume" form="numeric"/>
@@ -643,7 +643,7 @@
                 </else-if>
                 <else-if type="chapter" variable="container-title" match="all">
                   <!-- Scenario B: chapter in a multivolume container, no volume-title.
-                      Suppress "vol. N of" here — volume number moves to paginate pages. -->
+                      Suppress "vol. N of" here &#8212; volume number moves to paginate pages. -->
                 </else-if>
                 <else-if type="chapter" variable="collection-title" match="all">
                   <!--SBL 6.2.23-->
@@ -719,7 +719,7 @@
                   </group>
                 </if>
                 <else-if type="book" variable="collection-title" match="all">
-                  <!--SBL 6.2.21: book vol. N of *Series* — series now plain, emitted by collection-title -->
+                  <!--SBL 6.2.21: book vol. N of *Series* &#8212; series now plain, emitted by collection-title -->
                   <group delimiter=" ">
                     <label variable="volume" form="short" text-case="capitalize-first"/>
                     <number variable="volume" form="numeric"/>
@@ -743,7 +743,7 @@
                 </else-if>
                 <else-if type="chapter" variable="container-title" match="all">
                   <!-- Scenario B: chapter in multivolume container, no volume-title.
-                      Suppress here — "vol. N of" is prepended to container-title in the bib layout. -->
+                      Suppress here &#8212; "vol. N of" is prepended to container-title in the bib layout. -->
                 </else-if>
                 <else-if type="chapter" variable="collection-title" match="all">
                   <!--SBL 6.2.23-->

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -36,10 +36,13 @@
       <name>Andrew Dunning</name>
       <uri>https://orcid.org/0000-0003-0464-5036</uri>
     </contributor>
+    <contributor>
+      <name>Matthew B. Quintana</name>
+    </contributor>
     <category citation-format="note"/>
     <category field="theology"/>
     <summary>Society of Biblical Literature format with full notes and bibliography</summary>
-    <updated>2025-05-09T12:18:25+00:00</updated>
+    <updated>2026-04-01T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-US">
@@ -441,7 +444,8 @@
   <macro name="collection-title">
     <choose>
       <if variable="volume number-of-volumes" match="any">
-        <!-- Presence of Volume info indicates multivolume work rather than series -->
+        <!-- Presence of volume/number-of-volumes: series renders plain (not italic). -->
+        <!-- volume-title is handled in locators-note; only series output here. -->
         <choose>
           <!--This section required here rather than in title-note because the group delimiter inserts an unneeded comma otherwise-->
           <if type="chapter" variable="container-title" match="all">
@@ -456,7 +460,8 @@
             </group>
           </else-if>
         </choose>
-        <text variable="collection-title" form="short" text-case="title" font-style="italic"/>
+        <!-- Render series plain (no italics) when volume info is present -->
+        <text variable="collection-title" form="short" text-case="title"
         <text variable="collection-number" prefix=" "/>
       </if>
       <else>
@@ -468,7 +473,8 @@
   <macro name="collection-title-note">
     <choose>
       <if variable="volume number-of-volumes" match="any">
-        <!-- Presence of Volume info indicates multivolume work rather than series -->
+        <!-- Presence of volume/number-of-volumes: series renders plain (not italic). -->
+        <!-- volume-title is handled in the locators macro; only series output here. -->
         <choose>
           <!-- This section required here rather than in title-note because the group delimiter inserts an unneeded comma otherwise-->
           <if type="chapter paper-conference" match="any">
@@ -479,7 +485,8 @@
             </choose>
           </if>
         </choose>
-        <text variable="collection-title" form="short" text-case="title" font-style="italic"/>
+        <!-- Render series plain (no italics) when volume info is present -->
+        <text variable="collection-title" form="short" text-case="title"
         <text variable="collection-number" prefix=" "/>
       </if>
       <else>
@@ -507,6 +514,17 @@
                 </if>
               </choose>
             </if>
+            <!-- Scenario B: chapter in multivolume container, no volume-title. 
+            Prepend "vol. N of" before the italic container title in the bibliography. See SBLHS 6.2.22 -->
+            <else-if type="chapter" variable="volume container-title" match="all">
+              <choose>
+                <if variable="volume-title" match="none">
+                  <text term="volume" form="short" suffix=" "/>
+                  <number variable="volume"/>
+                  <text value="of" suffix=" "/>
+                </if>
+              </choose>
+            </else-if>
           </choose>
         </group>
       </if>
@@ -558,20 +576,41 @@
     <choose>
       <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
         <group delimiter=", ">
-          <!--Repositioned Edition to proceed volume-->
-          <text macro="edition-note"/>
           <choose>
             <if variable="volume">
               <!--If volume-->
               <choose>
-                <if type="book" variable="collection-title" match="all">
-                  <!--SBL 6.2.21-->
+                <if type="book" variable="volume-title" match="all">
+                  <!-- Scenario A: book with individual volume title in a multivolume set.
+                      Render: vol. N of *Volume Title* — series follows separately via collection-title-note. -->
+                  <group>
+                    <text term="volume" form="short" suffix=" "/>
+                    <number variable="volume" form="numeric"/>
+                    <text value=" of "/>
+                    <text variable="volume-title" font-style="italic" text-case="title"/>
+                  </group>
+                </if>
+                <else-if type="book" variable="collection-title" match="all">
+                  <!--SBL 6.2.21: book vol. N of *Series* — now series is plain, emitted by collection-title-note -->
                   <group>
                     <text term="volume" form="short" suffix=" "/>
                     <number variable="volume" form="numeric"/>
                     <text value=" of"/>
                   </group>
-                </if>
+                </else-if>
+                <else-if type="chapter" variable="volume-title" match="all">
+                  <!-- Scenario A variant for chapter: vol. N of *Volume Title* -->
+                  <group>
+                    <text term="volume" form="short" suffix=" "/>
+                    <number variable="volume" form="numeric"/>
+                    <text value=" of "/>
+                    <text variable="volume-title" font-style="italic" text-case="title"/>
+                  </group>
+                </else-if>
+                <else-if type="chapter" variable="container-title" match="all">
+                  <!-- Scenario B: chapter in a multivolume container, no volume-title.
+                      Suppress "vol. N of" here — volume number moves to paginate pages. -->
+                </else-if>
                 <else-if type="chapter" variable="collection-title" match="all">
                   <!--SBL 6.2.23-->
                   <group>
@@ -588,12 +627,25 @@
                 </else-if>
               </choose>
             </if>
-            <else>
-              <group>
-                <number variable="number-of-volumes" form="numeric"/>
-                <text term="volume" form="short" prefix=" " plural="true"/>
-              </group>
-            </else>
+          </choose>
+          <text macro="edition-note"/>
+          <choose>
+            <if variable="number-of-volumes">
+              <choose>
+                <if variable="volume" match="none">
+                  <group>
+                    <number variable="number-of-volumes" form="numeric"/>
+                    <text term="volume" form="short" prefix=" " plural="true"/>
+                  </group>
+                </if>
+                <else-if type="book" variable="volume-title" match="all">
+                  <group>
+                    <number variable="number-of-volumes" form="numeric"/>
+                    <text term="volume" form="short" prefix=" " plural="true"/>
+                  </group>
+                </else-if>
+              </choose>
+            </if>
           </choose>
         </group>
       </if>
@@ -609,20 +661,41 @@
       </if>
       <else-if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
         <group prefix=". " delimiter=". ">
-          <!--Repositioned Edition to proceed volume-->
-          <text macro="edition"/>
           <choose>
             <if variable="volume">
               <!--If volume-->
               <choose>
-                <if type="book" variable="collection-title" match="all">
-                  <!--SBL 6.2.21-->
+                <if type="book" variable="volume-title" match="all">
+                  <!-- Scenario A: book with individual volume title.
+                      Render: Vol. N of *Volume Title* — series follows separately. -->
+                  <group>
+                    <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+                    <number variable="volume" form="numeric"/>
+                    <text value=" of "/>
+                    <text variable="volume-title" font-style="italic" text-case="title"/>
+                  </group>
+                </if>
+                <else-if type="book" variable="collection-title" match="all">
+                  <!--SBL 6.2.21: book vol. N of *Series* — series now plain, emitted by collection-title -->
                   <group>
                     <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
                     <number variable="volume" form="numeric"/>
                     <text value=" of"/>
                   </group>
-                </if>
+                </else-if>
+                <else-if type="chapter" variable="volume-title" match="all">
+                  <!-- Scenario A variant for chapter: Vol. N of *Volume Title* -->
+                  <group>
+                    <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+                    <number variable="volume" form="numeric"/>
+                    <text value=" of "/>
+                    <text variable="volume-title" font-style="italic" text-case="title"/>
+                  </group>
+                </else-if>
+                <else-if type="chapter" variable="container-title" match="all">
+                  <!-- Scenario B: chapter in multivolume container, no volume-title.
+                      Suppress here — "vol. N of" is prepended to container-title in the bib layout. -->
+                </else-if>
                 <else-if type="chapter" variable="collection-title" match="all">
                   <!--SBL 6.2.23-->
                   <group>
@@ -639,12 +712,25 @@
                 </else-if>
               </choose>
             </if>
-            <else>
-              <group>
-                <number variable="number-of-volumes" form="numeric"/>
-                <text term="volume" form="short" prefix=" " plural="true"/>
-              </group>
-            </else>
+          </choose>
+          <text macro="edition"/>
+          <choose>
+            <if variable="number-of-volumes">
+              <choose>
+                <if variable="volume" match="none">
+                  <group>
+                    <number variable="number-of-volumes" form="numeric"/>
+                    <text term="volume" form="short" prefix=" " plural="true"/>
+                  </group>
+                </if>
+                <else-if type="book" variable="volume-title" match="all">
+                  <group>
+                    <number variable="number-of-volumes" form="numeric"/>
+                    <text term="volume" form="short" prefix=" " plural="true"/>
+                  </group>
+                </else-if>
+              </choose>
+            </if>
           </choose>
         </group>
       </else-if>
@@ -959,8 +1045,19 @@
           <if variable="volume">
             <choose>
               <if type="chapter" variable="container-title" match="all">
-                <!--Filter SBL 6.2.23-->
-                <text variable="page" prefix=", "/>
+                <!-- Scenario B: chapter in a multivolume container.
+                     If volume-title is absent, volume number paginates the pages as vol:pages.
+                     If volume-title is present (Scenario A variant), revert to plain page. -->
+                <choose>
+                  <if variable="volume-title">
+                    <text variable="page" prefix=", "/>
+                  </if>
+                  <else>
+                    <!-- vol:pages format per SBL 6.2.22 for multivolume container chapters -->
+                    <number variable="volume" prefix=", " suffix=":"/>
+                    <text variable="page"/>
+                  </else>
+                </choose>
               </if>
               <else-if type="chapter" variable="collection-title" position="subsequent" match="all">
                 <!--Filter SBL 6.2.22-->
@@ -1240,8 +1337,8 @@
             <choose>
               <if variable="volume collection-title" match="all">
                 <!--If Volume # and collection-title -->
-                <group delimiter=" ">
-                  <!--Added group to prevent comma between vol # of...and collection-title-->
+                <group delimiter=", ">
+                  <!--Use comma between locator phrase and series title (vol # of ..., collection-title). Necessary for citing a multivolume work that along belongs to a series-->
                   <text macro="locators-note"/>
                   <text macro="collection-title-note"/>
                 </group>
@@ -1298,9 +1395,9 @@
           </group>
           <choose>
             <if variable="volume collection-title" match="all">
-              <!--If Volume # and collection-title -->
+              <!--If Volume # and collection-title, use period between locator phrase and series title (Vol # of ... . collection-title). Necessary for citing a multivolume work that along belongs to a series -->
               <text macro="locators"/>
-              <text macro="collection-title" text-case="title" prefix=" "/>
+              <text macro="collection-title" text-case="title" prefix=". "/>
             </if>
             <else>
               <text macro="locators"/>

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -461,7 +461,7 @@
           </else-if>
         </choose>
         <!-- Render series plain (no italics) when volume info is present -->
-        <text variable="collection-title" form="short" text-case="title"
+        <text variable="collection-title" form="short" text-case="title"/>
         <text variable="collection-number" prefix=" "/>
       </if>
       <else>
@@ -486,7 +486,7 @@
           </if>
         </choose>
         <!-- Render series plain (no italics) when volume info is present -->
-        <text variable="collection-title" form="short" text-case="title"
+        <text variable="collection-title" form="short" text-case="title"/>
         <text variable="collection-number" prefix=" "/>
       </if>
       <else>


### PR DESCRIPTION
### Description
Revisions made to several macros (collection-title, collection-title-note, container-title, locators-note, locators, pages) and <citation> / <bibliography> in order to accommodate the volume-title variable and allow for proper handling of multivolume works and chapters of multivolume works (see SBLHS 6.2.20–23), which previously were either impossible to produce correctly or required extensive work-arounds.

### Checklist
- [x] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [x] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [x] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [x] Check that you've not used `<text value="...` if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.
