### PR TITLE
Add ISO-690:2021 (numeric, brackets, English)

### DIFF
--- a/iso690-2021-numeric-brackets-en.csl
+++ b/iso690-2021-numeric-brackets-en.csl
@@ -286,7 +286,7 @@
       <choose>
         <if type="book report dataset software" match="any">
           <group delimiter=" ">
-            <text macro="title" prefix=" "/>
+            <text macro="title"/>
             <text macro="edition"/>
             <text macro="version"/>
             <text macro="editor" suffix="."/>

--- a/iso690-2021-numeric-brackets-en.csl
+++ b/iso690-2021-numeric-brackets-en.csl
@@ -1,0 +1,381 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" et-al-min="6" et-al-use-first="5" page-range-format="expanded" default-locale="en-US">
+  <info>
+    <title>ISO-690:2021 (numeric, brackets, English)</title>
+    <title-short>ISO-690:2021 [numeric] EN</title-short>
+    <id>http://www.zotero.org/styles/iso690-2021-numeric-brackets-en</id>
+    <link href="http://www.zotero.org/styles/iso690-2021-numeric-brackets-en" rel="self"/>
+    <link href="http://www.zotero.org/styles/iso690-numeric-en" rel="template"/>
+    <link href="https://www.iso.org/standard/72642.html" rel="documentation"/>
+    <author>
+      <name>Mah.Zad.Yar</name>
+      <email>mah.zad.yar@gmail.com</email>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="generic-base"/>
+    <summary>Style based on ISO 690:2021(E) with numeric references in square brackets for English-language sources.</summary>
+    <updated>2026-04-20T18:25:28+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en-US">
+    <terms>
+      <term name="accessed">viewed</term>
+      <term name="available at">available from</term>
+      <term name="no-place">place not known</term>
+      <term name="no-publisher">publisher not known</term>
+    </terms>
+  </locale>
+  <macro name="author">
+    <names variable="author" suffix=". ">
+      <name delimiter="; " and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="6" et-al-use-first="5" initialize-with="." name-as-sort-order="first">
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given" text-case="capitalize-first"/>
+      </name>
+      <substitute>
+        <names variable="editor">
+          <name delimiter="; " and="text" delimiter-precedes-last="never" et-al-min="6" et-al-use-first="5" initialize-with="." name-as-sort-order="first">
+            <name-part name="family" text-case="uppercase"/>
+            <name-part name="given" text-case="capitalize-first"/>
+          </name>
+          <label form="short" text-case="capitalize-first" prefix=" "/>
+        </names>
+        <text term="anonymous" form="short" text-case="capitalize-first" prefix="[" suffix="]"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="container_author">
+    <names variable="container-author" suffix=" ">
+      <name delimiter="; " and="text" delimiter-precedes-last="never" et-al-min="6" et-al-use-first="5" initialize-with="." name-as-sort-order="first">
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given" text-case="capitalize-first"/>
+      </name>
+      <substitute>
+        <names variable="editor">
+          <name delimiter="; " and="text" delimiter-precedes-last="never" et-al-min="6" et-al-use-first="5" initialize-with="." name-as-sort-order="first">
+            <name-part name="family" text-case="uppercase"/>
+            <name-part name="given" text-case="capitalize-first"/>
+          </name>
+          <label form="short" text-case="capitalize-first" prefix=" " suffix="."/>
+        </names>
+        <text term="anonymous" form="short" text-case="capitalize-first" prefix="[" suffix="]"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="title">
+    <group delimiter=" " suffix=". ">
+      <choose>
+        <if type="book thesis report dataset software" match="any">
+          <group delimiter="">
+            <text variable="title" font-style="italic"/>
+            <text variable="original-title" prefix=" [" suffix="]"/>
+          </group>
+        </if>
+        <else-if type="paper-conference chapter article-journal article-magazine article-newspaper webpage post-weblog post" match="any">
+          <group delimiter="" suffix=". ">
+            <text variable="title"/>
+            <text variable="original-title" prefix=" [" suffix="]"/>
+          </group>
+          <text term="in" text-case="capitalize-first" suffix=": "/>
+          <text macro="container_author"/>
+          <choose>
+            <if variable="container-title">
+              <text variable="container-title" font-style="italic" suffix=" "/>
+            </if>
+            <else-if variable="event-title">
+              <text variable="event-title" font-style="italic" suffix=" "/>
+            </else-if>
+          </choose>
+        </else-if>
+      </choose>
+      <text macro="publication_source"/>
+    </group>
+  </macro>
+  <macro name="publication_source">
+    <choose>
+      <if variable="medium">
+        <text variable="medium" prefix="[" suffix="]"/>
+      </if>
+      <else-if type="dataset">
+        <text value="[dataset]"/>
+      </else-if>
+      <else-if type="software">
+        <text value="[software]"/>
+      </else-if>
+      <else-if variable="URL DOI" match="any">
+        <text term="online" prefix="[" suffix="]"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="editor">
+    <names variable="editor">
+      <label form="short" text-case="capitalize-first" suffix=" "/>
+      <name and="text" delimiter=", "/>
+    </names>
+  </macro>
+  <macro name="time_data">
+    <choose>
+      <if variable="URL DOI" match="any">
+        <group prefix=" [" suffix="]. ">
+          <text term="accessed" text-case="lowercase" suffix=" "/>
+          <date variable="accessed">
+            <date-part name="year" suffix="-" range-delimiter="–"/>
+            <date-part name="month" suffix="-" form="numeric-leading-zeros" range-delimiter="–"/>
+            <date-part name="day" form="numeric-leading-zeros" range-delimiter="–"/>
+          </date>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="availability">
+    <choose>
+      <if variable="DOI">
+        <group delimiter=": " suffix=". ">
+          <text term="available at" text-case="capitalize-first"/>
+          <text variable="DOI" prefix="https://doi.org/"/>
+        </group>
+      </if>
+      <else-if variable="URL">
+        <group delimiter=": " suffix=". ">
+          <text term="available at" text-case="capitalize-first"/>
+          <text variable="URL"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if variable="publisher publisher-place" match="all">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </if>
+      <else-if variable="publisher">
+        <group delimiter=": ">
+          <text term="no-place" prefix="[" suffix="]"/>
+          <text variable="publisher"/>
+        </group>
+      </else-if>
+      <else-if variable="publisher-place">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text term="no-publisher" prefix="[" suffix="]"/>
+        </group>
+      </else-if>
+      <else>
+        <group delimiter=": ">
+          <text term="no-place" prefix="[" suffix="]"/>
+          <text term="no-publisher" prefix="[" suffix="]"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="year-date">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year" suffix=". " range-delimiter="–"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" prefix="[" suffix="]. "/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="pages">
+    <choose>
+      <if type="book thesis" match="any">
+        <group delimiter=" ">
+          <text variable="number-of-pages"/>
+          <label variable="number-of-pages" form="short"/>
+        </group>
+      </if>
+      <else-if type="chapter paper-conference article-newspaper" match="any">
+        <group delimiter=" " suffix=". ">
+          <label variable="page" form="short"/>
+          <text variable="page"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="notes">
+    <text variable="note" suffix=". "/>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" " suffix=". ">
+          <number variable="edition" form="ordinal"/>
+          <label variable="edition" form="short"/>
+        </group>
+      </if>
+      <else-if variable="edition">
+        <text variable="edition" suffix=". "/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="version">
+    <text variable="version" prefix="Version " suffix=". "/>
+  </macro>
+  <macro name="license">
+    <text variable="license" prefix="License: " suffix=". "/>
+  </macro>
+  <macro name="archived_copy">
+    <choose>
+      <if variable="archive archive_location" match="any">
+        <group delimiter=": " suffix=". ">
+          <text value="Archived copy available from"/>
+          <choose>
+            <if variable="archive archive_location" match="all">
+              <group delimiter=", ">
+                <text variable="archive"/>
+                <text variable="archive_location"/>
+              </group>
+            </if>
+            <else-if variable="archive_location">
+              <text variable="archive_location"/>
+            </else-if>
+            <else-if variable="archive">
+              <text variable="archive"/>
+            </else-if>
+          </choose>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="publisher_block">
+    <group delimiter=", ">
+      <text macro="publisher"/>
+      <text macro="year-date"/>
+    </group>
+  </macro>
+  <macro name="issue">
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <label variable="volume" form="short"/>
+        <text variable="volume"/>
+      </group>
+      <group delimiter=" ">
+        <label variable="issue" form="short"/>
+        <text variable="issue"/>
+      </group>
+      <group delimiter=" ">
+        <label variable="page" form="short"/>
+        <text variable="page"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="isbn">
+    <text prefix="ISBN " variable="ISBN"/>
+  </macro>
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout vertical-align="baseline" delimiter=", " prefix="[" suffix="]">
+      <text variable="citation-number"/>
+    </layout>
+  </citation>
+  <bibliography et-al-min="6" et-al-use-first="5" second-field-align="flush">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout>
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="author"/>
+      <choose>
+        <if type="book report dataset software" match="any">
+          <group delimiter=" ">
+            <text macro="title" prefix=" "/>
+            <text macro="edition"/>
+            <text macro="version"/>
+            <text macro="editor" suffix="."/>
+            <group delimiter=", ">
+              <text macro="publisher"/>
+              <text macro="year-date"/>
+            </group>
+            <text macro="pages"/>
+            <text prefix="ISBN " variable="ISBN"/>
+            <text macro="license"/>
+            <text macro="availability"/>
+            <text macro="time_data"/>
+          </group>
+        </if>
+        <else-if type="article-journal article-magazine" match="any">
+          <text macro="title"/>
+          <text macro="edition"/>
+          <text macro="year-date"/>
+          <text macro="issue" suffix=". "/>
+          <text macro="license"/>
+          <text macro="availability"/>
+          <text macro="time_data"/>
+        </else-if>
+        <else-if type="article-newspaper">
+          <text macro="title"/>
+          <text macro="edition"/>
+          <text macro="publisher_block"/>
+          <text macro="pages"/>
+          <text macro="license"/>
+          <text macro="availability"/>
+          <text macro="time_data"/>
+        </else-if>
+        <else-if type="chapter entry entry-dictionary entry-encyclopedia" match="any">
+          <text macro="title"/>
+          <text macro="edition"/>
+          <text macro="publisher_block"/>
+          <text macro="pages"/>
+          <text macro="isbn"/>
+          <text macro="license"/>
+          <text macro="availability"/>
+          <text macro="time_data"/>
+        </else-if>
+        <else-if type="paper-conference">
+          <text macro="title"/>
+          <text macro="publisher_block"/>
+          <text macro="pages"/>
+          <text macro="license"/>
+          <text macro="availability"/>
+          <text macro="time_data"/>
+        </else-if>
+        <else-if type="thesis">
+          <text macro="title"/>
+          <text macro="publisher_block"/>
+          <text macro="license"/>
+          <text macro="availability"/>
+          <text macro="time_data"/>
+        </else-if>
+        <else-if type="patent">
+          <text macro="title"/>
+          <text macro="year-date"/>
+          <text variable="publisher-place"/>
+          <text macro="license"/>
+          <text macro="availability"/>
+          <text macro="time_data"/>
+        </else-if>
+        <else-if type="post-weblog post webpage" match="any">
+          <text macro="title"/>
+          <text macro="publisher_block"/>
+          <text macro="license"/>
+          <text macro="archived_copy"/>
+          <text macro="availability"/>
+          <text macro="time_data"/>
+        </else-if>
+        <else>
+          <group suffix=".">
+            <text macro="title" prefix=" "/>
+            <text macro="editor" prefix=" "/>
+          </group>
+          <group delimiter=", ">
+            <text macro="publisher"/>
+            <text macro="year-date"/>
+          </group>
+          <text macro="pages"/>
+          <text macro="notes"/>
+          <text macro="license"/>
+          <text macro="availability"/>
+          <text macro="time_data"/>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>

