### PR TITLE
Update rmit-university-harvard.csl

### DIFF
--- a/rmit-university-harvard.csl
+++ b/rmit-university-harvard.csl
@@ -138,6 +138,21 @@
       </substitute>
     </names>
   </macro>
+  <macro name="author-short-newspaper">
+    <choose>
+      <if variable="author">
+        <names variable="author">
+          <name form="short" and="text" delimiter=", " delimiter-precedes-last="never" initialize-with=". "/>
+        </names>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text variable="container-title"/>
+          <text macro="issued-date-full"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
   <macro name="access">
     <choose>
       <if variable="URL" type="article-newspaper document report speech webpage post post-weblog" match="any">
@@ -222,14 +237,21 @@
   </macro>
   <macro name="newspaper-webpage">
     <choose>
-      <if type="article-newspaper">
-        <group prefix=" " delimiter=", ">
-          <date variable="issued" prefix="">
-            <date-part name="day" suffix=" "/>
-            <date-part name="month" suffix=""/>
-          </date>
+      <if variable="URL">
+        <group delimiter=". ">
+          <text macro="accessed-date"/>
+          <text variable="URL"/>
         </group>
       </if>
+      <else-if variable="archive">
+        <group delimiter=", " suffix=".">
+          <text macro="accessed-date"/>
+          <group delimiter=" ">
+            <text variable="archive"/>
+            <text value="database"/>
+          </group>
+        </group>
+      </else-if>
     </choose>
   </macro>
   <macro name="presentation">
@@ -280,6 +302,20 @@
     <choose>
       <if variable="issued">
         <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued-date-full">
+    <choose>
+      <if variable="issued">
+        <date variable="issued" form="text">
+          <date-part name="day"/>
+          <date-part name="month"/>
           <date-part name="year"/>
         </date>
       </if>
@@ -354,6 +390,19 @@
             <text variable="locator" prefix=":"/>
           </group>
         </if>
+        <else-if type="article-newspaper article-magazine" match="any">
+          <group>
+            <group delimiter=" ">
+              <text macro="author-short-newspaper"/>
+              <choose>
+                <if variable="author">
+                  <text macro="year-date"/>
+                </if>
+              </choose>
+            </group>
+            <text variable="locator" prefix=":"/>
+          </group>
+        </else-if>
         <else-if type="document webpage" match="any">
           <group>
             <group delimiter=" ">
@@ -388,6 +437,9 @@
         <if type="article-journal">
           <text macro="author-journal"/>
         </if>
+        <else-if type="article-newspaper article-magazine" match="any">
+          <text macro="author-journal"/>
+        </else-if>
         <else-if type="document webpage" match="any">
           <text macro="author-webpage"/>
         </else-if>
@@ -396,9 +448,12 @@
         </else>
       </choose>
       <choose>
-        <if type="document webpage" match="any">
-          <text macro="year-date" prefix=" (" suffix=")"/>
+        <if type="article-newspaper article-magazine" match="any">
+          <text macro="issued-date-full" prefix=" (" suffix=")"/>
         </if>
+        <else-if type="document webpage" match="any">
+          <text macro="year-date" prefix=" (" suffix=")"/>
+        </else-if>
         <else>
           <date variable="issued" prefix=" (" suffix=")">
             <date-part name="year"/>
@@ -424,6 +479,19 @@
             </else>
           </choose>
         </if>
+        <else-if type="article-newspaper article-magazine" match="any">
+          <text variable="title" quotes="true" prefix=" "/>
+          <group delimiter=", " prefix=", ">
+            <text variable="container-title" font-style="italic"/>
+            <text macro="newspaper-webpage"/>
+          </group>
+          <choose>
+            <if variable="URL archive" match="any"/>
+            <else>
+              <text value="."/>
+            </else>
+          </choose>
+        </else-if>
         <else-if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
           <group delimiter=" " prefix=" ">
             <text macro="title"/>
@@ -473,10 +541,9 @@
         </else>
       </choose>
       <choose>
-        <if type="article-journal"/>
+        <if type="article-journal article-newspaper article-magazine" match="any"/>
         <else>
           <text macro="presentation" prefix=", "/>
-          <text macro="newspaper-webpage" prefix=", "/>
           <text macro="access" prefix=", "/>
         </else>
       </choose>

--- a/rmit-university-harvard.csl
+++ b/rmit-university-harvard.csl
@@ -59,7 +59,7 @@
           <name/>
           <substitute>
             <choose>
-              <if type="webpage post post-weblog" match="any">
+              <if type="document webpage post post-weblog" match="any">
                 <text variable="title" strip-periods="true" font-style="italic"/>
               </if>
               <else-if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
@@ -97,9 +97,30 @@
       </else>
     </choose>
   </macro>
+  <macro name="author-webpage">
+    <names variable="author">
+      <name name-as-sort-order="all" and="text" sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-last="never"/>
+      <label form="short" prefix=" (" suffix=")"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="noauthor_title"/>
+      </substitute>
+    </names>
+  </macro>
   <macro name="author-short">
     <names variable="author">
       <name form="short" and="symbol" delimiter=", " delimiter-precedes-last="never" initialize-with=". "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="noauthor_title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short-webpage">
