### PR TITLE
Create harvard-warwick-business-school.csl

### DIFF
--- a/harvard-warwick-business-school.csl
+++ b/harvard-warwick-business-school.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
   <info>
-    <title>Warwick Business School - Harvard</title>
+    <title>Warwick Business School (author-date/Harvard)</title>
     <title-short>WBS Harvard</title-short>
     <id>http://www.zotero.org/styles/harvard-warwick-business-school</id>
     <link href="http://www.zotero.org/styles/harvard-warwick-business-school" rel="self"/>

--- a/harvard-warwick-business-school.csl
+++ b/harvard-warwick-business-school.csl
@@ -1,0 +1,537 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
+  <info>
+    <title>Warwick Business School - Harvard</title>
+    <title-short>WBS Harvard</title-short>
+    <id>http://www.zotero.org/styles/harvard-warwick-business-school</id>
+    <link href="http://www.zotero.org/styles/harvard-warwick-business-school" rel="self"/>
+    <link href="http://www.zotero.org/styles/harvard-coventry-university" rel="template"/>
+    <link href="https://warwick.ac.uk/services/library/students/referencing/referencing-styles/#harvard" rel="documentation"/>
+    <link href="https://warwick.ac.uk/services/library/students/referencing/referencing-styles/harvard_warwick_wbs_quick_guide_2025_rhiannon_taylor.docx" rel="documentation"/>
+    <author>
+      <name>Xingzheng Wang</name>
+      <email>i@kousei.ooo</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="generic-base"/>
+    <summary>The Harvard author-date style - adapted for use at Warwick Business School, University of Warwick.</summary>
+    <updated>2026-04-18T18:24:23+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale>
+    <terms>
+      <term name="edition" form="short">edn.</term>
+      <term name="page-range-delimiter">-</term>
+      <term name="section" form="short">s.</term>
+    </terms>
+    <style-options punctuation-in-quote="false"/>
+  </locale>
+  <macro name="editor">
+    <names variable="editor" delimiter=", ">
+      <name name-as-sort-order="all" and="text" delimiter-precedes-last="never" sort-separator=", " initialize-with="." delimiter=", "/>
+      <label form="short" prefix=" (" suffix=")" strip-periods="true"/>
+    </names>
+  </macro>
+  <macro name="edby">
+    <names variable="editor" delimiter=", " prefix="ed. by ">
+      <name name-as-sort-order="all" and="text" delimiter-precedes-last="never" sort-separator=", " initialize-with="." delimiter=", "/>
+    </names>
+  </macro>
+  <macro name="transby">
+    <names variable="translator" delimiter=", " prefix="trans. by ">
+      <name name-as-sort-order="all" and="text" delimiter-precedes-last="never" sort-separator=", " initialize-with="." delimiter=", "/>
+    </names>
+  </macro>
+  <macro name="recipient">
+    <names variable="recipient" delimiter=", " prefix="to ">
+      <name name-as-sort-order="all" and="text" delimiter-precedes-last="never" sort-separator=", " initialize-with="." delimiter=", "/>
+    </names>
+  </macro>
+  <macro name="interviewer">
+    <names variable="interviewer" delimiter=", " prefix="interview by ">
+      <name and="text" delimiter-precedes-last="never" sort-separator=", " initialize-with="." delimiter=", "/>
+    </names>
+  </macro>
+  <macro name="bookauthor">
+    <names variable="container-author">
+      <name name-as-sort-order="all" and="text" delimiter-precedes-last="never" sort-separator=", " initialize-with="." delimiter=", "/>
+      <substitute>
+        <text macro="edby"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author">
+    <choose>
+      <if type="broadcast" match="any">
+        <choose>
+          <if variable="container-title">
+            <text variable="container-title" font-style="italic" text-case="title"/>
+          </if>
+          <else-if variable="title">
+            <text variable="title" font-style="italic" text-case="title"/>
+          </else-if>
+        </choose>
+      </if>
+      <else-if type="legislation">
+        <choose>
+          <if variable="container-title chapter-number" match="any">
+            <text variable="title" text-case="title"/>
+          </if>
+          <else>
+            <text variable="title" font-style="italic" text-case="title"/>
+          </else>
+        </choose>
+      </else-if>
+      <else>
+        <names variable="author">
+          <name name-as-sort-order="all" and="text" delimiter-precedes-last="never" sort-separator=", " initialize-with="." delimiter=", " form="long"/>
+          <label form="short" prefix=" (" suffix=")"/>
+          <substitute>
+            <names variable="editor"/>
+            <text macro="title"/>
+          </substitute>
+        </names>
+      </else>
+    </choose>
+  </macro>
+  <macro name="author-short">
+    <choose>
+      <if type="broadcast" match="any">
+        <choose>
+          <if variable="container-title">
+            <text variable="container-title" font-style="italic" text-case="title"/>
+          </if>
+          <else-if variable="title">
+            <text variable="title" font-style="italic" text-case="title"/>
+          </else-if>
+        </choose>
+      </if>
+      <else-if type="legislation">
+        <text variable="title" text-case="title"/>
+      </else-if>
+      <else>
+        <names variable="author">
+          <name form="short" and="text" delimiter-precedes-last="never" delimiter=", " initialize-with=". "/>
+          <et-al font-style="italic"/>
+          <substitute>
+            <names variable="editor"/>
+            <text macro="title"/>
+          </substitute>
+        </names>
+      </else>
+    </choose>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix="https://doi.org/"/>
+      </if>
+      <else-if variable="URL">
+        <group delimiter=" ">
+          <group delimiter=" ">
+            <text value="Available at:"/>
+            <text variable="URL"/>
+          </group>
+          <group prefix="(Accessed: " suffix=")">
+            <date variable="accessed">
+              <date-part name="day" suffix=" "/>
+              <date-part name="month" suffix=" "/>
+              <date-part name="year"/>
+            </date>
+          </group>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic legal_case legislation manuscript motion_picture report song webpage" match="any">
+        <text variable="title" font-style="italic" text-case="title"/>
+      </if>
+      <else-if variable="container-title" match="none">
+        <text variable="title" font-style="italic" text-case="title"/>
+      </else-if>
+      <else>
+        <text variable="title" quotes="true"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-online">
+    <text macro="title" suffix="."/>
+  </macro>
+  <macro name="container-title-online">
+    <text variable="container-title" suffix="." font-style="italic" text-case="title"/>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=": ">
+      <text variable="publisher-place"/>
+      <text variable="publisher"/>
+    </group>
+  </macro>
+  <macro name="year-date">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="year-date-legislation">
+    <choose>
+      <if variable="issued">
+        <group delimiter=", ">
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+          <choose>
+            <if variable="chapter-number">
+              <text variable="chapter-number"/>
+            </if>
+            <else>
+              <text variable="container-title"/>
+            </else>
+          </choose>
+        </group>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short" strip-periods="false"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="volume">
+    <group delimiter=" ">
+      <label variable="volume" form="short" plural="never"/>
+      <text variable="volume"/>
+    </group>
+  </macro>
+  <macro name="pages">
+    <group delimiter=" ">
+      <label variable="page" form="short"/>
+      <text variable="page"/>
+    </group>
+  </macro>
+  <macro name="volumes">
+    <group>
+      <text variable="number-of-volumes" suffix=" "/>
+      <label variable="volume" form="short" plural="always"/>
+    </group>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if type="article-newspaper article-magazine paper-conference broadcast post personal_communication interview post-weblog" match="any">
+        <date variable="issued">
+          <date-part name="day" suffix=" "/>
+          <date-part name="month"/>
+        </date>
+      </if>
+    </choose>
+    <choose>
+      <if type="broadcast paper-conference post personal_communication interview post-weblog" match="any">
+        <date variable="issued">
+          <date-part name="year" prefix=" "/>
+        </date>
+      </if>
+    </choose>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="by-cite" name-as-sort-order="all" collapse="year">
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="author-short"/>
+        <text macro="year-date"/>
+        <group delimiter="&#160;">
+          <label variable="locator" form="short"/>
+          <text variable="locator"/>
+        </group>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true">
+    <sort>
+      <key macro="author"/>
+      <key macro="year-date" sort="descending"/>
+      <key variable="citation-number" sort="ascending"/>
+      <key variable="title"/>
+    </sort>
+    <layout suffix=".">
+      <group delimiter=" ">
+        <text macro="author"/>
+        <choose>
+          <if type="legislation" match="any">
+            <text macro="year-date-legislation" prefix="(" suffix=")"/>
+          </if>
+          <else>
+            <text macro="year-date" prefix="(" suffix=")"/>
+          </else>
+        </choose>
+        <choose>
+          <if type="bill legislation" match="any">
+            <group delimiter=". ">
+              <text macro="edition"/>
+              <text variable="number"/>
+              <text macro="transby"/>
+              <text variable="references"/>
+              <text macro="publisher"/>
+              <text macro="access"/>
+            </group>
+          </if>
+          <else-if type="thesis">
+            <text macro="title-online"/>
+            <group delimiter=". ">
+              <text macro="edition"/>
+              <text macro="transby"/>
+              <text variable="genre"/>
+              <text macro="publisher"/>
+              <text macro="access"/>
+            </group>
+          </else-if>
+          <else-if type="webpage">
+            <text macro="title-online"/>
+            <group delimiter=". ">
+              <text macro="transby"/>
+              <text macro="edition"/>
+              <text macro="access"/>
+            </group>
+          </else-if>
+          <else-if type="manuscript">
+            <text macro="title-online"/>
+            <group delimiter=". ">
+              <text macro="transby"/>
+              <text variable="archive"/>
+              <text variable="archive_location"/>
+              <text variable="genre"/>
+              <text macro="publisher"/>
+              <text macro="access"/>
+            </group>
+          </else-if>
+          <else-if type="article-journal article-magazine article-newspaper song speech" match="any">
+            <group delimiter=", ">
+              <text macro="title"/>
+              <text variable="container-title" font-style="italic" text-case="title"/>
+              <text macro="issued"/>
+              <group>
+                <text variable="volume"/>
+                <text variable="issue" prefix="(" suffix=")"/>
+              </group>
+              <text macro="pages"/>
+            </group>
+            <text macro="access" prefix=" "/>
+          </else-if>
+          <else-if type="broadcast" match="any">
+            <choose>
+              <if variable="URL">
+                <group delimiter=". ">
+                  <text variable="publisher"/>
+                  <text macro="issued"/>
+                  <text macro="access"/>
+                </group>
+              </if>
+              <else>
+                <text variable="publisher"/>
+                <text macro="issued" prefix="[" suffix="]"/>
+              </else>
+            </choose>
+          </else-if>
+          <else-if type="motion_picture" match="any">
+            <text macro="title-online"/>
+            <group delimiter=". ">
+              <text variable="number"/>
+              <group delimiter=" ">
+                <text variable="medium" prefix="[" suffix="]"/>
+                <text macro="publisher"/>
+              </group>
+              <text macro="access"/>
+            </group>
+          </else-if>
+          <else-if type="book graphic legal_case" match="any">
+            <text macro="title-online"/>
+            <group delimiter=". ">
+              <text macro="edition"/>
+              <text macro="edby"/>
+              <text macro="transby"/>
+              <group delimiter=" ">
+                <text variable="collection-title"/>
+                <text variable="collection-number"/>
+                <text variable="number"/>
+              </group>
+              <text macro="volume"/>
+              <text macro="volumes"/>
+              <text variable="genre"/>
+              <text macro="publisher"/>
+              <text macro="access"/>
+            </group>
+          </else-if>
+          <else-if type="report" match="any">
+            <text macro="title-online"/>
+            <group delimiter=". ">
+              <text macro="edition"/>
+              <text macro="transby"/>
+              <group delimiter=" ">
+                <text variable="collection-title"/>
+                <text variable="collection-number"/>
+                <text variable="number"/>
+              </group>
+              <text macro="volume"/>
+              <text macro="volumes"/>
+              <group delimiter=", ">
+                <text macro="publisher"/>
+                <text variable="genre"/>
+              </group>
+              <text macro="access"/>
+            </group>
+          </else-if>
+          <else-if type="chapter" match="any">
+            <group delimiter=". ">
+              <group>
+                <text macro="title" suffix=", "/>
+                <group delimiter=" ">
+                  <text term="in"/>
+                  <text macro="editor"/>
+                  <group delimiter=" ">
+                    <text variable="container-title" font-style="italic" text-case="title"/>
+                    <group prefix="(" suffix=")" delimiter=", ">
+                      <text variable="collection-title"/>
+                      <group delimiter=" ">
+                        <label variable="volume" form="short" plural="never" text-case="capitalize-first"/>
+                        <text variable="volume"/>
+                      </group>
+                      <text variable="collection-number"/>
+                      <text variable="number"/>
+                    </group>
+                  </group>
+                </group>
+              </group>
+              <text macro="edition"/>
+              <text macro="volumes"/>
+              <group delimiter=", ">
+                <text macro="publisher"/>
+                <text macro="pages"/>
+              </group>
+              <text macro="access"/>
+            </group>
+          </else-if>
+          <else-if type="paper-conference" match="any">
+            <group delimiter=", ">
+              <text macro="title"/>
+              <text variable="container-title" font-style="italic" text-case="title"/>
+              <text macro="pages"/>
+            </group>
+            <text macro="access" prefix=" "/>
+          </else-if>
+          <else-if type="post" match="any">
+            <text macro="title"/>
+            <text macro="issued" prefix="[" suffix="]"/>
+            <text macro="container-title-online"/>
+            <group delimiter=". ">
+              <group>
+                <group>
+                  <text macro="transby"/>
+                  <text variable="volume"/>
+                  <text variable="issue" prefix=" (" suffix=")"/>
+                </group>
+                <text macro="pages"/>
+              </group>
+              <text macro="access"/>
+            </group>
+          </else-if>
+          <else-if type="personal_communication" match="any">
+            <text macro="title"/>
+            <text variable="genre" prefix="[" suffix="]"/>
+            <text macro="recipient"/>
+            <group delimiter=". ">
+              <text macro="issued" prefix="[" suffix="]"/>
+              <text macro="access"/>
+            </group>
+          </else-if>
+          <else-if type="entry-encyclopedia" match="any">
+            <text macro="title" suffix=". "/>
+            <text macro="container-title-online" prefix="in "/>
+            <group delimiter=". ">
+              <text macro="edition"/>
+              <text macro="edby"/>
+              <text macro="transby"/>
+              <text macro="volume"/>
+              <text variable="number"/>
+              <group delimiter=", ">
+                <text macro="publisher"/>
+                <text macro="pages"/>
+              </group>
+              <text macro="access"/>
+            </group>
+          </else-if>
+          <else-if type="map" match="any">
+            <text macro="title-online"/>
+            <group delimiter=". ">
+              <text variable="call-number"/>
+              <group delimiter=", ">
+                <text variable="scale"/>
+                <text variable="collection-title"/>
+              </group>
+              <text macro="publisher"/>
+              <text macro="access"/>
+            </group>
+          </else-if>
+          <else-if type="interview" match="any">
+            <group delimiter=", ">
+              <group delimiter=" ">
+                <text macro="title"/>
+                <text macro="interviewer" prefix="[" suffix="]"/>
+              </group>
+              <text macro="issued"/>
+            </group>
+          </else-if>
+          <else-if type="post-weblog" match="any">
+            <group delimiter=". ">
+              <text macro="title"/>
+              <group delimiter=" ">
+                <text macro="issued" prefix="[" suffix="]"/>
+                <text macro="access"/>
+              </group>
+            </group>
+          </else-if>
+          <else>
+            <text macro="title" suffix=". "/>
+            <text macro="container-title-online" prefix="in "/>
+            <group delimiter=". ">
+              <text macro="edition"/>
+              <text macro="bookauthor"/>
+              <group delimiter=" ">
+                <text variable="collection-title"/>
+                <text variable="collection-number"/>
+                <text variable="number"/>
+              </group>
+              <group delimiter=" ">
+                <text macro="volume"/>
+                <text variable="issue" prefix=" (" suffix=")"/>
+              </group>
+              <text macro="volumes"/>
+              <text macro="issued"/>
+              <text variable="genre"/>
+              <group delimiter=", ">
+                <text macro="publisher"/>
+                <text macro="pages"/>
+              </group>
+              <text macro="access"/>
+            </group>
+          </else>
+        </choose>
+      </group>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
## CSL Styles Pull Request Template
You're about to create a pull request to the CSL **styles** repository.
If you haven't done so already, see <https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md> for instructions on how to contribute, and <https://github.com/citation-style-language/styles/blob/master/STYLE_REQUIREMENTS.md> for the requirements a style must meet before acceptance.
In addition, please fill out the pull request template below.