--- a/iso690-2021-numeric-brackets-en.csl
+++ b/iso690-2021-numeric-brackets-en.csl
@@ -350,7 +350,7 @@
         <else-if type="patent">
           <text macro="title"/>
           <text macro="year-date"/>
-          <text variable="publisher-place"/>
+          <text variable="publisher-place" suffix=". "/>
           <text macro="license"/>
           <text macro="availability"/>
           <text macro="time_data"/>

--- a/iso690-2021-numeric-brackets-en.csl
+++ b/iso690-2021-numeric-brackets-en.csl
@@ -1,8 +1,8 @@
-﻿
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" et-al-min="6" et-al-use-first="5" page-range-format="expanded" default-locale="en-US">
   <info>
     <title>ISO-690:2021 (numeric, brackets, English)</title>
+    <title-short>ISO-690:2021 [numeric] EN</title-short>
     <title-short>ISO-690:2021 [numeric] EN</title-short>
     <id>http://www.zotero.org/styles/iso690-2021-numeric-brackets-en</id>
     <link href="http://www.zotero.org/styles/iso690-2021-numeric-brackets-en" rel="self"/>

--- a/iso690-2021-numeric-brackets-en.csl
+++ b/iso690-2021-numeric-brackets-en.csl
@@ -1,4 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿
+<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" et-al-min="6" et-al-use-first="5" page-range-format="expanded" default-locale="en-US">
   <info>
     <title>ISO-690:2021 (numeric, brackets, English)</title>