+    <names variable="author">
+      <name form="short" and="text" delimiter=", " delimiter-precedes-last="never" initialize-with=". " et-al-min="3" et-al-use-first="1"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -119,7 +140,7 @@
   </macro>
   <macro name="access">
     <choose>
-      <if variable="URL" type="article-newspaper report speech webpage post post-weblog" match="any">
+      <if variable="URL" type="article-newspaper document report speech webpage post post-weblog" match="any">
         <group delimiter=". ">
           <group delimiter=" " prefix=" ">
             <text term="accessed"/>
@@ -132,6 +153,22 @@
           <text variable="URL"/>
         </group>
       </if>
+    </choose>
+  </macro>
+  <macro name="webpage-source">
+    <choose>
+      <if variable="container-title">
+        <group delimiter=" ">
+          <text variable="container-title"/>
+          <text value="website"/>
+        </group>
+      </if>
+      <else-if variable="publisher">
+        <group delimiter=" ">
+          <text variable="publisher"/>
+          <text value="website"/>
+        </group>
+      </else-if>
     </choose>
   </macro>
   <macro name="accessed-date">
@@ -215,8 +252,15 @@
   </macro>
   <macro name="title">
     <choose>
-      <if type="webpage post post-weblog" match="any">
-        <text variable="title" strip-periods="true" font-style="italic"/>
+      <if type="document webpage post post-weblog" match="any">
+        <choose>
+          <if variable="title">
+            <text variable="title" strip-periods="true" font-style="italic"/>
+          </if>
+          <else-if type="webpage">
+            <text value="Homepage"/>
+          </else-if>
+        </choose>
       </if>
       <else-if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
         <text variable="title" strip-periods="false" font-style="italic" suffix=","/>
@@ -310,6 +354,15 @@
             <text variable="locator" prefix=":"/>
           </group>
         </if>
+        <else-if type="document webpage" match="any">
+          <group>
+            <group delimiter=" ">
+              <text macro="author-short-webpage"/>
+              <text macro="year-date"/>
+            </group>
+            <text variable="locator" prefix=":"/>
+          </group>
+        </else-if>
         <else>
           <group delimiter=", ">
             <group delimiter=" ">
@@ -335,13 +388,23 @@
         <if type="article-journal">
           <text macro="author-journal"/>
         </if>
+        <else-if type="document webpage" match="any">
+          <text macro="author-webpage"/>
+        </else-if>
         <else>
           <text macro="author"/>
         </else>
       </choose>
-      <date variable="issued" prefix=" (" suffix=")">
-        <date-part name="year"/>
-      </date>
+      <choose>
+        <if type="document webpage" match="any">
+          <text macro="year-date" prefix=" (" suffix=")"/>
+        </if>
+        <else>
+          <date variable="issued" prefix=" (" suffix=")">
+            <date-part name="year"/>
+          </date>
+        </else>
+      </choose>
       <choose>
         <if type="article-journal">
           <text variable="title" quotes="true" prefix=" "/>
@@ -384,7 +447,11 @@
             </group>
           </group>
         </else-if>
-        <else-if type="webpage post post-weblog" match="any">
+        <else-if type="document webpage" match="any">
+          <text macro="title" prefix=" "/>
+          <text macro="webpage-source" prefix=", "/>
+        </else-if>
+        <else-if type="post post-weblog" match="any">
           <text macro="title" prefix=" "/>
           <group delimiter=" " prefix=", ">
             <text variable="container-title"/>

--- a/rmit-university-harvard.csl
+++ b/rmit-university-harvard.csl
@@ -72,7 +72,7 @@
                   </else>
                 </choose>
               </else-if>
-              <else-if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
+              <else-if type="bill book dataset graphic legal_case legislation motion_picture report song thesis" match="any">
                 <text variable="title" strip-periods="true" font-style="italic"/>
               </else-if>
               <else>
@@ -133,6 +133,12 @@
         <text macro="noauthor_title"/>
       </substitute>
     </names>
+  </macro>
+  <macro name="author-report">
+    <group>
+      <text macro="author-book"/>
+      <text variable="authority" prefix=" (" suffix=")"/>
+    </group>
   </macro>
   <macro name="author-short">
     <names variable="author">
@@ -333,6 +339,54 @@
       </else>
     </choose>
   </macro>
+  <macro name="report-source">
+    <choose>
+      <if variable="container-title">
+        <group delimiter=" ">
+          <text variable="container-title"/>
+          <text value="website"/>
+        </group>
+      </if>
+      <else-if variable="publisher-place">
+        <text macro="publisher"/>
+      </else-if>
+      <else-if variable="publisher">
+        <group delimiter=" ">
+          <text variable="publisher"/>
+          <text value="website"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="report-access">
+    <choose>
+      <if variable="URL">
+        <group delimiter=". ">
+          <text macro="accessed-date"/>
+          <text variable="URL"/>
+        </group>
+      </if>
+      <else-if variable="archive">
+        <group delimiter=", " suffix=".">
+          <text macro="accessed-date"/>
+          <group delimiter=" ">
+            <text variable="archive"/>
+            <text value="database"/>
+          </group>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="dataset-format">
+    <choose>
+      <if variable="medium">
+        <text variable="medium" text-case="lowercase" prefix="[" suffix="]"/>
+      </if>
+      <else>
+        <text value="data set" prefix="[" suffix="]"/>
+      </else>
+    </choose>
+  </macro>
   <macro name="presentation">
     <choose>
       <if type="speech">
