### PR TITLE
Update suomen-laakarilehti.csl (documentation link)

### DIFF
--- a/dependent/suomen-laakarilehti.csl
+++ b/dependent/suomen-laakarilehti.csl
@@ -13,7 +13,7 @@
     <category citation-format="numeric"/>
     <category field="medicine"/>
     <issn>0039-5560</issn>
-    <updated>2012-09-09T21:58:08+00:00</updated>
+    <updated>2026-04-28T21:58:08+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
 </style>

--- a/dependent/suomen-laakarilehti.csl
+++ b/dependent/suomen-laakarilehti.csl
@@ -5,7 +5,7 @@
     <id>http://www.zotero.org/styles/suomen-laakarilehti</id>
     <link href="http://www.zotero.org/styles/suomen-laakarilehti" rel="self"/>
     <link href="http://www.zotero.org/styles/nlm-citation-sequence" rel="independent-parent"/>
-    <link href="http://www.laakarilehti.fi/kirjoittaja/instructions_to_authors_2010.html#9" rel="documentation"/>
+    <link href="https://www.laakarilehti.fi/kirjoitusohjeet/kirjallisuusviitteet/" rel="documentation"/>
     <category citation-format="numeric"/>
     <category field="medicine"/>
     <issn>0039-5560</issn>

--- a/dependent/suomen-laakarilehti.csl
+++ b/dependent/suomen-laakarilehti.csl
@@ -6,6 +6,10 @@
     <link href="http://www.zotero.org/styles/suomen-laakarilehti" rel="self"/>
     <link href="http://www.zotero.org/styles/nlm-citation-sequence" rel="independent-parent"/>
     <link href="https://www.laakarilehti.fi/kirjoitusohjeet/kirjallisuusviitteet/" rel="documentation"/>
+    <contributor>
+      <name>Shiyu Wang</name>
+      <email>shiyu.wang@student.jamk.fi</email>
+    </contributor>
     <category citation-format="numeric"/>
     <category field="medicine"/>
     <issn>0039-5560</issn>


### PR DESCRIPTION
### Description

The old documentation link to the Journal's style guide is no longer accessible.  I found a working link in Finnish.

