### PR TITLE
bio-protocol: sort bibliography by citation-number

### DIFF
--- a/bio-protocol.csl
+++ b/bio-protocol.csl
@@ -1113,11 +1113,7 @@
   </citation>
   <bibliography et-al-min="11" et-al-use-first="10" entry-spacing="0">
     <sort>
-      <key macro="author-bib"/>
-      <key macro="date-sort-group"/>
-      <key macro="date-sort-date" sort="ascending"/>
-      <key variable="status"/>
-      <key macro="title"/>
+      <key variable="citation-number"/>
     </sort>
     <layout>
       <group delimiter=" ">

--- a/bio-protocol.csl
+++ b/bio-protocol.csl
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" page-range-format="expanded" default-locale="en-US">
-  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Bio-protocol</title>
     <id>http://www.zotero.org/styles/bio-protocol</id>
@@ -15,7 +14,7 @@
     </contributor>
     <category citation-format="author-date"/>
     <category field="biology"/>
-    <updated>2025-07-31T06:45:17+00:00</updated>
+    <updated>2026-06-25T06:45:17+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -156,23 +155,6 @@
         </choose>
       </group>
     </group>
-  </macro>
-  <macro name="date-sort-group">
-    <!-- APA sorts 1. no-date items, 2. items with dates, 3. in-press (status) items -->
-    <choose>
-      <if variable="issued">
-        <text value="1"/>
-      </if>
-      <else-if variable="status">
-        <text value="2"/>
-      </else-if>
-      <else>
-        <text value="0"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="date-sort-date">
-    <date variable="issued" form="numeric"/>
   </macro>
   <!-- APA has two description elements following the title:
        title (parenthetical) [bracketed]  -->


### PR DESCRIPTION
### Summary
This PR updates bio-protocol.csl so bibliography entries are ordered by citation occurrence (numeric order) instead of author/date/title sorting.

### What changed

In the bibliography sort block, replaced multiple sort keys with a single key: citation-number.
No other macros, formatting rules, or citation rendering logic were changed.

### Why
The style uses numeric in-text citations, so the bibliography should follow order of first appearance in the manuscript.

### Description
Fixes bibliography ordering in bio-protocol.csl so references are listed by citation occurrence.
Replaces the bibliography sort keys with <key variable="citation-number"/>.
No other formatting or macro logic changed.


### Checklist
- [ ] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [ ] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [ ] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [ ] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [ ] Check that you've not used `<text value="...` if not absolutely necessary.
- [ ] Check that you've not changed line 1 of the style.
