### PR TITLE
Chicago: supply `sub-verbo` with shortened note

### DIFF
--- a/chicago-author-date-17th-edition.csl
+++ b/chicago-author-date-17th-edition.csl
@@ -521,7 +521,7 @@
               </if>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
                 <!-- contributors fall after the title of unsigned reference entries (CMOS18 14.130) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>

--- a/chicago-author-date-access-dates.csl
+++ b/chicago-author-date-access-dates.csl
@@ -524,7 +524,7 @@
               </if>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
                 <!-- contributors fall after the title of unsigned reference entries (CMOS18 14.130) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>

--- a/chicago-author-date-archive-place-first-no-url.csl
+++ b/chicago-author-date-archive-place-first-no-url.csl
@@ -524,7 +524,7 @@
               </if>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
                 <!-- contributors fall after the title of unsigned reference entries (CMOS18 14.130) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>

--- a/chicago-author-date-archive-place-first.csl
+++ b/chicago-author-date-archive-place-first.csl
@@ -524,7 +524,7 @@
               </if>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
                 <!-- contributors fall after the title of unsigned reference entries (CMOS18 14.130) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>

--- a/chicago-author-date-classic-no-url.csl
+++ b/chicago-author-date-classic-no-url.csl
@@ -524,7 +524,7 @@
               </if>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
                 <!-- contributors fall after the title of unsigned reference entries (CMOS18 14.130) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>

--- a/chicago-author-date-classic.csl
+++ b/chicago-author-date-classic.csl
@@ -524,7 +524,7 @@
               </if>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
                 <!-- contributors fall after the title of unsigned reference entries (CMOS18 14.130) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>

--- a/chicago-author-date-no-url.csl
+++ b/chicago-author-date-no-url.csl
@@ -524,7 +524,7 @@
               </if>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
                 <!-- contributors fall after the title of unsigned reference entries (CMOS18 14.130) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>

--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -524,7 +524,7 @@
               </if>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
                 <!-- contributors fall after the title of unsigned reference entries (CMOS18 14.130) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>

--- a/chicago-in-text-full-no-url.csl
+++ b/chicago-in-text-full-no-url.csl
@@ -545,7 +545,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -648,7 +648,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -657,7 +657,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -5925,9 +5925,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-in-text-full.csl
+++ b/chicago-in-text-full.csl
@@ -545,7 +545,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -648,7 +648,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -657,7 +657,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -5935,9 +5935,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-in-text-shortened-author-no-url.csl
+++ b/chicago-in-text-shortened-author-no-url.csl
@@ -531,7 +531,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -540,7 +540,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>

--- a/chicago-in-text-shortened-author-title-no-url.csl
+++ b/chicago-in-text-shortened-author-title-no-url.csl
@@ -531,7 +531,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -540,7 +540,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4210,9 +4210,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-in-text-shortened-author-title.csl
+++ b/chicago-in-text-shortened-author-title.csl
@@ -531,7 +531,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -540,7 +540,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4220,9 +4220,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-in-text-shortened-author.csl
+++ b/chicago-in-text-shortened-author.csl
@@ -531,7 +531,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -540,7 +540,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>

