### PR TITLE
Update historia-scribere.csl

### DIFF
--- a/historia-scribere.csl
+++ b/historia-scribere.csl
@@ -1,449 +1,246 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" delimiter-precedes-et-al="never" delimiter-precedes-last="always" default-locale="de-AT">
-  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>historia-scribere (Deutsch)</title>
-    <id>http://www.zotero.org/styles/historia-scribere</id>
-    <link href="http://www.zotero.org/styles/historia-scribere" rel="self"/>
-    <link href="http://www.zotero.org/styles/metropol-verlag" rel="template"/>
+    <title>historia.scribere (Deutsch) 2026</title>
+    <id>http://www.zotero.org/styles/historiascribere-2026</id>
+    <link href="http://www.zotero.org/styles/historiascribere" rel="template"/>
     <link href="https://historia.scribere.at/" rel="documentation"/>
-    <link href="https://www.uibk.ac.at/zeitgeschichte/images/zitierrichtlinien_hs2019.pdf" rel="documentation"/>
+    <link href="https://fileshare.uibk.ac.at/f/b898e83813eb45039f86/" rel="documentation"/>
     <author>
-      <name>Patrick O'Brien, PhD</name>
+      <name>Eva Pfanzelter</name>
+    </author>
+    <author>
+      <name>Alexander Renner</name>
     </author>
     <category citation-format="note"/>
     <category field="history"/>
-    <eissn>2073-8927</eissn>
-    <updated>2021-11-26T10:19:37+00:00</updated>
+    <updated>2026-01-24T01:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
     <terms>
-      <term name="interviewer" form="verb">Interview geführt von</term>
-      <term name="letter">Schreiben</term>
-      <term name="number-of-volumes" form="short">Bd.</term>
-      <term name="no date" form="short">o. D.</term>
       <term name="ibid" form="long">ebenda</term>
-      <term name="issue" form="long">Heft</term>
       <term name="accessed">eingesehen</term>
+      <term name="et-al">u. a.</term>
+      <term name="editor" form="short">Hrsg.</term>
+      <term name="interviewer" form="verb">Interview geführt von</term>
+      <term name="reviewed-author">Rezension zu</term>
+      <term name="issue" form="short">Nr.</term>
     </terms>
   </locale>
-  <macro name="subsequent-reference">
-    <choose>
-      <if match="any" type="article">
-        <group delimiter=", ">
-          <text macro="archive-location"/>
-          <text macro="locator"/>
-        </group>
-      </if>
-      <else>
-        <group delimiter=", ">
-          <group delimiter=", ">
-            <text macro="creator-for-subsequent"/>
-            <text macro="identifier-for-subsequent"/>
-          </group>
-          <text macro="locator"/>
-        </group>
-      </else>
-    </choose>
-  </macro>
   <macro name="creator">
     <names variable="author">
-      <name delimiter="/" et-al-min="4" et-al-use-first="3"/>
-      <label form="short" text-case="capitalize-first" prefix=" (" suffix=")"/>
+      <name delimiter="/" et-al-min="4" et-al-use-first="1"/>
+      <label form="short" prefix=" (" suffix=")"/>
       <substitute>
         <names variable="editor"/>
         <names variable="composer"/>
-        <names variable="director"/>
       </substitute>
     </names>
   </macro>
   <macro name="creator-bib">
     <names variable="author">
       <name delimiter="/" et-al-min="4" et-al-use-first="3" name-as-sort-order="all"/>
-      <label form="short" text-case="capitalize-first" prefix=" (" suffix=")"/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="composer"/>
-        <names variable="director"/>
-      </substitute>
-    </names>
-  </macro>
-  <macro name="creator-for-subsequent">
-    <names variable="author">
-      <name form="short" et-al-min="4" et-al-use-first="1"/>
       <label form="short" prefix=" (" suffix=")"/>
       <substitute>
         <names variable="editor"/>
