### PR TITLE
Update bluebook-law-review.csl

### DIFF
--- a/bluebook-law-review.csl
+++ b/bluebook-law-review.csl
@@ -23,6 +23,10 @@
       <name>Shay Elbaum</name>
       <email>selbaum@law.harvard.edu</email>
     </contributor>
+    <contributor>
+      <name>Daniel Epps</name>
+      <email>epps@wustl.edu</email>
+    </contributor>
     <category citation-format="note"/>
     <category field="law"/>
     <summary>The Bluebook legal citation style for law reviews.</summary>
@@ -362,8 +366,10 @@
                 <group delimiter=" ">
                   <text value="supra" font-style="italic"/>
                   <text value="note"/>
-                  <text variable="first-reference-note-number"/>
-                  <text macro="at_page"/>
+                  <group delimiter=", ">
+                    <text variable="first-reference-note-number"/>
+                    <text macro="at_page"/>
+                  </group>
                 </group>
               </group>
             </else>


### PR DESCRIPTION
## Problem

In `subsequent` position, short cites with a pincite render as:

> Smith, *supra* note 7 at 12

Standard Bluebook short-form practice puts a comma between the
"*supra* note N" reference and the "at X" pincite:

> Smith, *supra* note 7, at 12

## Cause

The `<group delimiter=" ">` in the `subsequent`/`else` branch (lines
362–367) joins `first-reference-note-number` and `at_page` with a single
space, producing "note 7 at 12" rather than "note 7, at 12".

## Fix

Wrap `first-reference-note-number` and the `at_page` macro in an inner
`<group delimiter=", ">` so the comma is inserted only when the pincite
is present.

## Scope

- Only affects subsequent cites that include a `locator`. When no locator
  is present, `at_page` renders empty, the inner group is suppressed, and
  output is unchanged ("Smith, *supra* note 7").
- No schema impact; pure structural change.
- No new variables consumed; no item-type behavior changes.