@@ -346,8 +400,18 @@
   </macro>
   <macro name="report-number">
     <choose>
-      <if type="report">
-        <text variable="number" suffix=","/>
+      <if type="report" variable="number" match="all">
+        <group delimiter=" ">
+          <choose>
+            <if variable="genre">
+              <text variable="genre" text-case="lowercase"/>
+            </if>
+            <else>
+              <text value="report number"/>
+            </else>
+          </choose>
+          <text variable="number"/>
+        </group>
       </if>
     </choose>
   </macro>
@@ -504,7 +568,7 @@
             <text variable="locator" prefix=":"/>
           </group>
         </else-if>
-        <else-if type="book chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
+        <else-if type="book chapter dataset entry-dictionary entry-encyclopedia paper-conference report" match="any">
           <group>
             <group delimiter=" ">
               <text macro="author-short-book"/>
@@ -554,6 +618,9 @@
         <else-if type="book chapter paper-conference" match="any">
           <text macro="author-book"/>
         </else-if>
+        <else-if type="report dataset" match="any">
+          <text macro="author-report"/>
+        </else-if>
         <else>
           <text macro="author"/>
         </else>
@@ -571,7 +638,7 @@
         <else-if type="article-newspaper article-magazine" match="any">
           <text macro="issued-date-full" prefix=" (" suffix=")"/>
         </else-if>
-        <else-if type="document webpage" match="any">
+        <else-if type="document webpage report dataset" match="any">
           <text macro="year-date" prefix=" (" suffix=")"/>
         </else-if>
         <else-if type="paper-conference">
@@ -661,7 +728,25 @@
             </if>
           </choose>
         </else-if>
-        <else-if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
+        <else-if type="report">
+          <group delimiter=", " prefix=" ">
+            <text variable="title" strip-periods="false" font-style="italic"/>
+            <text macro="report-number"/>
+            <text macro="report-source"/>
+            <text macro="report-access"/>
+          </group>
+        </else-if>
+        <else-if type="dataset">
+          <group delimiter=", " prefix=" ">
+            <group delimiter=" ">
+              <text variable="title" strip-periods="false" font-style="italic"/>
+              <text macro="dataset-format"/>
+            </group>
+            <text macro="webpage-source"/>
+            <text macro="report-access"/>
+          </group>
+        </else-if>
+        <else-if type="bill book graphic legal_case legislation motion_picture song thesis" match="any">
           <group delimiter=" " prefix=" ">
             <text macro="title"/>
             <text macro="report-number"/>
@@ -705,7 +790,7 @@
         </else>
       </choose>
       <choose>
-        <if type="article-journal article-newspaper article-magazine paper-conference" match="any"/>
+        <if type="article-journal article-newspaper article-magazine paper-conference report dataset" match="any"/>
         <else>
           <text macro="presentation" prefix=", "/>
           <text macro="access" prefix=", "/>

--- a/rmit-university-harvard.csl
+++ b/rmit-university-harvard.csl
@@ -10,9 +10,12 @@
       <name>Katie Finch</name>
       <email>library.systems@rmit.edu.au</email>
     </author>
+    <contributor>
+      <name>King Nguyen</name>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
-    <updated>2025-07-31T10:12:22+00:00</updated>
+    <updated>2026-04-29T10:12:22+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">

--- a/rmit-university-harvard.csl
+++ b/rmit-university-harvard.csl
@@ -62,9 +62,12 @@
           <name/>
           <substitute>
             <choose>
-              <if type="document webpage post post-weblog" match="any">
-                <text variable="title" strip-periods="true" font-style="italic"/>
+              <if type="post-weblog">
+                <text variable="container-title" strip-periods="true"/>
               </if>
+              <else-if type="document webpage post" match="any">
+                <text variable="title" strip-periods="true" font-style="italic"/>
+              </else-if>
               <else-if type="entry-dictionary entry-encyclopedia" match="any">
                 <choose>
                   <if variable="container-title">
@@ -137,6 +140,22 @@
       </substitute>
     </names>
   </macro>
+  <macro name="author-post">
+    <choose>
+      <if variable="author">
+        <names variable="author">
+          <name name-as-sort-order="all" and="text" sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-last="never"/>
+          <label form="short" prefix=" (" suffix=")"/>
+        </names>
+      </if>
+      <else-if variable="container-title">
+        <text variable="container-title"/>
+      </else-if>
+      <else>
+        <text macro="noauthor_title"/>
+      </else>
+    </choose>
+  </macro>
   <macro name="author-report">
     <group>
       <text macro="author-book"/>