-        <names variable="composer"/>
-        <names variable="director"/>
       </substitute>
     </names>
   </macro>
   <macro name="title">
-    <text variable="title"/>
-  </macro>
-  <macro name="identifier-for-subsequent">
     <choose>
-      <if variable="title title-short" match="any">
-        <text variable="title" form="short"/>
+      <if type="graphic">
+        <text variable="title" font-style="italic"/>
       </if>
-      <else-if type="personal_communication">
+      <else-if type="review">
         <group delimiter=" ">
-          <text term="letter"/>
-          <names variable="recipient">
-            <label form="verb" prefix=" " suffix=" "/>
-            <name et-al-min="2" et-al-use-first="1"/>
+          <text term="reviewed-author"/>
+          <text variable="reviewed-title" font-style="italic"/>
+        </group>
+      </else-if>
+      <else-if type="interview">
+        <group delimiter=", ">
+          <text variable="title"/>
+          <names variable="interviewer">
+            <label form="verb" suffix=" "/>
+            <name delimiter="/"/>
           </names>
         </group>
       </else-if>
-      <else-if type="interview">
-        <names variable="interviewer" delimiter=", ">
-          <label form="verb" prefix=" " suffix=" "/>
-          <name et-al-min="2" et-al-use-first="1"/>
-        </names>
-      </else-if>
-      <else-if type="report song broadcast motion_picture webpage post post-weblog" match="any">
-        <text variable="collection-title"/>
-        <text variable="container-title"/>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="in">
-    <choose>
-      <if type="chapter paper-conference entry-encyclopedia entry-dictionary article-magazine article-newspaper article-journal" match="any">
-        <text term="in"/>
-      </if>
-    </choose>
-  </macro>
-  <macro name="container-creator">
-    <choose>
-      <if type="chapter paper-conference" match="any">
-        <names variable="editor">
-          <name delimiter="/" et-al-min="4" et-al-use-first="3"/>
-          <label form="short" text-case="capitalize-first" prefix=" (" suffix=")"/>
-          <substitute>
-            <names variable="container-author"/>
-            <names variable="collection-editor"/>
-          </substitute>
-        </names>
-      </if>
-    </choose>
-  </macro>
-  <macro name="container-information">
-    <choose>
-      <if type="chapter paper-conference entry-encyclopedia entry-dictionary" match="any">
-        <text variable="container-title" font-style="normal"/>
-      </if>
-      <else-if type="report song broadcast motion_picture webpage post post-weblog" match="any">
-        <group delimiter=", ">
-          <text variable="genre"/>
-          <text variable="collection-title"/>
-          <text variable="container-title"/>
-        </group>
-      </else-if>
-      <else-if type="article-newspaper article-magazine article-journal" match="any">
-        <text variable="container-title" font-style="italic"/>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="journal-volume">
-    <choose>
-      <if type="article-journal">
-        <group delimiter=" ">
-          <number variable="volume"/>
-          <group delimiter=", ">
-            <date date-parts="year" form="text" variable="issued" prefix="(" suffix=")"/>
-            <group delimiter=" ">
-              <label variable="issue"/>
-              <number variable="issue"/>
-            </group>
-          </group>
-        </group>
-      </if>
-      <else-if type="report song broadcast" match="any">
-        <number variable="number"/>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="volumes">
-    <choose>
-      <if type="book chapter entry-encyclopedia entry-dictionary song motion_picture" match="any">
-        <group delimiter=" ">
-          <label text-case="capitalize-first" variable="volume" form="short"/>
-          <number text-case="capitalize-first" variable="volume"/>
-        </group>
-      </if>
-    </choose>
-  </macro>
-  <macro name="type-description">
-    <choose>
-      <if type="manuscript thesis speech" match="any">
-        <text variable="genre"/>
-      </if>
-      <else-if type="personal_communication">
-        <group delimiter=", ">
-          <group delimiter=" ">
-            <text term="letter"/>
-            <names variable="recipient">
-              <label form="verb" prefix=" " suffix=" "/>
-              <name and="text" delimiter-precedes-last="never"/>
-            </names>
-          </group>
-          <text variable="genre"/>
-        </group>
-      </else-if>
-      <else-if type="interview">
-        <names variable="interviewer" delimiter=", ">
-          <label form="verb" prefix=" " suffix=" "/>
-          <name and="text" delimiter-precedes-last="never"/>
-        </names>
-      </else-if>
-      <else-if type="motion_picture song broadcast" match="any">
-        <group delimiter=", ">
-          <text variable="medium"/>
-          <text variable="dimensions"/>
-        </group>
-      </else-if>
-      <else-if type="book">
-        <choose>
-          <if variable="version medium" match="any">
-            <group delimiter=", ">
-              <group delimiter=" ">
-                <text term="version"/>
-                <text variable="version"/>
-              </group>
-              <text variable="medium"/>
-            </group>
-          </if>
-        </choose>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="alt-publisher">
-    <choose>
-      <if type="book chapter paper-conference entry-dictionary entry-encyclopedia" match="none">
-        <text variable="publisher"/>
-      </if>
-    </choose>
-  </macro>
-  <macro name="place">
-    <choose>
-      <if type="speech">
-        <group delimiter=", ">
-          <text variable="event"/>
-          <text variable="event-place"/>
-        </group>
-      </if>
-      <else-if type="article-magazine article-newspaper" match="any"/>
       <else>