--- a/chicago-notes-archive-place-first-no-url.csl
+++ b/chicago-notes-archive-place-first-no-url.csl
@@ -445,7 +445,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -548,7 +548,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -557,7 +557,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4875,9 +4875,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-archive-place-first.csl
+++ b/chicago-notes-archive-place-first.csl
@@ -445,7 +445,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -548,7 +548,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -557,7 +557,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4885,9 +4885,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-bibliography-17th-edition.csl
+++ b/chicago-notes-bibliography-17th-edition.csl
@@ -543,7 +543,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -646,7 +646,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -655,7 +655,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -5919,9 +5919,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-bibliography-access-dates.csl
+++ b/chicago-notes-bibliography-access-dates.csl
@@ -546,7 +546,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -649,7 +649,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -658,7 +658,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -5871,9 +5871,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-bibliography-annotated-abstract.csl
+++ b/chicago-notes-bibliography-annotated-abstract.csl
@@ -546,7 +546,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -649,7 +649,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -658,7 +658,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -5873,9 +5873,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-bibliography-annotated.csl
+++ b/chicago-notes-bibliography-annotated.csl
@@ -546,7 +546,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -649,7 +649,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -658,7 +658,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -5873,9 +5873,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-bibliography-archive-place-first-no-url.csl
+++ b/chicago-notes-bibliography-archive-place-first-no-url.csl
@@ -545,7 +545,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -648,7 +648,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -657,7 +657,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -5848,9 +5848,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-bibliography-archive-place-first.csl
+++ b/chicago-notes-bibliography-archive-place-first.csl
@@ -545,7 +545,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -648,7 +648,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -657,7 +657,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -5858,9 +5858,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-bibliography-classic-archive-place-first-no-url.csl
+++ b/chicago-notes-bibliography-classic-archive-place-first-no-url.csl
@@ -546,7 +546,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -649,7 +649,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -658,7 +658,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -5843,9 +5843,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-bibliography-classic-archive-place-first.csl
+++ b/chicago-notes-bibliography-classic-archive-place-first.csl
@@ -546,7 +546,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -649,7 +649,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -658,7 +658,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -5853,9 +5853,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-bibliography-classic-no-url.csl
+++ b/chicago-notes-bibliography-classic-no-url.csl
@@ -546,7 +546,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -649,7 +649,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -658,7 +658,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -5857,9 +5857,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-bibliography-classic.csl
+++ b/chicago-notes-bibliography-classic.csl
@@ -546,7 +546,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -649,7 +649,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -658,7 +658,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -5867,9 +5867,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-bibliography-no-url.csl
+++ b/chicago-notes-bibliography-no-url.csl
@@ -545,7 +545,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -648,7 +648,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -657,7 +657,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -5862,9 +5862,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-bibliography-subsequent-author-classic-no-url.csl
+++ b/chicago-notes-bibliography-subsequent-author-classic-no-url.csl
@@ -546,7 +546,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -649,7 +649,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -658,7 +658,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -5920,9 +5920,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-bibliography-subsequent-author-classic.csl
+++ b/chicago-notes-bibliography-subsequent-author-classic.csl
@@ -546,7 +546,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -649,7 +649,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -658,7 +658,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -5930,9 +5930,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-bibliography-subsequent-author-no-url.csl
+++ b/chicago-notes-bibliography-subsequent-author-no-url.csl
@@ -545,7 +545,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -648,7 +648,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -657,7 +657,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -5925,9 +5925,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-bibliography-subsequent-author-title-17th-edition.csl
+++ b/chicago-notes-bibliography-subsequent-author-title-17th-edition.csl
@@ -543,7 +543,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -646,7 +646,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -655,7 +655,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -5856,9 +5856,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-bibliography-subsequent-author.csl
+++ b/chicago-notes-bibliography-subsequent-author.csl
@@ -545,7 +545,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -648,7 +648,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -657,7 +657,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -5935,9 +5935,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-bibliography-subsequent-ibid-17th-edition.csl
+++ b/chicago-notes-bibliography-subsequent-ibid-17th-edition.csl
@@ -543,7 +543,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -646,7 +646,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -655,7 +655,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -5856,9 +5856,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-bibliography-subsequent-ibid-classic-no-url.csl
+++ b/chicago-notes-bibliography-subsequent-ibid-classic-no-url.csl
@@ -546,7 +546,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -649,7 +649,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -658,7 +658,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -5857,9 +5857,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-bibliography-subsequent-ibid-classic.csl
+++ b/chicago-notes-bibliography-subsequent-ibid-classic.csl
@@ -546,7 +546,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -649,7 +649,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -658,7 +658,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -5867,9 +5867,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-bibliography-subsequent-ibid-no-url.csl
+++ b/chicago-notes-bibliography-subsequent-ibid-no-url.csl
@@ -545,7 +545,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -648,7 +648,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -657,7 +657,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -5862,9 +5862,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-bibliography-subsequent-ibid.csl
+++ b/chicago-notes-bibliography-subsequent-ibid.csl
@@ -545,7 +545,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -648,7 +648,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -657,7 +657,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -5872,9 +5872,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-bibliography-subsequent-title-no-url.csl
+++ b/chicago-notes-bibliography-subsequent-title-no-url.csl
@@ -545,7 +545,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -648,7 +648,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -657,7 +657,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -5862,9 +5862,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-bibliography-subsequent-title.csl
+++ b/chicago-notes-bibliography-subsequent-title.csl
@@ -545,7 +545,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -648,7 +648,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -657,7 +657,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -5872,9 +5872,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-bibliography.csl
+++ b/chicago-notes-bibliography.csl
@@ -545,7 +545,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -648,7 +648,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -657,7 +657,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -5872,9 +5872,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-classic-archive-place-first-no-url.csl
+++ b/chicago-notes-classic-archive-place-first-no-url.csl
@@ -445,7 +445,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -548,7 +548,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -557,7 +557,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4873,9 +4873,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-classic-archive-place-first.csl
+++ b/chicago-notes-classic-archive-place-first.csl
@@ -445,7 +445,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -548,7 +548,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -557,7 +557,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4883,9 +4883,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-classic-no-url.csl
+++ b/chicago-notes-classic-no-url.csl
@@ -445,7 +445,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -548,7 +548,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -557,7 +557,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4873,9 +4873,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-classic.csl
+++ b/chicago-notes-classic.csl
@@ -445,7 +445,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -548,7 +548,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -557,7 +557,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4883,9 +4883,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-no-url.csl
+++ b/chicago-notes-no-url.csl
@@ -445,7 +445,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -548,7 +548,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -557,7 +557,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4875,9 +4875,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-publisher-place-archive-place-first-no-url.csl
+++ b/chicago-notes-publisher-place-archive-place-first-no-url.csl
@@ -445,7 +445,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -548,7 +548,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -557,7 +557,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4873,9 +4873,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-publisher-place-archive-place-first.csl
+++ b/chicago-notes-publisher-place-archive-place-first.csl
@@ -445,7 +445,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -548,7 +548,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -557,7 +557,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4883,9 +4883,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-publisher-place-label-page-archive-place-first-no-url.csl
+++ b/chicago-notes-publisher-place-label-page-archive-place-first-no-url.csl
@@ -444,7 +444,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -547,7 +547,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -556,7 +556,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4872,9 +4872,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-publisher-place-label-page-archive-place-first.csl
+++ b/chicago-notes-publisher-place-label-page-archive-place-first.csl
@@ -444,7 +444,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -547,7 +547,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -556,7 +556,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4882,9 +4882,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-publisher-place-no-url.csl
+++ b/chicago-notes-publisher-place-no-url.csl
@@ -445,7 +445,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -548,7 +548,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -557,7 +557,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4873,9 +4873,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes-publisher-place.csl
+++ b/chicago-notes-publisher-place.csl
@@ -445,7 +445,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -548,7 +548,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -557,7 +557,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4883,9 +4883,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-notes.csl
+++ b/chicago-notes.csl
@@ -445,7 +445,7 @@
           </if>
           <else-if type="broadcast" variable="container-title number title">
             <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-            <text macro="author-title-substitute-container"/>