@@ -198,6 +217,21 @@
         <text macro="noauthor_title"/>
       </substitute>
     </names>
+  </macro>
+  <macro name="author-short-post">
+    <choose>
+      <if variable="author">
+        <names variable="author">
+          <name form="short" and="text" delimiter=", " delimiter-precedes-last="never" initialize-with=". " et-al-min="3" et-al-use-first="1"/>
+        </names>
+      </if>
+      <else-if variable="container-title">
+        <text variable="container-title"/>
+      </else-if>
+      <else>
+        <text macro="noauthor_title"/>
+      </else>
+    </choose>
   </macro>
   <macro name="access">
     <choose>
@@ -390,6 +424,16 @@
       </else>
     </choose>
   </macro>
+  <macro name="social-media-format">
+    <choose>
+      <if variable="medium">
+        <text variable="medium" prefix="[" suffix="]"/>
+      </if>
+      <else-if variable="genre">
+        <text variable="genre" prefix="[" suffix="]"/>
+      </else-if>
+    </choose>
+  </macro>
   <macro name="presentation">
     <choose>
       <if type="speech">
@@ -571,6 +615,28 @@
             <text variable="locator" prefix=":"/>
           </group>
         </else-if>
+        <else-if type="post">
+          <group delimiter=" ">
+            <text macro="author-short-post"/>
+            <text macro="year-date"/>
+          </group>
+        </else-if>
+        <else-if type="post-weblog">
+          <choose>
+            <if variable="author">
+              <group delimiter=" ">
+                <text macro="author-short-post"/>
+                <text macro="year-date"/>
+              </group>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text variable="container-title"/>
+                <text macro="issued-date-full"/>
+              </group>
+            </else>
+          </choose>
+        </else-if>
         <else-if type="book chapter dataset entry-dictionary entry-encyclopedia paper-conference report" match="any">
           <group>
             <group delimiter=" ">
@@ -611,6 +677,9 @@
         <else-if type="document webpage" match="any">
           <text macro="author-webpage"/>
         </else-if>
+        <else-if type="post post-weblog" match="any">
+          <text macro="author-post"/>
+        </else-if>
         <else-if type="entry-dictionary entry-encyclopedia" match="any">
           <choose>
             <if variable="author">
@@ -643,6 +712,19 @@
         </else-if>
         <else-if type="document webpage report dataset" match="any">
           <text macro="year-date" prefix=" (" suffix=")"/>
+        </else-if>
+        <else-if type="post">
+          <text macro="issued-date-full" prefix=" (" suffix=")"/>
+        </else-if>
+        <else-if type="post-weblog">
+          <choose>
+            <if variable="author">
+              <text macro="issued-date-full" prefix=" (" suffix=")"/>
+            </if>
+            <else>
+              <text macro="issued-date-full" prefix=" (" suffix="),"/>
+            </else>
+          </choose>
         </else-if>
         <else-if type="paper-conference">
           <text macro="issued-date-full" prefix=" (" suffix=")"/>
@@ -772,10 +854,25 @@
           <text macro="webpage-source" prefix=", "/>
         </else-if>
         <else-if type="post post-weblog" match="any">
-          <text macro="title" prefix=" "/>
-          <group delimiter=" " prefix=", ">
-            <text variable="container-title"/>
-          </group>
+          <choose>
+            <if type="post">
+              <group delimiter=" " prefix=" ">
+                <text variable="title" prefix="'" suffix="'"/>
+                <text macro="social-media-format"/>
+              </group>
+              <group delimiter=", " prefix=", ">
+                <text variable="container-title"/>
+                <text macro="report-access"/>
+              </group>
+            </if>
+            <else-if type="post-weblog">
+              <text variable="title" prefix=" '" suffix="'"/>
+              <group delimiter=", " prefix=", ">
+                <text variable="container-title" font-style="italic"/>
+                <text macro="report-access"/>
+              </group>
+            </else-if>
+          </choose>
         </else-if>
         <else>
           <group suffix=",">
@@ -793,7 +890,7 @@
         </else>
       </choose>
       <choose>
-        <if type="article-journal article-newspaper article-magazine paper-conference report dataset" match="any"/>
+        <if type="article-journal article-newspaper article-magazine paper-conference post post-weblog report dataset" match="any"/>
         <else>
           <text macro="presentation" prefix=", "/>
           <text macro="access" prefix=", "/>

--- a/rmit-university-harvard.csl
+++ b/rmit-university-harvard.csl
@@ -20,6 +20,8 @@
   </info>
   <locale xml:lang="en">
     <terms>
+      <term name="article-locator">Article</term>
+      <term name="dataset">data set</term>
       <term name="editor" form="short">
         <single>ed.</single>
         <multiple>eds</multiple>
@@ -29,8 +31,11 @@
         <multiple>trans</multiple>
       </term>
       <term name="edition" form="short">edn</term>
+      <term name="issue" form="short">no.</term>
+      <term name="speech">conference presentation</term>
       <term name="volume" form="short">vol.</term>
       <term name="chapter" form="short">ch.</term>