-        <text variable="publisher-place"/>
+        <text variable="title"/>
       </else>
     </choose>
   </macro>
-  <macro name="date">
+  <macro name="container">
     <choose>
-      <if type="article-journal" match="none">
-        <choose>
-          <if type="book chapter paper-conference thesis" match="any">
-            <choose>
-              <if variable="issued">
-                <text macro="edition"/>
-                <date variable="issued" form="numeric" date-parts="year"/>
-              </if>
-              <else>
-                <text term="no date" form="short"/>
-              </else>
-            </choose>
-          </if>
-          <else-if type="article-newspaper article-magazine graphic entry-encyclopedia entry-dictionary report speech interview manuscript personal_communication" match="any">
-            <choose>
-              <if variable="issued">
-                <date form="numeric" variable="issued"/>
-              </if>
-              <else>
-                <text term="no date" form="short"/>
-              </else>
-            </choose>
-          </else-if>
-          <else-if type="webpage post-weblog" match="any">
-            <date variable="issued">
-              <date-part name="day" suffix=". "/>
-              <date-part name="month" form="numeric" suffix=". "/>
-              <date-part name="year"/>
-            </date>
-          </else-if>
-        </choose>
-      </if>
-    </choose>
-  </macro>
-  <macro name="pages">
-    <group delimiter=", ">
-      <group delimiter=" ">
-        <label variable="page" form="short"/>
-        <text variable="page"/>
-      </group>
-      <text macro="locator"/>
-    </group>
-  </macro>
-  <macro name="locator">
-    <group delimiter=" ">
-      <text value="hier"/>
-      <label variable="locator" form="short"/>
-      <text variable="locator"/>
-    </group>
-  </macro>
-  <macro name="book-series">
-    <choose>
-      <if type="book chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
-        <group delimiter=", " prefix="(" suffix=")">
-          <text variable="collection-title"/>
-          <group delimiter=" ">
-            <label text-case="capitalize-first" variable="collection-number" form="short"/>
-            <text variable="collection-number"/>
-          </group>
+      <if type="chapter paper-conference" match="any">
+        <group delimiter=", " prefix="in: ">
+          <names variable="editor">
+            <name delimiter="/" et-al-min="4" et-al-use-first="3"/>
+            <label form="short" prefix=" (" suffix=")"/>
+          </names>
+          <text variable="container-title"/>
         </group>
       </if>