### Description
New author–date Harvard style used at **Warwick Business School (WBS)**, University of Warwick, based on the official 2025 WBS Quick Guide to Harvard Referencing (Rhiannon Taylor). Templated from `harvard-coventry-university.csl` with adjustments for WBS-specific conventions (e.g. `edn.` for editions, `Available at:` / `(Accessed: …)` phrasing, single author + *et al.* italics in citations for 3+ authors, parenthetical in-text citations).

Official WBS guidance:
- https://warwick.ac.uk/services/library/students/referencing/referencing-styles/#harvard
- https://warwick.ac.uk/services/library/students/referencing/referencing-styles/harvard_warwick_wbs_quick_guide_2025_rhiannon_taylor.docx

### Local validation
Ran the repository's CI-equivalent checks locally before opening this PR:

- RelaxNG: `jing -c csl.rnc harvard-warwick-business-school.csl` → no errors
- Schematron (`csl.sch`): all macro references resolve, macro names unique
- Filename matches `[a-z0-9-]+\.csl`
- `<id>` == `http://www.zotero.org/styles/harvard-warwick-business-school` == `<link rel="self">`
- `<rights>` is CC BY-SA 3.0 with the required statement
- `<updated>` is valid ISO 8601
- 2-space indentation throughout
- All 20 defined macros are used; all 20 referenced macros are defined

### Checklist
- [x] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.
- [x] Check that you've added a link to the style guidelines with `rel="documentation"`.
- [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update.
- [x] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [x] Check that you've not used `<text value="...` if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.
