### PR TITLE
Fix typos in a variety of styles

### DIFF
--- a/american-mathematical-society-label.csl
+++ b/american-mathematical-society-label.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" default-locale="en-US">
   <info>
-    <title>Amercian Mathematical Society (label)</title>
+    <title>American Mathematical Society (label)</title>
     <title-short>AMS</title-short>
     <id>http://www.zotero.org/styles/american-mathematical-society-label</id>
     <link href="http://www.zotero.org/styles/american-mathematical-society-label" rel="self"/>

--- a/american-mathematical-society-numeric.csl
+++ b/american-mathematical-society-numeric.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" default-locale="en-US">
   <info>
-    <title>Amercian Mathematical Society (numeric)</title>
+    <title>American Mathematical Society (numeric)</title>
     <title-short>AMS</title-short>
     <id>http://www.zotero.org/styles/american-mathematical-society-numeric</id>
     <link href="http://www.zotero.org/styles/american-mathematical-society-numeric" rel="self"/>

--- a/ankara-universitesi-sosyal-bilimler-enstitusu-hukuk-fakultesi.csl
+++ b/ankara-universitesi-sosyal-bilimler-enstitusu-hukuk-fakultesi.csl
@@ -109,7 +109,7 @@
     <group delimiter=" ">
       <!-- Yazarlar, ilk atıf-->
       <names variable="author" font-weight="bold">
-        <!-- sort-seperator isim soyad arasındaki separator
+        <!-- sort-separator isim soyad arasındaki separator
 Name-as-sort-order TASKIN Yavuz, AYDIN Kemal gibi iki yazar oldugunda, first ise ilki, all ise hepsi icin  soyad-ad yazilmasi
 delimiter iki isim arasındaki separator -->
         <name delimiter-precedes-et-al="never" delimiter-precedes-last="always" name-as-sort-order="all" sort-separator=", " delimiter="/">
@@ -159,7 +159,7 @@ delimiter iki isim arasındaki separator -->
   <macro name="contributors">
     <group delimiter=". ">
       <names variable="author" font-weight="bold">
-        <!-- sort-seperator isim soyad arasındaki virgül, delimiter iki yazar arasındaki delimiter-->
+        <!-- sort-separator isim soyad arasındaki virgül, delimiter iki yazar arasındaki delimiter-->
         <name delimiter-precedes-et-al="never" delimiter-precedes-last="always" name-as-sort-order="all" sort-separator=", " delimiter="/">
           <!-- Kaynakça/bibliyografi de yazar soyad büyük -->
           <name-part name="family" text-case="uppercase"/>

--- a/bioresources.csl
+++ b/bioresources.csl
@@ -14,7 +14,7 @@
     <category citation-format="author-date"/>
     <category field="biology"/>
     <issn>1930-2126</issn>
-    <summary>The style for the journal Bioresources says that it follows the one of the J. Water Resources Planing and Management published by the American Society of Civial Engineers. However, there are slight differences, e.g. title and container-title are seperated by a comma and not a point, doi is added always at the end.</summary>
+    <summary>The style for the journal Bioresources says that it follows the one of the J. Water Resources Planning and Management published by the American Society of Civil Engineers. However, there are slight differences, e.g. title and container-title are separated by a comma and not a point, doi is added always at the end.</summary>
     <updated>2015-12-04T07:28:32+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>

--- a/food-and-agriculture-organization-of-the-united-nations-numeric.csl
+++ b/food-and-agriculture-organization-of-the-united-nations-numeric.csl
@@ -113,7 +113,7 @@
     </group>
   </macro>
   <macro name="in-and-container">
-    <!-- Outputs "In: XX ed. Container-title (italic)" if container-title exists. "XX ed. " will be omited if there's no editor. -->
+    <!-- Outputs "In: XX ed. Container-title (italic)" if container-title exists. "XX ed. " will be omitted if there's no editor. -->
     <choose>
       <if variable="container-title">
         <group delimiter=" ">

--- a/food-and-agriculture-organization-of-the-united-nations.csl
+++ b/food-and-agriculture-organization-of-the-united-nations.csl
@@ -135,7 +135,7 @@
     </group>
   </macro>
   <macro name="in-and-container">
-    <!-- Outputs "In: XX ed. Container-title (italic)" if container-title exists. "XX ed. " will be omited if there's no editor. -->
+    <!-- Outputs "In: XX ed. Container-title (italic)" if container-title exists. "XX ed. " will be omitted if there's no editor. -->
     <choose>
       <if variable="container-title">
         <group delimiter=" ">


### PR DESCRIPTION
### Description
Hi, I am a @JabRef developer. Huge thanks for your work to maintain the CSL project!

I found some typos when trying out [styles](https://github.com/citation-style-language/styles/blob/master/american-mathematical-society-label.csl) with alphanumeric format. I fixed those, along with a few typos in other files.

Would appreciate your feedback!

### Checklist
- [ ] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [ ] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [ ] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [x] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [x] Check that you've not used `<text value="...` if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.