+      <else-if type="article-journal article-newspaper article-magazine" match="any">
+        <group delimiter=", " prefix="in: ">
+          <text variable="container-title" font-style="italic"/>
+          <choose>
+            <if type="article-journal">
+              <group delimiter=" ">
+                <number variable="volume"/>
+                <date variable="issued" prefix="(" suffix=")">
+                  <date-part name="year"/>
+                </date>
+                <number variable="issue" prefix=", "/>
+              </group>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text term="issue" form="short"/>
+                <text variable="issue"/>
+              </group>
+              <date variable="issued" form="numeric"/>
+            </else>
+          </choose>
+        </group>
+      </else-if>
     </choose>
   </macro>
-  <macro name="artwork-description">
+  <macro name="imprint">
     <choose>
       <if type="graphic">
         <group delimiter=", ">
-          <text variable="medium"/>
-          <text variable="dimensions"/>
+          <text variable="publisher-place"/>
+          <text variable="archive_location"/>
+        </group>
+      </if>
+      <else-if type="manuscript article" match="any">
+        <group delimiter=", ">
+          <text variable="archive"/>
+          <text variable="archive_location"/>
+          <date variable="issued" form="numeric"/>
+        </group>
+      </else-if>
+      <else-if type="thesis">
+        <group delimiter=", ">
           <text variable="genre"/>
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </group>
+      </else-if>
+      <else-if type="article-journal article-newspaper article-magazine" match="none">
+        <group delimiter=" ">
+          <group delimiter=": ">
+            <text variable="publisher-place"/>
+            <text variable="publisher"/>
+          </group>
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="identifiers">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI">
+          <text variable="DOI" prefix="[DOI " suffix="]"/>
+        </if>
+        <else-if variable="ISBN">
+          <text variable="ISBN" prefix="[ISBN " suffix="]"/>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="DOI" match="none">
+        <group delimiter=", ">
+          <text variable="URL"/>
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date variable="accessed" form="numeric"/>
+          </group>
+        </group>
+      </if>
+      <else>
+        <text variable="URL"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locator">
+    <choose>
+      <if variable="locator">
+        <group delimiter=" ">
+          <text term="cited"/>
+          <label variable="locator" form="short"/>
+          <text variable="locator"/>
         </group>
       </if>
     </choose>
   </macro>
-  <macro name="archive-location">
-    <group delimiter=", ">
-      <text variable="archive"/>
-      <text variable="archive_location"/>
-      <text variable="call-number"/>
-    </group>
-  </macro>
-  <macro name="url-web-documents-only">
-    <choose>
-      <if type="webpage post post-weblog" match="any">
-        <text macro="url"/>
-      </if>
-    </choose>
-  </macro>
-  <macro name="url">
-    <group delimiter=", ">
-      <text variable="URL"/>
-      <group delimiter=" ">
-        <text term="accessed"/>
-        <date variable="accessed">
-          <date-part name="day" suffix="."/>
-          <date-part name="month" form="numeric" suffix="."/>
-          <date-part name="year"/>
-        </date>
-      </group>
-    </group>
-  </macro>
-  <macro name="edition">
-    <number vertical-align="sup" variable="edition" form="ordinal"/>
-  </macro>
   <citation>
-    <layout delimiter="; " suffix=".">
+    <layout suffix="." delimiter="; ">
       <choose>
-        <if position="ibid-with-locator">
+        <if position="ibid">
           <group delimiter=", ">
             <text term="ibid"/>
             <text macro="locator"/>
           </group>
         </if>
-        <else-if position="ibid">
-          <text term="ibid"/>
-        </else-if>
         <else-if position="subsequent">
-          <text macro="subsequent-reference"/>
+          <group delimiter=", ">
+            <text macro="creator"/>
+            <text variable="title" form="short"/>
+            <text macro="locator"/>
+          </group>
         </else-if>
         <else>