@@ -118,9 +119,9 @@
         <group prefix=" [" suffix="]. ">
           <text term="accessed" text-case="lowercase" suffix=" "/>
           <date variable="accessed">
-            <date-part name="year" suffix="-" range-delimiter="–"/>
-            <date-part name="month" suffix="-" form="numeric-leading-zeros" range-delimiter="–"/>
-            <date-part name="day" form="numeric-leading-zeros" range-delimiter="–"/>
+            <date-part name="year" suffix="-" range-delimiter="&#8211;"/>
+            <date-part name="month" suffix="-" form="numeric-leading-zeros" range-delimiter="&#8211;"/>
+            <date-part name="day" form="numeric-leading-zeros" range-delimiter="&#8211;"/>
           </date>
         </group>
       </if>
@@ -174,7 +175,7 @@
     <choose>
       <if variable="issued">
         <date variable="issued">
-          <date-part name="year" suffix=". " range-delimiter="–"/>
+          <date-part name="year" suffix=". " range-delimiter="&#8211;"/>
         </date>
       </if>
       <else>
@@ -251,15 +252,15 @@
   </macro>
   <macro name="issue">
     <group delimiter=", ">
-      <group delimiter=" ">
+      <group delimiter="&#160;">
         <label variable="volume" form="short"/>
         <text variable="volume"/>
       </group>