+            <text macro="author-title-substitute-container-short"/>
           </else-if>
           <else-if match="any" type="broadcast motion_picture song">
             <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -548,7 +548,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -557,7 +557,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4885,9 +4885,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-shortened-notes-bibliography-17th-edition.csl
+++ b/chicago-shortened-notes-bibliography-17th-edition.csl
@@ -528,7 +528,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -537,7 +537,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4297,9 +4297,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-shortened-notes-bibliography-access-dates.csl
+++ b/chicago-shortened-notes-bibliography-access-dates.csl
@@ -531,7 +531,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -540,7 +540,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4219,9 +4219,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-shortened-notes-bibliography-archive-place-first-no-url.csl
+++ b/chicago-shortened-notes-bibliography-archive-place-first-no-url.csl
@@ -531,7 +531,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -540,7 +540,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4196,9 +4196,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-shortened-notes-bibliography-archive-place-first.csl
+++ b/chicago-shortened-notes-bibliography-archive-place-first.csl
@@ -531,7 +531,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -540,7 +540,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4206,9 +4206,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-shortened-notes-bibliography-classic-archive-place-first-no-url.csl
+++ b/chicago-shortened-notes-bibliography-classic-archive-place-first-no-url.csl
@@ -531,7 +531,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -540,7 +540,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4190,9 +4190,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-shortened-notes-bibliography-classic-archive-place-first.csl
+++ b/chicago-shortened-notes-bibliography-classic-archive-place-first.csl
@@ -531,7 +531,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -540,7 +540,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4200,9 +4200,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-shortened-notes-bibliography-classic-no-url.csl
+++ b/chicago-shortened-notes-bibliography-classic-no-url.csl
@@ -531,7 +531,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -540,7 +540,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4204,9 +4204,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-shortened-notes-bibliography-classic.csl
+++ b/chicago-shortened-notes-bibliography-classic.csl
@@ -531,7 +531,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -540,7 +540,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4214,9 +4214,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-shortened-notes-bibliography-no-url.csl
+++ b/chicago-shortened-notes-bibliography-no-url.csl
@@ -531,7 +531,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -540,7 +540,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4210,9 +4210,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-shortened-notes-bibliography-subsequent-author-classic-no-url.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-author-classic-no-url.csl
@@ -531,7 +531,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -540,7 +540,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4298,9 +4298,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-shortened-notes-bibliography-subsequent-author-classic.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-author-classic.csl
@@ -531,7 +531,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -540,7 +540,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4308,9 +4308,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-shortened-notes-bibliography-subsequent-author-no-url.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-author-no-url.csl
@@ -531,7 +531,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -540,7 +540,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4304,9 +4304,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-shortened-notes-bibliography-subsequent-author-title-17th-edition.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-author-title-17th-edition.csl
@@ -528,7 +528,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -537,7 +537,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4203,9 +4203,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-shortened-notes-bibliography-subsequent-author.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-author.csl
@@ -531,7 +531,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -540,7 +540,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4314,9 +4314,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-shortened-notes-bibliography-subsequent-ibid-17th-edition.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-ibid-17th-edition.csl
@@ -528,7 +528,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -537,7 +537,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4234,9 +4234,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-shortened-notes-bibliography-subsequent-ibid-classic-no-url.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-ibid-classic-no-url.csl
@@ -531,7 +531,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -540,7 +540,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4235,9 +4235,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-shortened-notes-bibliography-subsequent-ibid-classic.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-ibid-classic.csl
@@ -531,7 +531,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -540,7 +540,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4245,9 +4245,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-shortened-notes-bibliography-subsequent-ibid-no-url.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-ibid-no-url.csl
@@ -531,7 +531,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -540,7 +540,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4241,9 +4241,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-shortened-notes-bibliography-subsequent-ibid.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-ibid.csl
@@ -531,7 +531,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -540,7 +540,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4251,9 +4251,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-shortened-notes-bibliography-subsequent-title-no-url.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-title-no-url.csl
@@ -531,7 +531,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -540,7 +540,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4241,9 +4241,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-shortened-notes-bibliography-subsequent-title.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-title.csl
@@ -531,7 +531,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -540,7 +540,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4251,9 +4251,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/chicago-shortened-notes-bibliography.csl
+++ b/chicago-shortened-notes-bibliography.csl
@@ -531,7 +531,7 @@
               </if>
               <else-if type="broadcast" variable="container-title number title">
                 <!-- note contributors fall after the title of `broadcast` (CMOS18 14.165) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
               <else-if match="any" type="broadcast motion_picture song">
                 <!-- note contributors fall after the title of `broadcast`, `motion_picture` (CMOS18 14.165), `song` (CMOS18 14.163)  -->