+      <term name="webpage">website</term>
     </terms>
   </locale>
   <macro name="editor">
@@ -255,13 +260,13 @@
       <if variable="container-title">
         <group delimiter=" ">
           <text variable="container-title"/>
-          <text value="website"/>
+          <text term="webpage"/>
         </group>
       </if>
       <else-if variable="publisher">
         <group delimiter=" ">
           <text variable="publisher"/>
-          <text value="website"/>
+          <text term="webpage"/>
         </group>
       </else-if>
     </choose>
@@ -289,13 +294,13 @@
               <if variable="publisher">
                 <group delimiter=" ">
                   <text variable="publisher"/>
-                  <text value="website"/>
+                  <text term="webpage"/>
                 </group>
               </if>
               <else-if variable="archive">
                 <group delimiter=" ">
                   <text variable="archive"/>
-                  <text value="website"/>
+                  <text term="webpage"/>
                 </group>
               </else-if>
             </choose>
@@ -340,7 +345,7 @@
         <text variable="genre" text-case="lowercase" prefix="[" suffix="]"/>
       </if>
       <else>
-        <text value="conference presentation" prefix="[" suffix="]"/>
+        <text term="speech" prefix="[" suffix="]"/>
       </else>
     </choose>
   </macro>
@@ -381,7 +386,7 @@
       <if variable="container-title">
         <group delimiter=" ">
           <text variable="container-title"/>
-          <text value="website"/>
+          <text term="webpage"/>
         </group>
       </if>
       <else-if variable="publisher-place">
@@ -390,7 +395,7 @@
       <else-if variable="publisher">
         <group delimiter=" ">
           <text variable="publisher"/>
-          <text value="website"/>
+          <text term="webpage"/>
         </group>
       </else-if>
     </choose>
@@ -420,7 +425,7 @@
         <text variable="medium" text-case="lowercase" prefix="[" suffix="]"/>
       </if>
       <else>
-        <text value="data set" prefix="[" suffix="]"/>
+        <text term="dataset" prefix="[" suffix="]"/>
       </else>
     </choose>
   </macro>
@@ -539,11 +544,21 @@
               <text variable="page-first"/>
             </else>
           </choose>
-          <text variable="number" prefix="Article "/>
+          <choose>
+            <if variable="number">
+              <group delimiter=" ">
+                <text term="article-locator"/>
+                <text variable="number"/>
+              </group>
+            </if>
+          </choose>
         </group>
       </if>
       <else-if variable="number">
-        <text variable="number" prefix="Article "/>
+        <group delimiter=" ">
+          <text term="article-locator"/>
+          <text variable="number"/>
+        </group>
       </else-if>
     </choose>
   </macro>
@@ -882,8 +897,14 @@
           <group prefix=" ">
             <text variable="container-title" font-style="italic"/>
             <group prefix=", " delimiter=", ">
-              <text variable="volume" prefix="vol. "/>
-              <text variable="issue" prefix="no. "/>
+              <group delimiter=" ">
+                <label variable="volume" form="short"/>
+                <text variable="volume"/>
+              </group>
+              <group delimiter=" ">
+                <label variable="issue" form="short"/>
+                <text variable="issue"/>
+              </group>
               <text macro="pages"/>
             </group>
           </group>

--- a/rmit-university-harvard.csl
+++ b/rmit-university-harvard.csl
@@ -38,14 +38,22 @@
   </macro>
   <macro name="noauthor_title">
     <choose>
-      <if type="article-newspaper">
+      <if type="article-journal">
+        <names variable="author">
+          <name/>
+          <substitute>
+            <text variable="container-title"/>
+          </substitute>
+        </names>
+      </if>
+      <else-if type="article-newspaper">
         <names variable="author">
           <name/>
           <substitute>
             <text variable="container-title" font-style="italic"/>
           </substitute>
         </names>
-      </if>
+      </else-if>
       <else>
         <names variable="author">
           <name/>
@@ -77,9 +85,31 @@
       </substitute>
     </names>
   </macro>
+  <macro name="author-journal">
+    <choose>
+      <if variable="author">
+        <names variable="author">
+          <name name-as-sort-order="all" and="text" sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-last="never"/>
+        </names>
+      </if>
+      <else>
+        <text variable="container-title"/>
+      </else>
+    </choose>
+  </macro>
   <macro name="author-short">
     <names variable="author">
       <name form="short" and="symbol" delimiter=", " delimiter-precedes-last="never" initialize-with=". "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="noauthor_title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short-journal">
+    <names variable="author">
+      <name form="short" and="text" delimiter=", " delimiter-precedes-last="never" initialize-with=". " et-al-min="3" et-al-use-first="1"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -102,6 +132,55 @@
           <text variable="URL"/>
         </group>
       </if>
