### PR TITLE
Add: computerartists-literaturangabe-alpha1 (New metadata-transparent style)

### DIFF
--- a/computerartists-literaturangabe-alpha1.csl
+++ b/computerartists-literaturangabe-alpha1.csl
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="never" page-range-format="minimal">
-  <info>
+ <info>
     <title>ComputerArtists Literaturangabe Alpha 1</title>
     <title-short>CArtisLitAng_A1</title-short>
     <id>http://www.zotero.org/styles/computerartists-literaturangabe-alpha1</id>
     <link rel="self" href="http://www.zotero.org/styles/computerartists-literaturangabe-alpha1"/>
+    <link rel="template" href="http://www.zotero.org/styles/apa"/>
+    <link rel="documentation" href="https://github.com/ComputerArtists"/>
     <author>
       <name>Thomas Lahme</name>
       <email>ComputerArtist_ThL@proton.me</email>

--- a/computerartists-literaturangabe-alpha1.csl
+++ b/computerartists-literaturangabe-alpha1.csl
@@ -1,0 +1,527 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="never" page-range-format="minimal">
+  <info>
+    <title>ComputerArtists Literaturangabe Alpha 1</title>
+    <title-short>CArtisLitAng_A1</title-short>
+    <id>http://www.zotero.org/styles/computerartists-literaturangabe-alpha1</id>
+    <link rel="self" href="http://www.zotero.org/styles/computerartists-literaturangabe-alpha1"/>
+    <author>
+      <name>Thomas Lahme</name>
+      <email>ComputerArtist_ThL@proton.me</email>
+    </author>
+    <summary>Fußnotenbasierte Vollzitationsvorlage mit typabhängiger Feldlogik und Literaturverzeichnis am Dokumentende.</summary>
+    <published>2026-05-09T15:00:00+00:00</published>
+    <updated>2026-05-09T15:00:00+00:00</updated>
+    <rights>Public Domain</rights>
+  </info>
+
+  <macro name="title-main">
+    <group delimiter=" ">
+      <text variable="title" quotes="true" font-weight="bold"/>
+      <text variable="subtitle" quotes="true" font-weight="bold" prefix=": "/>
+    </group>
+  </macro>
+
+  <macro name="title-block">
+    <text macro="title-main"/>
+    <choose>
+      <if type="article-journal article-magazine article-newspaper chapter paper-conference" match="any">
+        <text variable="container-title" quotes="true" prefix=" in: "/>
+      </if>
+    </choose>
+    <text variable="collection-title" quotes="true" prefix=" | Reihe: "/>
+    <text variable="volume-title" quotes="true" prefix=" | Bandtitel: "/>
+    <text variable="original-title" quotes="true" prefix=" | Originaltitel: "/>
+  </macro>
+
+  <macro name="title-by-type">
+    <choose>
+      <if type="book thesis report manuscript" match="any">
+        <group delimiter=" | ">
+          <text macro="title-main" prefix="Haupttitel: "/>
+          <text variable="collection-title" quotes="true" prefix="Reihe: "/>
+          <text variable="volume-title" quotes="true" prefix="Bandtitel: "/>
+          <text variable="original-title" quotes="true" prefix="Originaltitel: "/>
+        </group>
+      </if>
+      <else-if type="article-journal article-magazine article-newspaper chapter paper-conference" match="any">
+        <group delimiter=" | ">
+          <text macro="title-main" prefix="Beitragstitel: "/>
+          <text variable="container-title" quotes="true" prefix="Container: "/>
+          <text variable="collection-title" quotes="true" prefix="Reihe: "/>
+        </group>
+      </else-if>
+      <else-if type="webpage post-weblog post" match="any">
+        <group delimiter=" | ">
+          <text macro="title-main" prefix="Seitentitel: "/>
+          <text variable="container-title" quotes="true" prefix="Website: "/>
+        </group>
+      </else-if>
+      <else-if type="motion_picture broadcast map graphic song" match="any">
+        <group delimiter=" | ">
+          <text macro="title-main" prefix="Werktitel: "/>
+          <text variable="collection-title" quotes="true" prefix="Serie/Sammlung: "/>
+        </group>
+      </else-if>
+      <else>
+        <text macro="title-block"/>
+      </else>
+    </choose>
+  </macro>
+
+  <macro name="contributor-primary">
+    <names variable="author">
+      <name and="text" delimiter=", " initialize-with=". "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+  </macro>
+
+  <macro name="contributor-detail">
+    <choose>
+      <if variable="author">
+        <group delimiter=" | ">
+          <names variable="editor">
+            <label form="short" text-case="capitalize-first" suffix=": "/>
+            <name and="text" delimiter=", " initialize-with=". "/>
+          </names>
+          <names variable="translator">
+            <label form="short" text-case="capitalize-first" suffix=": "/>
+            <name and="text" delimiter=", " initialize-with=". "/>
+          </names>
+        </group>
+      </if>
+      <else-if variable="editor">
+        <names variable="editor">
+          <name and="text" delimiter=", " initialize-with=". "/>
+          <label form="short" prefix=" (" suffix=")"/>
+        </names>
+      </else-if>
+      <else-if variable="translator">
+        <names variable="translator">
+          <name and="text" delimiter=", " initialize-with=". "/>
+          <label form="short" prefix=" (" suffix=")"/>
+        </names>
+      </else-if>
+    </choose>
+  </macro>
+
+  <macro name="contributor-by-role">
+    <group delimiter=" | ">
+      <names variable="author">
+        <text value="Rolle Autor*in (Urheberschaft): "/>
+        <name and="text" delimiter=", " initialize-with=". "/>
+      </names>
+      <names variable="editor">
+        <text value="Rolle Herausgeber*in (Redaktion): "/>
+        <name and="text" delimiter=", " initialize-with=". "/>
+      </names>
+      <names variable="translator">
+        <text value="Rolle Uebersetzer*in (Sprachuebertragung): "/>
+        <name and="text" delimiter=", " initialize-with=". "/>
+      </names>
+      <names variable="composer">
+        <text value="Rolle Komponist*in (musikalische Urheberschaft): "/>
+        <name and="text" delimiter=", " initialize-with=". "/>
+      </names>
+      <names variable="director">
+        <text value="Rolle Regie (inszenatorische Leitung): "/>
+        <name and="text" delimiter=", " initialize-with=". "/>
+      </names>
+      <names variable="producer">
+        <text value="Rolle Produktion (produktionsverantwortlich): "/>
+        <name and="text" delimiter=", " initialize-with=". "/>
+      </names>
+      <names variable="interviewer">
+        <text value="Rolle Interviewfuehrung: "/>
+        <name and="text" delimiter=", " initialize-with=". "/>
+      </names>
+      <names variable="recipient">
+        <text value="Rolle Adressat*in: "/>
+        <name and="text" delimiter=", " initialize-with=". "/>
+      </names>
+    </group>
+  </macro>
+
+  <macro name="edition-block">
+    <group delimiter=", ">
+      <text variable="edition" suffix=". Aufl."/>
+      <text variable="version" prefix="Version "/>
+      <text variable="number" prefix="Nr. "/>
+      <text variable="volume" prefix="Bd. "/>
+      <text variable="issue" prefix="Heft "/>
+    </group>
+  </macro>
+
+  <macro name="edition-by-type">
+    <choose>
+      <if type="book thesis report manuscript" match="any">
+        <group delimiter=" | ">
+          <text variable="edition" prefix="Auflage: " suffix="."/>
+          <text variable="version" prefix="Version: "/>
+          <text variable="number" prefix="Nummer: "/>
+          <text variable="volume" prefix="Band: "/>
+        </group>
+      </if>
+      <else-if type="article-journal article-magazine article-newspaper chapter paper-conference" match="any">
+        <group delimiter=" | ">
+          <text variable="volume" prefix="Band: "/>
+          <text variable="issue" prefix="Heft: "/>
+          <text variable="number" prefix="Nummer: "/>
+        </group>
+      </else-if>
+      <else-if type="webpage post-weblog post" match="any">
+        <group delimiter=" | ">
+          <text variable="version" prefix="Version: "/>
+          <text variable="edition" prefix="Ausgabe: " suffix="."/>
+        </group>
+      </else-if>
+      <else>
+        <text macro="edition-block"/>
+      </else>
+    </choose>
+  </macro>
+
+  <macro name="pub-block">
+    <group delimiter=", ">
+      <text variable="publisher"/>
+      <text variable="publisher-place"/>
+      <date variable="issued">
+        <date-part name="year"/>
+      </date>
+    </group>
+  </macro>
+
+  <macro name="publication-by-type">
+    <choose>
+      <if type="book thesis report manuscript" match="any">
+        <text macro="pub-block"/>
+      </if>
+      <else-if type="article-journal article-magazine article-newspaper chapter paper-conference" match="any">
+        <group delimiter=", ">
+          <text variable="container-title" quotes="true"/>
+          <text variable="collection-title" quotes="true"/>
+          <text variable="volume" prefix="Bd. "/>
+          <text variable="issue" prefix="Heft "/>
+          <text variable="page" prefix="S. "/>
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </group>
+      </else-if>
+      <else-if type="webpage post-weblog post" match="any">
+        <group delimiter=", ">
+          <text variable="container-title" quotes="true"/>
+          <text variable="publisher"/>
+          <date variable="issued" form="text"/>
+        </group>
+      </else-if>
+      <else>
+        <text macro="pub-block"/>
+      </else>
+    </choose>
+  </macro>
+
+  <macro name="publication-type-label">
+    <choose>
+      <if type="book" match="any">
+        <text value="Publikationstyp: Buch"/>
+      </if>
+      <else-if type="chapter" match="any">
+        <text value="Publikationstyp: Buchkapitel"/>
+      </else-if>
+      <else-if type="article-journal" match="any">
+        <text value="Publikationstyp: Zeitschriftenartikel"/>
+      </else-if>
+      <else-if type="article-magazine article-newspaper" match="any">
+        <text value="Publikationstyp: Presseartikel"/>
+      </else-if>
+      <else-if type="paper-conference" match="any">
+        <text value="Publikationstyp: Konferenzbeitrag"/>
+      </else-if>
+      <else-if type="thesis" match="any">
+        <text value="Publikationstyp: Hochschulschrift"/>
+      </else-if>
+      <else-if type="report" match="any">
+        <text value="Publikationstyp: Bericht"/>
+      </else-if>
+      <else-if type="webpage post-weblog post" match="any">
+        <text value="Publikationstyp: Online-Quelle"/>
+      </else-if>
+      <else-if type="motion_picture broadcast" match="any">
+        <text value="Publikationstyp: Audiovisuelles Werk"/>
+      </else-if>
+      <else-if type="song" match="any">
+        <text value="Publikationstyp: Musikwerk"/>
+      </else-if>
+      <else>
+        <text value="Publikationstyp: Sonstige Quelle"/>
+      </else>
+    </choose>
+  </macro>
+
+  <macro name="id-block">
+    <group delimiter=" | ">
+      <text variable="ISBN" prefix="ISBN: "/>
+      <text variable="DOI" prefix="DOI: "/>
+      <text variable="ISSN" prefix="ISSN: "/>
+      <text variable="URL" prefix="URL: "/>
+    </group>
+  </macro>
+
+  <macro name="context-block">
+    <group delimiter=" | ">
+      <text variable="language" prefix="Sprache: "/>
+      <text variable="rights" prefix="Rechte: "/>
+      <text variable="medium" prefix="Medium: "/>
+      <text variable="genre" prefix="Genre: "/>
+    </group>
+  </macro>
+
+  <macro name="context-by-type">
+    <choose>
+      <if type="webpage post-weblog post" match="any">
+        <group delimiter=" | ">
+          <text variable="language" prefix="Sprache: "/>
+          <text variable="medium" prefix="Medientyp: "/>
+          <text variable="genre" prefix="Format/Genre: "/>
+          <text variable="rights" prefix="Rechte: "/>
+        </group>
+      </if>
+      <else-if type="motion_picture broadcast song" match="any">
+        <group delimiter=" | ">
+          <text variable="medium" prefix="Träger/Medium: "/>
+          <text variable="genre" prefix="Genre: "/>
+          <text variable="language" prefix="Sprache: "/>
+          <text variable="rights" prefix="Rechte: "/>
+        </group>
+      </else-if>
+      <else>
+        <text macro="context-block"/>
+      </else>
+    </choose>
+  </macro>
+
+  <macro name="access-block">
+    <group delimiter=" ">
+      <text term="accessed" text-case="capitalize-first" suffix=": "/>
+      <date variable="accessed" form="text"/>
+    </group>
+  </macro>
+
+  <citation disambiguate-add-year-suffix="true">
+    <sort>
+      <key macro="contributor-primary"/>
+      <key variable="title"/>
+    </sort>
+    <layout prefix="[" suffix="].">
+      <choose>
+        <if type="book thesis report manuscript" match="any">
+          <group delimiter=" | ">
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="contributor-primary" prefix="Verantwortung (primaer): "/>
+              </if>
+            </choose>
+            <choose>
+              <if variable="title subtitle" match="any">
+                <text macro="title-main" prefix="Werktitel (Haupttitel): "/>
+              </if>
+            </choose>
+            <group delimiter=", ">
+              <choose>
+                <if variable="publisher">
+                  <text variable="publisher" prefix="Publikationsstelle (Verlag/Institution): "/>
+                </if>
+              </choose>
+              <choose>
+                <if variable="issued">
+                  <date variable="issued" prefix="Zeitangabe (Erscheinungsjahr): ">
+                    <date-part name="year"/>
+                  </date>
+                </if>
+              </choose>
+            </group>
+            <choose>
+              <if variable="locator">
+                <text variable="locator" prefix="Fundstelle (Seite): S. "/>
+              </if>
+            </choose>
+          </group>
+        </if>
+        <else-if type="article-journal article-magazine article-newspaper chapter paper-conference" match="any">
+          <group delimiter=" | ">
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="contributor-primary" prefix="Verantwortung (Beitrag): "/>
+              </if>
+            </choose>
+            <choose>
+              <if variable="title subtitle" match="any">
+                <text macro="title-main" prefix="Beitragstitel: "/>
+              </if>
+            </choose>
+            <choose>
+              <if variable="container-title">
+                <text variable="container-title" prefix="Publikationsorgan (Container): "/>
+              </if>
+            </choose>
+            <group delimiter=" ">
+              <choose>
+                <if variable="volume">
+                  <text variable="volume" prefix="Band: "/>
+                </if>
+              </choose>
+              <choose>
+                <if variable="issue">
+                  <text variable="issue" prefix="Heft: "/>
+                </if>
+              </choose>
+            </group>
+            <choose>
+              <if variable="issued">
+                <date variable="issued" prefix="Zeitangabe (Jahr): ">
+                  <date-part name="year"/>
+                </date>
+              </if>
+            </choose>
+            <choose>
+              <if variable="locator">
+                <text variable="locator" prefix="Fundstelle (Seite): S. "/>
+              </if>
+            </choose>
+          </group>
+        </else-if>
+        <else-if type="webpage post-weblog post" match="any">
+          <group delimiter=" | ">
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="contributor-primary" prefix="Verantwortung (Online-Inhalt): "/>
+              </if>
+            </choose>
+            <choose>
+              <if variable="title subtitle" match="any">
+                <text macro="title-main" prefix="Seitentitel/Beitragstitel: "/>
+              </if>
+            </choose>
+            <choose>
+              <if variable="container-title">
+                <text variable="container-title" prefix="Plattform/Website: "/>
+              </if>
+            </choose>
+            <choose>
+              <if variable="issued">
+                <date variable="issued" form="text" prefix="Zeitangabe (Veroeffentlichungsdatum): "/>
+              </if>
+            </choose>
+            <choose>
+              <if variable="locator">
+                <text variable="locator" prefix="Fundstelle (Absatz): Abs. "/>
+              </if>
+            </choose>
+          </group>
+        </else-if>
+        <else-if type="motion_picture broadcast song" match="any">
+          <group delimiter=" | ">
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="contributor-primary" prefix="Verantwortung (AV/Musik): "/>
+              </if>
+            </choose>
+            <choose>
+              <if variable="title subtitle" match="any">
+                <text macro="title-main" prefix="Werktitel (AV/Musik): "/>
+              </if>
+            </choose>
+            <choose>
+              <if variable="issued">
+                <date variable="issued" prefix="Zeitangabe (Jahr): ">
+                  <date-part name="year"/>
+                </date>
+              </if>
+            </choose>
+            <choose>
+              <if variable="locator">
+                <text variable="locator" prefix="Fundstelle (Timecode): "/>
+              </if>
+            </choose>
+          </group>
+        </else-if>
+        <else>
+          <group delimiter=" | ">
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="contributor-primary" prefix="Verantwortung (primaer): "/>
+              </if>
+            </choose>
+            <choose>
+              <if variable="title subtitle" match="any">
+                <text macro="title-main" prefix="Werktitel: "/>
+              </if>
+            </choose>
+            <choose>
+              <if variable="publisher publisher-place issued container-title collection-title volume issue page" match="any">
+                <text macro="publication-by-type" prefix="Publikationskontext: "/>
+              </if>
+            </choose>
+            <choose>
+              <if variable="locator">
+                <text variable="locator" prefix="Fundstelle: "/>
+              </if>
+            </choose>
+            <choose>
+              <if variable="citation-key">
+                <text variable="citation-key" prefix="Interner Zitationsschluessel: "/>
+              </if>
+            </choose>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </citation>
+
+  <bibliography entry-spacing="2" line-spacing="1" hanging-indent="true">
+    <sort>
+      <key macro="contributor-primary"/>
+      <key variable="title"/>
+    </sort>
+    <layout>
+      <group display="block">
+        <text macro="contributor-primary"/>
+      </group>
+      <group display="block">
+        <text macro="title-by-type"/>
+      </group>
+      <group display="block">
+        <text macro="contributor-by-role"/>
+      </group>
+      <group display="block">
+        <text macro="edition-by-type"/>
+      </group>
+      <group display="block">
+        <text macro="publication-type-label"/>
+      </group>
+      <group display="block">
+        <text macro="publication-by-type"/>
+      </group>
+      <group display="block">
+        <text macro="id-block"/>
+      </group>
+      <group display="block">
+        <text macro="context-by-type"/>
+      </group>
+      <group display="block">
+        <text variable="abstract" prefix="Abstract: " font-style="italic"/>
+      </group>
+      <group display="block">
+        <choose>
+          <if variable="URL DOI">
+            <text macro="access-block"/>
+          </if>
+        </choose>
+      </group>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
## CSL Styles Pull Request Template
You're about to create a pull request to the CSL **styles** repository.  
If you haven't done so already, see <https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md> for instructions on how to contribute, and <https://github.com/citation-style-language/styles/blob/master/STYLE_REQUIREMENTS.md> for the requirements a style must meet before acceptance.  
In addition, please fill out the pull request template below.