-      <group delimiter=" ">
+      <group delimiter="&#160;">
         <label variable="issue" form="short"/>
         <text variable="issue"/>
       </group>
-      <group delimiter=" ">
+      <group delimiter="&#160;">
         <label variable="page" form="short"/>
         <text variable="page"/>
       </group>

--- a/iso690-2021-numeric-brackets-en.csl
+++ b/iso690-2021-numeric-brackets-en.csl
@@ -325,10 +325,12 @@
           <text macro="edition"/>
           <text macro="publisher_block"/>
           <text macro="pages"/>
-          <text macro="isbn"/>
-          <text macro="license"/>
-          <text macro="availability"/>
-          <text macro="time_data"/>
+          <group delimiter=" ">
+            <text macro="isbn"/>
+            <text macro="license"/>
+            <text macro="availability"/>
+            <text macro="time_data"/>
+          </group>
         </else-if>
         <else-if type="paper-conference">
           <text macro="title"/>

--- a/iso690-2021-numeric-brackets-en.csl
+++ b/iso690-2021-numeric-brackets-en.csl
@@ -364,9 +364,9 @@
           <text macro="time_data"/>
         </else-if>
         <else>
-          <group suffix=".">
-            <text macro="title" prefix=" "/>
-            <text macro="editor" prefix=" "/>
+          <group delimiter=" " suffix=".">
+            <text macro="title"/>
+            <text macro="editor"/>
           </group>
           <group delimiter=", ">
             <text macro="publisher"/>

--- a/iso690-2021-numeric-brackets-en.csl
+++ b/iso690-2021-numeric-brackets-en.csl
@@ -3,7 +3,6 @@
   <info>
     <title>ISO-690:2021 (numeric, brackets, English)</title>
     <title-short>ISO-690:2021 [numeric] EN</title-short>
-    <title-short>ISO-690:2021 [numeric] EN</title-short>
     <id>http://www.zotero.org/styles/iso690-2021-numeric-brackets-en</id>
     <link href="http://www.zotero.org/styles/iso690-2021-numeric-brackets-en" rel="self"/>
     <link href="http://www.zotero.org/styles/iso690-numeric-en" rel="template"/>


### PR DESCRIPTION
Added a new independent style variant for ISO 690:2021 in English with numeric citations in square brackets.
This style is derived from the existing ISO 690 numeric English style and includes explicit metadata and behavior for the bracketed numeric variant.

**Key updates included:**
- New variant identity in title, file slug, ID and self link
- Template lineage link to ISO 690 numeric English style
- ISO 690:2021-focused formatting updates across references
- DOI precedence over URL for access location
- Improved online source handling including viewed date placement
- Expanded handling for modern digital resources (software, datasets, version, license, archived copy)
- Locale term adjustments and robust fallback behavior for missing metadata

**Validation:**
Style validates with no schema errors

**Checklist:**
- [x] Added template link
- [x] Added documentation link
- [x] Added author metadata
- [x] Used terms/labels where appropriate
- [x] Kept line 1 unchanged