@@ -540,7 +540,7 @@
               <!-- unsigned reference articles consulted in physical formats list `title` in the manner of a `sub-verbo` locator (CMOS18 14.130) -->
               <else-if match="any" variable="DOI URL"/>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>
@@ -4220,9 +4220,23 @@
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>
-          <if match="none" type="bill hearing legal_case legislation regulation treaty">
+          <if match="any" type="bill hearing legal_case legislation regulation treaty"/>
+          <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
+            <group delimiter=" ">
+              <choose>
+                <if locator="sub-verbo"/>
+                <!-- Only print reference entries use `sub-verbo` (CMOS18 14.131) -->
+                <else-if match="any" variable="DOI URL"/>
+                <else-if variable="container-title title">
+                  <text form="short" term="sub-verbo"/>
+                </else-if>
+              </choose>
+              <text macro="title-and-descriptions-short"/>
+            </group>
+          </else-if>
+          <else>
             <text macro="title-and-descriptions-short"/>
-          </if>
+          </else>
         </choose>
         <text macro="citation-notes-shortened-author-title-disambiguate"/>
         <choose>

--- a/taylor-and-francis-chicago-author-date.csl
+++ b/taylor-and-francis-chicago-author-date.csl
@@ -505,7 +505,7 @@
               </if>
               <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
                 <!-- contributors fall after the title of unsigned reference entries (CMOS18 14.130) -->
-                <text macro="author-title-substitute-container"/>
+                <text macro="author-title-substitute-container-short"/>
               </else-if>
             </choose>
             <names variable="illustrator"/>


### PR DESCRIPTION
Supply missing `sub-verbo` term with shortened notes and allow use of a short `container-title` with `entry-dictionary` and `entry-encylopedia`.
