### PR TITLE
OSCOLA: Restrict URL display to online-only items

### DIFF
--- a/oscola-journal-abbreviations.csl
+++ b/oscola-journal-abbreviations.csl
@@ -8,6 +8,7 @@
     <link href="http://www.zotero.org/styles/oscola-journal-abbreviations" rel="self"/>
     <link href="http://www.zotero.org/styles/oscola" rel="template"/>
     <link href="https://www.law.ox.ac.uk/oscola" rel="documentation"/>
+    <link href="https://zotero.org/groups/2205533/collections/AC7ETLN4" rel="documentation"/>
     <author>
       <name>Sebastian Karcher</name>
       <uri>https://orcid.org/0000-0001-8249-7388</uri>
@@ -24,8 +25,8 @@
     </contributor>
     <category citation-format="note"/>
     <category field="law"/>
-    <summary>Oxford University Standard for Citation of Legal Authorities, notes system, with journal abbreviations. For a Zotero group showing data entry: https://zotero.org/groups/2205533/collections/AC7ETLN4</summary>
-    <updated>2026-02-07T00:00:00+00:00</updated>
+    <summary>Oxford University Standard for Citation of Legal Authorities, notes system, with journal abbreviations.</summary>
+    <updated>2026-04-15T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -539,7 +540,10 @@
   </macro>
   <macro name="URL">
     <choose>
+      <!-- display URLs only for online-only works -->
       <if match="any" type="bill legal_case legislation"/>
+      <else-if match="any" variable="page"/>
+      <else-if match="any" type="book chapter classic pamphlet"/>
       <else-if match="any" variable="DOI URL">
         <!-- OSCOLA does not distinguish between DOIs and URLs; used here as a permalink -->
         <group delimiter=" ">

--- a/oscola-no-ibid.csl
+++ b/oscola-no-ibid.csl
@@ -8,6 +8,7 @@
     <link href="http://www.zotero.org/styles/oscola-no-ibid" rel="self"/>
     <link href="http://www.zotero.org/styles/oscola" rel="template"/>
     <link href="https://www.law.ox.ac.uk/oscola" rel="documentation"/>
+    <link href="https://zotero.org/groups/2205533/collections/AC7ETLN4" rel="documentation"/>
     <author>
       <name>Sebastian Karcher</name>
       <uri>https://orcid.org/0000-0001-8249-7388</uri>
@@ -18,8 +19,8 @@
     </author>
     <category citation-format="note"/>
     <category field="law"/>
-    <summary>Oxford University Standard for Citation of Legal Authorities, notes system, no ibid. For a Zotero group showing data entry: https://zotero.org/groups/2205533/collections/AC7ETLN4</summary>
-    <updated>2026-02-07T00:00:00+00:00</updated>
+    <summary>Oxford University Standard for Citation of Legal Authorities, notes system, no ibid.</summary>
+    <updated>2026-04-15T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -523,7 +524,10 @@
   </macro>
   <macro name="URL">
     <choose>
+      <!-- display URLs only for online-only works -->
       <if match="any" type="bill legal_case legislation"/>
+      <else-if match="any" variable="page"/>
+      <else-if match="any" type="book chapter classic pamphlet"/>
       <else-if match="any" variable="DOI URL">
         <!-- OSCOLA does not distinguish between DOIs and URLs; used here as a permalink -->
         <group delimiter=" ">

--- a/oscola.csl
+++ b/oscola.csl
@@ -7,6 +7,7 @@
     <id>http://www.zotero.org/styles/oscola</id>
     <link href="http://www.zotero.org/styles/oscola" rel="self"/>
     <link href="https://www.law.ox.ac.uk/oscola" rel="documentation"/>
+    <link href="https://zotero.org/groups/2205533/collections/AC7ETLN4" rel="documentation"/>
     <author>
       <name>Sebastian Karcher</name>
       <uri>https://orcid.org/0000-0001-8249-7388</uri>
@@ -17,8 +18,8 @@
     </author>
     <category citation-format="note"/>
     <category field="law"/>
-    <summary>Oxford University Standard for Citation of Legal Authorities, notes system. For a Zotero group showing data entry: https://zotero.org/groups/2205533/collections/AC7ETLN4</summary>
-    <updated>2026-02-07T00:00:00+00:00</updated>
+    <summary>Oxford University Standard for Citation of Legal Authorities, notes system.</summary>
+    <updated>2026-04-15T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -522,7 +523,10 @@
   </macro>
   <macro name="URL">
     <choose>
+      <!-- display URLs only for online-only works -->
       <if match="any" type="bill legal_case legislation"/>
+      <else-if match="any" variable="page"/>
+      <else-if match="any" type="book chapter classic pamphlet"/>
       <else-if match="any" variable="DOI URL">
         <!-- OSCOLA does not distinguish between DOIs and URLs; used here as a permalink -->
         <group delimiter=" ">


### PR DESCRIPTION
OSCOLA only displays URLs for items that items that are only available in digital format. This imitates the typical Zotero behaviour for journal articles and restricts display for item types that normally have a print equivalent.
