### PR TITLE
Create selcuk-medical-journal.csl

### DIFF
--- a/selcuk-medical-journal-submission-ready.csl
+++ b/selcuk-medical-journal-submission-ready.csl
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+  <info>
+    <title>Selcuk Medical Journal</title>
+    <title-short>Selcuk Med J</title-short>
+    <id>http://www.zotero.org/styles/selcuk-medical-journal</id>
+    <link href="http://www.zotero.org/styles/selcuk-medical-journal" rel="self"/>
+    <author>
+      <name>OpenAI</name>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="medicine"/>
+    <summary>Numeric style for Selcuk Medical Journal: citations in parentheses, abbreviated journal titles, first 3 authors then et al., supports journal articles, books, chapters, theses, webpages, ahead-of-print, and sources without DOI.</summary>
+    <updated>2026-04-05T09:00:00+03:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+
+  <locale xml:lang="en">
+    <terms>
+      <term name="et-al">et al.</term>
+      <term name="in">In:</term>
+      <term name="accessed">Accessed</term>
+    </terms>
+  </locale>
+
+  <macro name="author">
+    <names variable="author">
+      <name name-as-sort-order="all" sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-last="always" et-al-min="4" et-al-use-first="3"/>
+      <et-al font-style="normal"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+  </macro>
+
+  <macro name="editor">
+    <names variable="editor">
+      <name name-as-sort-order="all" sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-last="always" et-al-min="4" et-al-use-first="3"/>
+      <label form="short" prefix=", " text-case="capitalize-first"/>
+    </names>
+  </macro>
+
+  <macro name="title">
+    <text variable="title"/>
+  </macro>
+
+  <macro name="journal">
+    <text variable="container-title" form="short"/>
+  </macro>
+
+  <macro name="year">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+
+  <macro name="volume-issue">
+    <group delimiter="">
+      <text variable="volume"/>
+      <choose>
+        <if variable="issue">
+          <group prefix="(" suffix=")">
+            <text variable="issue"/>
+          </group>
+        </if>
+      </choose>
+    </group>
+  </macro>
+
+  <macro name="pages">
+    <text variable="page"/>
+  </macro>
+
+  <macro name="doi">
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix=". doi: "/>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="url-access">
+    <group delimiter=". ">
+      <text variable="URL"/>
+      <group>
+        <text term="accessed" suffix=" "/>
+        <date variable="accessed">
+          <date-part name="day" form="numeric-leading-zeros" suffix=" "/>
+          <date-part name="month" form="short" suffix=" "/>
+          <date-part name="year"/>
+        </date>
+      </group>
+    </group>
+  </macro>
+
+  <macro name="publisher-place">
+    <group delimiter=": ">
+      <text variable="publisher-place"/>
+      <text variable="publisher"/>
+    </group>
+  </macro>
+
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <number variable="edition" form="ordinal"/>
+        <text term="edition" form="short" prefix=" " suffix="."/>
+      </if>
+      <else-if variable="edition">
+        <text variable="edition" suffix="."/>
+      </else-if>
+    </choose>
+  </macro>
+
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter=", ">
+      <text variable="citation-number"/>
+    </layout>
+  </citation>
+
+  <bibliography et-al-min="4" et-al-use-first="3" second-field-align="flush">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout suffix=".">
+      <text variable="citation-number" suffix=" "/>
+      <choose>
+
+        <if type="article-journal article-magazine article-newspaper paper-conference" match="any">
+          <group delimiter=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <group delimiter=" ">
+              <text macro="journal" suffix="."/>
+              <group delimiter="">
+                <text macro="year" suffix=";"/>
+                <text macro="volume-issue" suffix=":"/>
+                <text macro="pages"/>
+              </group>
+            </group>
+          </group>
+          <text macro="doi"/>
+        </if>
+
+        <else-if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
+          <group delimiter=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <group delimiter=" ">
+              <group delimiter=" ">
+                <text term="in"/>
+                <text macro="editor"/>
+              </group>
+              <text variable="container-title"/>
+            </group>
+            <group delimiter=", ">
+              <text macro="edition"/>
+              <text macro="publisher-place"/>
+            </group>
+            <group delimiter="">
+              <text macro="year" suffix=":"/>
+              <text macro="pages"/>
+            </group>
+          </group>
+        </else-if>
+
+        <else-if type="book">
+          <group delimiter=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <group delimiter=", ">
+              <text macro="edition"/>
+              <text macro="publisher-place"/>
+            </group>
+            <text macro="year"/>
+          </group>
+        </else-if>
+
+        <else-if type="thesis">
+          <group delimiter=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <text value="PhD thesis"/>
+            <group delimiter=", ">
+              <text variable="publisher"/>
+              <text macro="year"/>
+            </group>
+          </group>
+        </else-if>
+
+        <else-if type="webpage post post-weblog" match="any">
+          <group delimiter=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <text variable="container-title"/>
+            <text macro="url-access"/>
+          </group>
+        </else-if>
+
+        <else-if type="report">
+          <group delimiter=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <group delimiter=", ">
+              <text variable="number"/>
+              <text macro="publisher-place"/>
+            </group>
+            <text macro="year"/>
+          </group>
+        </else-if>
+
+        <else>
+          <group delimiter=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <text variable="container-title"/>
+            <text macro="year"/>
+          </group>
+        </else>
+
+      </choose>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
Add Selcuk Medical Journal citation style
This PR adds a new CSL style for Selcuk Medical Journal.

- Numeric citation format (1)
- First 3 authors then et al.
- Abbreviated journal titles
- Page range shortening (e.g., 1234-40)
- Supports articles, books, chapters (In:), theses (PhD thesis), and webpages (with accessed date)

Sample reference:
Vikse BE, Aasarød K, Bostad L, et al. Clinical prognostic factors in biopsy-proven benign nephrosclerosis. Nephrol Dial Transplant. 2003;18(3):517-23. doi: 10.1093/ndt/18.3.517.

## CSL Styles Pull Request Template
You're about to create a pull request to the CSL **styles** repository.  
If you haven't done so already, see <https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md> for instructions on how to contribute, and <https://github.com/citation-style-language/styles/blob/master/STYLE_REQUIREMENTS.md> for the requirements a style must meet before acceptance.  
In addition, please fill out the pull request template below.


### Description
(Briefly describe the style or changes you're proposing.)


### Checklist
- [x] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [x] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [x] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [x] Check that you've not used `<text value="...` if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.