+    </choose>
+  </macro>
+  <macro name="accessed-date">
+    <choose>
+      <if variable="accessed">
+        <group delimiter=" ">
+          <text term="accessed"/>
+          <date variable="accessed" form="text">
+            <date-part name="day"/>
+            <date-part name="month"/>
+            <date-part name="year"/>
+          </date>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="journal-access">
+    <choose>
+      <if variable="URL">
+        <group delimiter=". ">
+          <group delimiter=", ">
+            <choose>
+              <if variable="publisher">
+                <group delimiter=" ">
+                  <text variable="publisher"/>
+                  <text value="website"/>
+                </group>
+              </if>
+              <else-if variable="archive">
+                <group delimiter=" ">
+                  <text variable="archive"/>
+                  <text value="website"/>
+                </group>
+              </else-if>
+            </choose>
+            <text macro="accessed-date"/>
+          </group>
+          <text variable="URL"/>
+        </group>
+      </if>
+      <else-if variable="archive">
+        <group delimiter=", " suffix=".">
+          <text macro="accessed-date"/>
+          <group delimiter=" ">
+            <text variable="archive"/>
+            <text value="database"/>
+          </group>
+        </group>
+      </else-if>
     </choose>
   </macro>
   <macro name="newspaper-webpage">
@@ -165,6 +244,38 @@
       </else>
     </choose>
   </macro>
+  <macro name="journal-pages">
+    <choose>
+      <if variable="page page-first" match="any">
+        <group delimiter=", ">
+          <choose>
+            <if variable="page">
+              <text variable="page"/>
+            </if>
+            <else>
+              <text variable="page-first"/>
+            </else>
+          </choose>
+          <text variable="number" prefix="Article "/>
+        </group>
+      </if>
+      <else-if variable="number">
+        <text variable="number" prefix="Article "/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="journal-volume-issue-pages">
+    <group delimiter=":">
+      <group>
+        <text variable="volume"/>
+        <text variable="issue" prefix="(" suffix=")"/>
+      </group>
+      <text macro="journal-pages"/>
+    </group>
+  </macro>
+  <macro name="doi">
+    <text variable="DOI" prefix="doi:"/>
+  </macro>
   <macro name="pages">
     <label suffix=" " variable="page" form="short"/>
     <text variable="page"/>
@@ -189,16 +300,29 @@
   </macro>
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" collapse="year">
     <layout prefix="(" suffix=")" delimiter="; ">
-      <group delimiter=", ">
-        <group delimiter=" ">
-          <text macro="author-short"/>
-          <text macro="year-date"/>
-        </group>
-        <group delimiter=" ">
-          <label variable="locator" form="short"/>
-          <text variable="locator"/>
-        </group>
-      </group>
+      <choose>
+        <if type="article-journal">
+          <group>
+            <group delimiter=" ">
+              <text macro="author-short-journal"/>
+              <text macro="year-date"/>
+            </group>
+            <text variable="locator" prefix=":"/>
+          </group>
+        </if>
+        <else>
+          <group delimiter=", ">
+            <group delimiter=" ">
+              <text macro="author-short"/>
+              <text macro="year-date"/>
+            </group>
+            <group delimiter=" ">
+              <label variable="locator" form="short"/>
+              <text variable="locator"/>
+            </group>
+          </group>
+        </else>
+      </choose>
     </layout>
   </citation>
   <bibliography hanging-indent="false">
@@ -207,12 +331,37 @@
       <key macro="year-date"/>
     </sort>
     <layout>
-      <text macro="author"/>
+      <choose>
+        <if type="article-journal">
+          <text macro="author-journal"/>
+        </if>
+        <else>
+          <text macro="author"/>
+        </else>
+      </choose>
       <date variable="issued" prefix=" (" suffix=")">
         <date-part name="year"/>
       </date>
       <choose>
-        <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
+        <if type="article-journal">
+          <text variable="title" quotes="true" prefix=" "/>
+          <group delimiter=", " prefix=", ">
+            <text variable="container-title" font-style="italic"/>
+            <text macro="journal-volume-issue-pages"/>
+          </group>
+          <choose>
+            <if variable="DOI">
+              <text macro="doi" prefix=", " suffix="."/>
+            </if>
+            <else-if variable="URL archive" match="any">
+              <text macro="journal-access" prefix=", "/>
+            </else-if>
+            <else>
+              <text value="."/>
+            </else>
+          </choose>
+        </if>
+        <else-if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
           <group delimiter=" " prefix=" ">
             <text macro="title"/>
             <text macro="report-number"/>
@@ -220,7 +369,7 @@
             <text macro="editor"/>
           </group>
           <text prefix=" " macro="publisher"/>
-        </if>
+        </else-if>
         <else-if type="chapter paper-conference" match="any">
           <text macro="title" prefix=" "/>
           <group delimiter=" " prefix=", ">
@@ -256,9 +405,14 @@
           </group>
         </else>
       </choose>
-      <text macro="presentation" prefix=", "/>
-      <text macro="newspaper-webpage" prefix=", "/>
-      <text macro="access" prefix=", "/>
+      <choose>
+        <if type="article-journal"/>
+        <else>
+          <text macro="presentation" prefix=", "/>
+          <text macro="newspaper-webpage" prefix=", "/>
+          <text macro="access" prefix=", "/>
+        </else>
+      </choose>
     </layout>
   </bibliography>
 </style>