### Description
Submission of the new citation style: "ComputerArtists Literaturangabe Alpha 1".

This style is a specialized, metadata-transparent instrument developed for the ComputerArtists Lexicon project, which explores the intersections of AI, Philosophy of Technology, and Digital Art.

Key Methodological Features:

    Explicit Labeling: Unlike traditional styles, this CSL explicitly labels metadata fields (e.g., "Werktitel", "Verantwortung", "Publikationsorgan") within the citation. This is a functional requirement to ensure structural transparency and prevent the "Deepfake of Logic" in source documentation.

    Deep Contributor Mapping: Provides granular role identification for interdisciplinary works, including Composers, Directors, Interviewers, and Translators.

    Digital Evidence Focus: Advanced type-dependent logic for online sources, ensuring that digital footprints (URLs, DOIs, and access dates) are clearly anchored as "t-bound" evidence.

    Contextual Metadata: Includes dedicated blocks for medium, language, and rights to provide a holistic view of the source's origin.

Technical Compliance:

    Template: Based on the logical structure of APA.  

    Locale: Optimized for German (de-DE).

    Domain: Academic research in IT-Philosophy and Media Theory.


### Checklist
- [x] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
[x] Link to template: Yes, added APA as a logical baseline.  

[x] Link to documentation: Yes, linked to the ComputerArtists project.  

[ ] Correct terms/labels instead of hardcoding: Note: Labels are used intentionally as part of a "structural transparency" methodology.

[ ] Not used <text value="...: Note: Used for explicit role descriptions (e.g., "Rolle Autor*in"). This is a functional requirement for the associated Lexicon project.
- [ ] Check that you've not changed line 1 of the style.