-          <choose>
-            <if type="article" match="any">
-              <text macro="archive-location"/>
-            </if>
-            <else>
-              <group delimiter=", ">
-                <group delimiter=", ">
-                  <text macro="creator"/>
-                  <group delimiter=", ">
-                    <text macro="title"/>
-                    <group delimiter=", ">
-                      <group delimiter=": ">
-                        <text macro="in"/>
-                        <text macro="container-creator"/>
-                        <group delimiter=", ">
-                          <group delimiter=" ">
-                            <text macro="container-information"/>
-                            <text macro="journal-volume"/>
-                          </group>
-                          <text macro="volumes"/>
-                        </group>
-                      </group>
-                    </group>
-                    <text macro="type-description"/>
-                  </group>
-                </group>
-                <text macro="alt-publisher"/>
-                <group delimiter=" ">
-                  <text macro="place"/>
-                  <group delimiter=", ">
-                    <text macro="date"/>
-                  </group>
-                  <date variable="original-date" form="text" prefix="[" suffix="]"/>
-                  <text macro="book-series"/>
-                </group>
-                <text macro="artwork-description"/>
-                <text macro="pages"/>
-                <text macro="url-web-documents-only"/>
-              </group>
-            </else>
-          </choose>
+          <group delimiter=", ">
+            <text macro="creator"/>
+            <text macro="title"/>
+            <text macro="container"/>
+            <group delimiter=" " prefix="(" suffix=")">
+              <text variable="collection-title"/>
+              <text variable="collection-number"/>
+            </group>
+            <text macro="identifiers"/>
+            <text macro="imprint"/>
+            <text macro="access"/>
+            <text macro="locator"/>
+          </group>
         </else>
       </choose>
     </layout>
   </citation>
   <bibliography hanging-indent="true">
     <sort>
-      <key macro="creator-bib" names-min="3" names-use-first="3"/>
+      <key macro="creator-bib"/>
       <key variable="issued" sort="descending"/>
     </sort>
     <layout suffix=".">
       <group delimiter=", ">
-        <group delimiter=", ">
-          <text macro="creator-bib"/>
-          <group delimiter=", ">
-            <text macro="title"/>
-            <group delimiter=": ">
-              <text macro="in"/>
-              <text macro="container-creator"/>
-            </group>
-            <group delimiter=", ">
-              <group delimiter=" ">
-                <text macro="container-information"/>
-                <text macro="journal-volume"/>
-              </group>
-              <text macro="volumes"/>
-            </group>
-            <text macro="type-description"/>
-          </group>
+        <text macro="creator-bib"/>
+        <text macro="title"/>
+        <text macro="container"/>
+        <group delimiter=" " prefix="(" suffix=")">
+          <text variable="collection-title"/>
+          <text variable="collection-number"/>
         </group>
-        <text macro="alt-publisher"/>
-        <group delimiter=" ">
-          <text macro="place"/>
-          <text macro="date"/>
-          <date variable="original-date" form="text" prefix="[" suffix="]"/>
-          <text macro="book-series"/>
-        </group>
-        <text macro="artwork-description"/>
-        <text macro="archive-location"/>
-        <text macro="pages"/>
-        <text macro="url-web-documents-only"/>
+        <text macro="identifiers"/>
+        <text macro="imprint"/>
+        <choose>
+          <if type="article-journal chapter article-newspaper" match="any">
+            <text variable="page" prefix="S. "/>
+          </if>
+        </choose>
+        <text macro="access"/>
       </group>
     </layout>
   </bibliography>


### PR DESCRIPTION
The 2026 version of the historia.scribere style is a massive update of the original

## CSL Styles Pull Request Template
You're about to create a pull request to the CSL **styles** repository.  
If you haven't done so already, see <https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md> for instructions on how to contribute, and <https://github.com/citation-style-language/styles/blob/master/STYLE_REQUIREMENTS.md> for the requirements a style must meet before acceptance.  
In addition, please fill out the pull request template below.


### Description
ISBN, DOI and other persistent identifiers added, many new media-formats added.


### Checklist
- [x] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [x] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [ ] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [ ] Check that you've not used `<text value="...` if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.
