### PR TITLE
Przegląd Lekarski - ZOTERO

### DIFF
--- a/przeglad-lekarski-jagiellonian-medical-review.csl
+++ b/przeglad-lekarski-jagiellonian-medical-review.csl
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+  <info>
+    <title>Przegląd Lekarski - Jagiellonian Medical Review</title>
+    <title-short>Prz Lek Jagiellonian Med Rev</title-short>
+    <id>https://www.zotero.org/styles/przeglad-lekarski-jagiellonian-medical-review</id>
+    <link href="https://www.zotero.org/styles/przeglad-lekarski-jagiellonian-medical-review" rel="self"/>
+    <link href="https://www.mp.pl/jmr/about-us/" rel="documentation"/>
+    <author>
+      <name>Joanna Marszalik</name>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="medicine"/>
+    <issn>0033-2240</issn>
+    <eissn>3072-0036</eissn>
+    <updated>2026-03-03T00:00:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">
+      This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License
+    </rights>
+  </info>
+
+  <locale xml:lang="en">
+    <terms>
+      <term name="page-range-delimiter">-</term>
+    </terms>
+  </locale>
+
+  <macro name="author">
+    <group suffix=".">
+      <names variable="author">
+        <name font-variant="normal" delimiter-precedes-et-al="always"
+              delimiter-precedes-last="always" initialize-with=""
+              name-as-sort-order="all" sort-separator=" "/>
+        <label form="short" prefix=", "/>
+        <substitute>
+          <names variable="editor"/>
+        </substitute>
+      </names>
+    </group>
+  </macro>
+
+  <macro name="editor">
+    <names variable="editor">
+      <name name-as-sort-order="all" sort-separator=" "
+            delimiter-precedes-last="always" initialize-with=""
+            delimiter=", "/>
+      <label form="long" prefix=", " suffix="."/>
+    </names>
+  </macro>
+
+  <macro name="title">
+    <text variable="title" quotes="false"/>
+  </macro>
+
+  <macro name="year">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
+
+  <macro name="journal">
+    <group delimiter=" ">
+      <text variable="container-title" form="short" strip-periods="true" suffix="."/>
+      <text macro="year" suffix=";"/>
+      <text variable="volume"/>
+    </group>
+  </macro>
+
+  <macro name="conference">
+    <group delimiter=", ">
+      <text variable="container-title"/>
+      <group delimiter=" ">
+        <text variable="publisher"/>
+        <text macro="year"/>
+      </group>
+    </group>
+  </macro>
+
+  <macro name="book-publisher">
+    <group delimiter=", ">
+      <group delimiter=": ">
+        <text variable="publisher-place"/>
+        <text variable="publisher"/>
+      </group>
+      <text macro="year"/>
+    </group>
+  </macro>
+
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+
+  <citation>
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout prefix="[" suffix="]" delimiter=",">
+      <group delimiter=":">
+        <text variable="citation-number"/>
+        <text variable="locator"/>
+      </group>
+    </layout>
+  </citation>
+
+  <bibliography et-al-min="5" et-al-use-first="3"
+                second-field-align="flush" entry-spacing="0">
+    <layout suffix=".">
+      <text variable="citation-number"/>
+      <text macro="author" suffix=". "/>
+      <text macro="title" suffix=". "/>
+
+      <choose>
+        <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+          <text macro="edition" suffix=" "/>
+          <text macro="book-publisher" suffix="."/>
+        </if>
+
+        <else-if type="paper-conference">
+          <group suffix="." delimiter=", ">
+            <text macro="conference"/>
+            <text variable="page"/>
+          </group>
+        </else-if>
+
+        <else-if type="chapter paper-conference" match="any">
+          <text term="in" text-case="capitalize-first" suffix=": "/>
+          <text macro="editor" suffix=" "/>
+          <text variable="container-title" suffix=". "/>
+          <text macro="edition" suffix=" "/>
+          <group suffix=".">
+            <text macro="book-publisher"/>
+            <text variable="page" prefix=": "/>
+          </group>
+        </else-if>
+
+        <else-if type="article-journal">
+          <group suffix=".">
+            <text macro="journal"/>
+            <text variable="page" strip-periods="false" prefix=": "/>
+          </group>
+        </else-if>
+
+        <else>
+          <group suffix="." delimiter=" ">
+            <group delimiter=" ">
+              <text variable="container-title"/>
+              <text variable="volume"/>
+            </group>
+            <text macro="year"/>
+            <text variable="page"/>
+          </group>
+          <text variable="URL" prefix=" "/>
+        </else>
+
+      </choose>
+    </layout>
+  </bibliography>
+
+</style>


### PR DESCRIPTION
This pull request adds a new CSL citation style for the journal **Przegląd Lekarski – Jagiellonian Medical Review**.

The style follows the journal's reference formatting guidelines and uses a numeric citation format with in-text citations in square brackets.

ISSN: 0033-2240
eISSN: 3072-0036

Journal guidelines: https://www.mp.pl/jmr/about-us/