--- a/rmit-university-harvard.csl
+++ b/rmit-university-harvard.csl
@@ -291,6 +291,48 @@
       </else-if>
     </choose>
   </macro>
+  <macro name="conference-format">
+    <choose>
+      <if variable="genre">
+        <text variable="genre" text-case="lowercase" prefix="[" suffix="]"/>
+      </if>
+      <else>
+        <text value="conference presentation" prefix="[" suffix="]"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="conference-name">
+    <choose>
+      <if variable="event">
+        <text variable="event" font-style="italic"/>
+      </if>
+      <else>
+        <text variable="container-title" font-style="italic"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="conference-access">
+    <choose>
+      <if variable="archive">
+        <group delimiter=", " prefix=", " suffix=".">
+          <text macro="accessed-date"/>
+          <group delimiter=" ">
+            <text variable="archive"/>
+            <text value="database"/>
+          </group>
+        </group>
+      </if>
+      <else-if variable="URL">
+        <group delimiter=". " prefix=", ">
+          <text macro="accessed-date"/>
+          <text variable="URL"/>
+        </group>
+      </else-if>
+      <else>
+        <text value="."/>
+      </else>
+    </choose>
+  </macro>
   <macro name="presentation">
     <choose>
       <if type="speech">
@@ -462,7 +504,7 @@
             <text variable="locator" prefix=":"/>
           </group>
         </else-if>
-        <else-if type="book chapter entry-dictionary entry-encyclopedia" match="any">
+        <else-if type="book chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
           <group>
             <group delimiter=" ">
               <text macro="author-short-book"/>
@@ -509,7 +551,7 @@
             </if>
           </choose>
         </else-if>
-        <else-if type="book chapter" match="any">
+        <else-if type="book chapter paper-conference" match="any">
           <text macro="author-book"/>
         </else-if>
         <else>
@@ -531,6 +573,9 @@
         </else-if>
         <else-if type="document webpage" match="any">
           <text macro="year-date" prefix=" (" suffix=")"/>
+        </else-if>
+        <else-if type="paper-conference">
+          <text macro="issued-date-full" prefix=" (" suffix=")"/>
         </else-if>
         <else>
           <date variable="issued" prefix=" (" suffix=")">
@@ -626,18 +671,13 @@
           <text prefix=" " macro="publisher"/>
         </else-if>
         <else-if type="paper-conference">
-          <text macro="title" prefix=" "/>
-          <group delimiter=" " prefix=", ">
-            <text term="in"/>
-            <group delimiter=", ">
-              <text macro="editor"/>
-              <text variable="container-title" font-style="italic"/>
-              <text variable="collection-title"/>
-              <text macro="edition"/>
-              <text macro="publisher"/>
-              <text macro="pages"/>
-            </group>
+          <text variable="title" quotes="true" prefix=" "/>
+          <text macro="conference-format" prefix=" "/>
+          <group delimiter=", " prefix=", ">
+            <text macro="conference-name"/>
+            <text variable="event-place"/>
           </group>
+          <text macro="conference-access"/>
         </else-if>
         <else-if type="document webpage" match="any">
           <text macro="title" prefix=" "/>
@@ -665,7 +705,7 @@
         </else>
       </choose>
       <choose>
-        <if type="article-journal article-newspaper article-magazine" match="any"/>
+        <if type="article-journal article-newspaper article-magazine paper-conference" match="any"/>
         <else>
           <text macro="presentation" prefix=", "/>
           <text macro="access" prefix=", "/>

--- a/rmit-university-harvard.csl
+++ b/rmit-university-harvard.csl
@@ -62,6 +62,16 @@
               <if type="document webpage post post-weblog" match="any">
                 <text variable="title" strip-periods="true" font-style="italic"/>
               </if>
+              <else-if type="entry-dictionary entry-encyclopedia" match="any">
+                <choose>
+                  <if variable="container-title">
+                    <text variable="container-title" strip-periods="true" font-style="italic"/>
+                  </if>
+                  <else>
+                    <text variable="title" strip-periods="true" font-style="italic"/>
+                  </else>
+                </choose>
+              </else-if>
               <else-if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
                 <text variable="title" strip-periods="true" font-style="italic"/>
               </else-if>
@@ -81,6 +91,22 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
+        <text macro="noauthor_title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="editor-book">
+    <names variable="editor" delimiter=", ">
+      <name name-as-sort-order="all" and="text" sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-last="never"/>
+      <label form="short" strip-periods="true" prefix=" (" suffix=")"/>
+    </names>
+  </macro>
+  <macro name="author-book">
+    <names variable="author">
+      <name name-as-sort-order="all" and="text" sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-last="never"/>
+      <label form="short" prefix=" (" suffix=")"/>
+      <substitute>
+        <text macro="editor-book"/>
         <text macro="noauthor_title"/>
       </substitute>
     </names>
@@ -152,6 +178,17 @@
         </group>
       </else>
     </choose>
