### PR TITLE
Update bluebook-inline.csl

### DIFF
--- a/bluebook-inline.csl
+++ b/bluebook-inline.csl
@@ -17,6 +17,10 @@
       <name>Nancy Sims</name>
       <email>nsims@umich.edu</email>
     </contributor>
+    <contributor>
+      <name>Daniel Epps</name>
+      <email>epps@wustl.edu</email>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="law"/>
     <summary>Bluebook citation formatting for in-text citations.</summary>
@@ -37,14 +41,14 @@
         <group delimiter=" ">
           <text variable="volume"/>
           <names variable="author" font-variant="small-caps">
-            <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
+            <name form="short" and="symbol" delimiter=", " initialize-with=". " delimiter-precedes-last="never"/>
           </names>
         </group>
       </else-if>
       <else>
         <group delimiter=" ">
           <names variable="author">
-            <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
+            <name form="short" and="symbol" delimiter=", " initialize-with=". " delimiter-precedes-last="never"/>
           </names>
         </group>
       </else>


### PR DESCRIPTION
## Problem

In `bluebook-inline.csl`, short cites with 3 or more authors render with
an Oxford comma before the ampersand:

> Smith, Jones, & Brown, *supra* note 7

Bluebook author-list convention is "A, B & C" — no comma before the
ampersand. Expected:

> Smith, Jones & Brown, *supra* note 7

## Cause

The two short-cite `<name>` elements (lines 40, 47) omit
`delimiter-precedes-last="never"`, so they fall back to CSL's
`contextual` default — inserting a comma before the connector when
there are 3+ names.

The other four `<name>` elements in this file (lines 73, 104, 118, 135)
already specify `delimiter-precedes-last="never"`. The two short-cite
elements are the only ones missing the attribute.

## Why this is uncontroversial

This brings the two short-cite `<name>` elements into alignment with the
file's own convention used everywhere else.

Companion to PR #8160, which fixes the same defect (plus an
`and="text"` → `and="symbol"` correction that doesn't apply here) in
`bluebook-law-review.csl`.

## Scope

- Only affects rendering of short cites with 3 or more names. 1- and
  2-name cites are unchanged.
- No schema impact; `delimiter-precedes-last` is a standard CSL attribute.
- No new variables consumed; no item-type behavior changes.