### PR TITLE
Update bluebook-law-review.csl

### DIFF
--- a/bluebook-law-review.csl
+++ b/bluebook-law-review.csl
@@ -23,6 +23,10 @@
       <name>Shay Elbaum</name>
       <email>selbaum@law.harvard.edu</email>
     </contributor>
+    <contributor>
+      <name>Daniel Epps</name>
+      <email>epps@wustl.edu</email>
+    </contributor>
     <category citation-format="note"/>
     <category field="law"/>
     <summary>The Bluebook legal citation style for law reviews.</summary>
@@ -67,7 +71,7 @@
   </macro>
   <macro name="name-short-macro">
     <names variable="author">
-      <name form="short" and="text" delimiter=", "/>
+      <name form="short" and="symbol" delimiter=", " delimiter-precedes-last="never"/>
       <substitute>
         <text variable="title" form="short"/>
       </substitute>
@@ -91,7 +95,7 @@
   </macro>
   <macro name="editor-translator">
     <names variable="editor translator" delimiter=", ">
-      <name and="symbol" delimiter=", "/>
+      <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
       <label form="short" strip-periods="false" prefix=" "/>
     </names>
   </macro>


### PR DESCRIPTION
## Problem

Two related defects in `bluebook-law-review.csl` cause 3+ author short cites
and 3+ editor full cites to render with separators that don't match Bluebook
author-list convention.

For a three-author short cite of a book, the current output is:

> SMITH, JONES, AND BROWN, *supra* note 7

Bluebook author-list convention is "A, B & C" — no Oxford comma before the
ampersand, and "&" rather than "and". Expected:

> SMITH, JONES & BROWN, *supra* note 7

The same Oxford-comma defect affects 3+ editor lists in full cites via the
`editor-translator` macro.

## Cause

- `name-short-macro` (line 70) uses `and="text"` and omits
  `delimiter-precedes-last="never"`, so it falls back to CSL's `contextual`
  default — inserting a comma before the connector when there are 3+ names.
- `editor-translator` (line 94) also omits `delimiter-precedes-last="never"`,
  with the same effect on 3+ editor lists.

## Why this is uncontroversial

The global `name-macro` in this file (line 41) already specifies
`and="symbol" delimiter-precedes-last="never"`, so full author cites
render correctly. The sibling style `bluebook-inline.csl` already
uses `and="symbol"` in its short-cite `<name>` elements (lines 40, 47).
This PR brings the two stragglers in `bluebook-law-review.csl` into
alignment with the file's own global convention.

Note: `bluebook-inline.csl` is missing `delimiter-precedes-last="never"`
on the same short-cite `<name>` elements and produces the same
Oxford-comma defect for 3+ author short cites; a follow-up PR will
address that.

## Scope

- Only affects rendering of name lists with 3 or more names. 1- and 2-name
  cites are unchanged.
- No schema impact; both attributes are standard CSL.
- No new variables consumed; no item-type behavior changes.