+  </macro>
+  <macro name="author-short-book">
+    <names variable="author">
+      <name form="short" and="text" delimiter=", " delimiter-precedes-last="never" initialize-with=". " et-al-min="3" et-al-use-first="1"/>
+      <substitute>
+        <names variable="editor">
+          <name form="short" and="text" delimiter=", " delimiter-precedes-last="never" initialize-with=". " et-al-min="3" et-al-use-first="1"/>
+        </names>
+        <text macro="noauthor_title"/>
+      </substitute>
+    </names>
   </macro>
   <macro name="access">
     <choose>
@@ -298,6 +335,19 @@
       <text variable="publisher-place"/>
     </group>
   </macro>
+  <macro name="book-publisher">
+    <group delimiter=", ">
+      <text variable="publisher"/>
+      <choose>
+        <if variable="DOI">
+          <text macro="doi"/>
+        </if>
+        <else>
+          <text variable="publisher-place"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
   <macro name="year-date">
     <choose>
       <if variable="issued">
@@ -412,6 +462,15 @@
             <text variable="locator" prefix=":"/>
           </group>
         </else-if>
+        <else-if type="book chapter entry-dictionary entry-encyclopedia" match="any">
+          <group>
+            <group delimiter=" ">
+              <text macro="author-short-book"/>
+              <text macro="year-date"/>
+            </group>
+            <text variable="locator" prefix=":"/>
+          </group>
+        </else-if>
         <else>
           <group delimiter=", ">
             <group delimiter=" ">
@@ -443,14 +502,33 @@
         <else-if type="document webpage" match="any">
           <text macro="author-webpage"/>
         </else-if>
+        <else-if type="entry-dictionary entry-encyclopedia" match="any">
+          <choose>
+            <if variable="author">
+              <text macro="author-book"/>
+            </if>
+          </choose>
+        </else-if>
+        <else-if type="book chapter" match="any">
+          <text macro="author-book"/>
+        </else-if>
         <else>
           <text macro="author"/>
         </else>
       </choose>
       <choose>
-        <if type="article-newspaper article-magazine" match="any">
-          <text macro="issued-date-full" prefix=" (" suffix=")"/>
+        <if type="entry-dictionary entry-encyclopedia" match="any">
+          <choose>
+            <if variable="author">
+              <date variable="issued" prefix=" (" suffix=")">
+                <date-part name="year"/>
+              </date>
+            </if>
+          </choose>
         </if>
+        <else-if type="article-newspaper article-magazine" match="any">
+          <text macro="issued-date-full" prefix=" (" suffix=")"/>
+        </else-if>
         <else-if type="document webpage" match="any">
           <text macro="year-date" prefix=" (" suffix=")"/>
         </else-if>
@@ -492,6 +570,52 @@
             </else>
           </choose>
         </else-if>
+        <else-if type="book">
+          <group delimiter=", " prefix=" " suffix=".">
+            <text variable="title" strip-periods="false" font-style="italic"/>
+            <text macro="edition"/>
+            <text macro="book-publisher"/>
+          </group>
+        </else-if>
+        <else-if type="chapter">
+          <text variable="title" quotes="true" prefix=" "/>
+          <group delimiter=", " prefix=", " suffix=".">
+            <group delimiter=" ">
+              <text term="in"/>
+              <text macro="editor-book"/>
+              <text variable="container-title" font-style="italic"/>
+            </group>
+            <text macro="edition"/>
+            <text macro="book-publisher"/>
+          </group>
+        </else-if>
+        <else-if type="entry-dictionary entry-encyclopedia" match="any">
+          <choose>
+            <if variable="author">
+              <text variable="title" quotes="true" prefix=" "/>
+              <choose>
+                <if variable="editor">
+                  <group delimiter=", " prefix=", " suffix=".">
+                    <group delimiter=" ">
+                      <text term="in"/>
+                      <text macro="editor-book"/>
+                    </group>
+                    <text variable="container-title" font-style="italic"/>
+                    <text macro="edition"/>
+                    <text macro="book-publisher"/>
+                  </group>
+                </if>
+                <else>
+                  <group delimiter=", " prefix=", " suffix=".">
+                    <text variable="container-title" font-style="italic"/>
+                    <text macro="edition"/>
+                    <text macro="book-publisher"/>
+                  </group>
+                </else>
+              </choose>
+            </if>
+          </choose>
+        </else-if>
         <else-if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
           <group delimiter=" " prefix=" ">
             <text macro="title"/>
@@ -501,7 +625,7 @@
           </group>
           <text prefix=" " macro="publisher"/>
         </else-if>
-        <else-if type="chapter paper-conference" match="any">
+        <else-if type="paper-conference">
           <text macro="title" prefix=" "/>
           <group delimiter=" " prefix=", ">
             <text term="in"/>


### PR DESCRIPTION
### Description
Updates `rmit-university-harvard.csl` to better match the current RMIT Easy Cite Harvard guidance.

This revises formatting for journal articles, webpages, newspaper and magazine articles, books and chapters, conference papers, reports, and datasets. It also updates item-type-specific author/date handling, DOI/report number output, access date/URL/database formatting, no-author substitutions, and style metadata with contributor information.


### Checklist
- [x] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [x] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [x] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [x] Check that you've not used `<text value="...` if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.
