### PR TITLE
Add style: Núcleo de Mecanização e Agricultura de Precisão - ABNT (Portuguese - Brazil)

### DIFF
--- a/nucleo-de-mecanizacao-e-agricultura-de-precisao-abnt.csl
+++ b/nucleo-de-mecanizacao-e-agricultura-de-precisao-abnt.csl
@@ -1,0 +1,766 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" demote-non-dropping-particle="never">
+
+  <info>
+    <title>Núcleo de Mecanização e Agricultura de Precisão - ABNT (Portuguese - Brazil)</title>
+    <title-short>NMAP</title-short>
+    <id>http://www.zotero.org/styles/nucleo-de-mecanizacao-e-agricultura-de-precisao-abnt</id>
+    <link href="http://www.zotero.org/styles/nucleo-de-mecanizacao-e-agricultura-de-precisao-abnt" rel="self"/>
+    <link href="http://www.zotero.org/styles/instituto-brasileiro-de-informacao-em-ciencia-e-tecnologia-abnt-initials" rel="template"/>
+    <author>
+      <name>Vicente Felipe Cordeiro dos Santos</name>
+      <email>vicentefelipesantoss@gmail.com</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="science"/>
+    <summary>Estilo customizado do NMAP para formatação de referências, priorizando DOI e suprimindo local de publicação.</summary>
+    <updated>2026-06-01T20:30:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="pt">
+    <terms>
+      <term name="in">in</term>
+      <term name="ordinal">.</term>
+      <term name="no-publisher" form="short">s.n.</term>
+    </terms>
+  </locale>
+  <macro name="access">
+    <choose>
+      <if variable="DOI">
+        <group delimiter=": ">
+          <text value="doi" text-case="uppercase"/>
+          <text variable="DOI" prefix="https://doi.org/"/>
+        </group>
+      </if>
+      <else-if variable="URL">
+        <group delimiter=": ">
+          <text term="available at" text-case="capitalize-first"/>
+          <text variable="URL"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; " delimiter-precedes-last="always">
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
+      </name>
+      <et-al font-style="italic"/>
+      <label form="short" prefix=" (" suffix=".)"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="organizer"/>
+        <names variable="collection-editor"/>
+        <names variable="translator"/>
+        <text variable="title" text-case="uppercase"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; " delimiter-precedes-last="always">
+        <name-part name="family"/>
+        <name-part name="given"/>
+      </name>
+      <et-al font-style="italic"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="book">
+            <text variable="title" form="short"/>
+          </if>
+          <else>
+            <text variable="title" form="short" quotes="false"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="citation-locator">
+    <group delimiter=" ">
+      <label variable="locator" form="short"/>
+      <text variable="locator"/>
+    </group>
+  </macro>
+  <macro name="collection-info">
+    <choose>
+      <if type="book chapter entry-dictionary entry-encyclopedia map report" match="any">
+        <group delimiter=", " prefix="(" suffix=")">
+          <text variable="collection-title"/>
+          <text variable="collection-number"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="composer">
+    <group delimiter=": ">
+      <names variable="composer">
+        <label form="long" text-case="capitalize-first" suffix=": "/>
+        <name delimiter=", " sort-separator=" " delimiter-precedes-last="always">
+          <name-part name="given"/>
+          <name-part name="family"/>
+        </name>
+        <et-al font-style="italic"/>
+        <substitute>
+          <text variable="title" text-case="uppercase"/>
+        </substitute>
+      </names>
+    </group>
+  </macro>
+  <macro name="container-contributors">
+    <choose>
+      <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
+        <group delimiter=": ">
+          <text term="in" font-style="italic" text-case="capitalize-first"/>
+          <names variable="container-author" delimiter=", ">
+            <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; " delimiter-precedes-last="always">
+              <name-part name="family" text-case="uppercase"/>
+              <name-part name="given"/>
+            </name>
+            <et-al font-style="italic"/>
+            <label form="short" prefix=" (" suffix=".)"/>
+            <substitute>
+              <names variable="organizer"/>
+              <names variable="editor"/>
+              <names variable="collection-editor"/>
+              <names variable="container-author"/>
+            </substitute>
+          </names>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-title">
+    <choose>
+      <if type="chapter entry-dictionary entry-encyclopedia" match="any">
+        <choose>
+          <if variable="author collection-editor container-author editor organizer" match="any">
+            <text variable="container-title" font-weight="bold"/>
+          </if>
+          <else>
+            <group delimiter=": ">
+              <text term="in" font-style="italic" text-case="capitalize-first"/>
+              <text variable="container-title"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+      <else-if type="paper-conference" match="any">
+        <text variable="container-title" font-weight="bold"/>
+      </else-if>
+      <else-if type="article article-newspaper article-magazine article-journal bill post post-weblog webpage" match="any">
+        <choose>
+          <if variable="container-author editor collection-editor organizer" match="any"/>
+        </choose>
+        <text variable="container-title" font-weight="bold"/>
+      </else-if>
+      <else>
+        <text variable="container-title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="contributor">
+    <choose>
+      <if type="article article-journal article-magazine article-newspaper interview" match="any">
+        <names variable="interviewer">
+          <label form="long" text-case="capitalize-first" suffix=": "/>
+          <name delimiter=", " sort-separator=" " delimiter-precedes-last="always">
+            <name-part name="given"/>
+            <name-part name="family"/>
+          </name>
+          <et-al font-style="italic"/>
+        </names>
+      </if>
+      <else-if type="patent" match="any">
+        <text variable="authority" prefix="Depositante: "/>
+      </else-if>
+      <else-if type="personal_communication" match="any">
+        <names variable="recipient">
+          <label form="long" text-case="capitalize-first" suffix=": "/>
+          <name delimiter=", " sort-separator=" " delimiter-precedes-last="always">
+            <name-part name="given"/>
+            <name-part name="family"/>
+          </name>
+          <et-al font-style="italic"/>
+        </names>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="dimensions">
+    <choose>
+      <if type="broadcast motion_picture song" match="any">
+        <text variable="dimensions" prefix="(" suffix=")"/>
+      </if>
+      <else>
+        <text variable="dimensions"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="director">
+    <names variable="director">
+      <label form="long" text-case="capitalize-first" suffix=": "/>
+      <name delimiter=", " sort-separator=" " delimiter-precedes-last="always">
+        <name-part name="given"/>
+        <name-part name="family"/>
+      </name>
+      <et-al font-style="italic"/>
+      <substitute>
+        <text variable="title" text-case="uppercase"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <label variable="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if type="paper-conference" match="any">
+        <choose>
+          <if variable="organizer editor container-author" match="any">
+            <text variable="event" text-case="uppercase"/>
+          </if>
+          <else>
+            <group delimiter=": ">
+              <text term="in" font-style="italic" text-case="capitalize-first"/>
+              <text variable="event" text-case="uppercase"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <text variable="event"/>
+        <text variable="event-place"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="guest">
+    <choose>
+      <if variable="guest" match="any">
+        <names variable="guest">
+          <label form="long" text-case="capitalize-first" suffix=": "/>
+          <name delimiter=", " sort-separator=" " delimiter-precedes-last="always">
+            <name-part name="given"/>
+            <name-part name="family"/>
+          </name>
+          <et-al font-style="italic"/>
+        </names>
+      </if>
+      <else-if variable="author" match="any"/>
+      <else>
+        <text variable="title" text-case="uppercase"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if variable="issued" match="any">
+        <date variable="issued" delimiter=" ">
+          <date-part name="day"/>
+          <date-part name="month" form="short"/>
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else-if type="patent" match="any">
+        <date variable="issued" delimiter=" " prefix="Concessão: ">
+          <date-part name="day"/>
+          <date-part name="month" form="short"/>
+          <date-part name="year"/>
+        </date>
+      </else-if>
+      <else>
+        <text term="no date" form="short" text-case="capitalize-first" font-style="italic" prefix="[" suffix="]"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued-year">
+    <choose>
+      <if variable="issued" match="any">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short" text-case="capitalize-first" font-style="italic" prefix="[" suffix="]"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locators">
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <label variable="volume" form="short"/>
+        <text variable="volume"/>
+      </group>
+      <group delimiter=" ">
+        <label variable="issue" form="short"/>
+        <text variable="issue"/>
+      </group>
+      <group delimiter=" ">
+        <label variable="edition" form="short"/>
+        <text variable="edition"/>
+      </group>
+      <group delimiter=" ">
+        <label variable="section" text-case="capitalize-first"/>
+        <text variable="section"/>
+      </group>
+      <group delimiter=" ">
+        <label variable="page" form="short"/>
+        <text variable="page"/>
+      </group>
+      <group delimiter=" ">
+        <label variable="number" form="short"/>
+        <text variable="number"/>
+      </group>
+      <group delimiter=" ">
+        <label variable="version" form="long" text-case="capitalize-first"/>
+        <text variable="version"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="medium">
+    <choose>
+      <if type="software" match="any">
+        <text variable="medium" prefix="(" suffix=")"/>
+      </if>
+      <else-if type="broadcast" match="any">
+        <text variable="medium" font-style="italic"/>
+      </else-if>
+      <else>
+        <text variable="medium"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="number-of-pages">
+    <choose>
+      <if type="book chapter paper-conference report" match="any">
+        <choose>
+          <if variable="number-of-pages" match="any">
+            <group delimiter=" ">
+              <text variable="number-of-pages"/>
+              <label variable="number-of-pages" form="short"/>
+            </group>
+          </if>
+        </choose>
+      </if>
+      <else-if type="thesis" match="any">
+        <choose>
+          <if variable="number-of-pages" match="any">
+            <group delimiter=" ">
+              <text variable="number-of-pages"/>
+              <text term="folio" form="short"/>
+            </group>
+          </if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="performer">
+    <text term="performer" form="verb" text-case="capitalize-first" suffix=": "/>
+    <names variable="author">
+      <name delimiter=", " sort-separator=" " delimiter-precedes-last="always">
+        <name-part name="given"/>
+        <name-part name="family"/>
+      </name>
+      <et-al font-style="italic"/>
+    </names>
+  </macro>
+  <macro name="place">
+    <text value=""/>
+  </macro>
+  <macro name="producer">
+    <names variable="producer">
+      <label form="long" text-case="capitalize-first" suffix=": "/>
+      <name delimiter=", " sort-separator=" " delimiter-precedes-last="always">
+        <name-part name="given"/>
+        <name-part name="family"/>
+      </name>
+      <et-al font-style="italic"/>
+      <substitute>
+        <text variable="title" text-case="uppercase"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="article" match="any">
+        <choose>
+          <if variable="publisher">
+            <text variable="publisher" font-weight="bold"/>
+          </if>
+          <else>
+            <text term="no-publisher" form="short" text-case="capitalize-first" font-style="normal" font-weight="bold" prefix="[" suffix="]"/>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <group delimiter=": ">
+          <text macro="place"/>
+          <choose>
+            <if variable="publisher">
+              <text variable="publisher"/>
+            </if>
+            <else>
+              <text term="no-publisher" form="short" text-case="capitalize-first" font-style="italic" prefix="[" suffix="]"/>
+            </else>
+          </choose>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="submitted">
+    <choose>
+      <if variable="submitted" match="any">
+        <date variable="submitted" delimiter=" " prefix="Depósito: ">
+          <date-part name="day"/>
+          <date-part name="month" form="short"/>
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short" text-case="capitalize-first" font-style="italic" prefix=", [" suffix="]"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="article article-newspaper article-magazine article-journal bill chapter paper-conference post post-weblog webpage" match="any">
+        <text variable="title"/>
+      </if>
+      <else-if type="entry-dictionary entry-encyclopedia" match="any">
+        <choose>
+          <if variable="author container-author collection-editor editor organizer contributor" match="any">
+            <text variable="title" font-weight="bold"/>
+          </if>
+          <else>
+            <text variable="title" text-case="uppercase"/>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="motion_picture song" match="any">
+        <text variable="title" text-case="uppercase"/>
+      </else-if>
+      <else-if type="personal_communication" match="any">
+        <text variable="title" font-weight="bold"/>
+      </else-if>
+      <else>
+        <text variable="title" font-weight="bold"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="translator">
+    <names variable="translator" delimiter=", ">
+      <label text-case="capitalize-first" suffix=": "/>
+      <name delimiter=", " sort-separator=" " delimiter-precedes-last="always">
+        <name-part name="given"/>
+        <name-part name="family"/>
+      </name>
+      <et-al font-style="italic"/>
+    </names>
+  </macro>
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year-suffix" givenname-disambiguation-rule="primary-name" year-suffix-delimiter=", ">
+    <sort>
+      <key macro="author"/>
+      <key macro="title"/>
+      <key macro="issued-year"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group>
+        <text suffix=", " macro="author-short"/>
+        <text macro="issued-year"/>
+        <text prefix=", " macro="citation-locator"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="false" entry-spacing="1" line-spacing="1">
+    <sort>
+      <key macro="author"/>
+      <key macro="title"/>
+      <key macro="issued"/>
+    </sort>
+    <layout suffix=".">
+      <choose>
+        <if type="article">
+          <group delimiter=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <text macro="translator"/>
+            <text macro="contributor"/>
+            <group delimiter=", ">
+              <text macro="publisher"/>
+              <text macro="locators"/>
+              <text macro="issued"/>
+            </group>
+            <text macro="access"/>
+          </group>
+        </if>
+        <else-if type="article-journal article-magazine article-newspaper" match="any">
+          <group delimiter=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <text macro="translator"/>
+            <text macro="contributor"/>
+            <group delimiter=", ">
+              <text macro="container-title"/>
+              <text macro="place"/>
+              <text macro="locators"/>
+              <text macro="issued"/>
+            </group>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <else-if type="bill">
+          <group delimiter=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <text variable="abstract"/>
+            <group delimiter=", ">
+              <text macro="container-title"/>
+              <text macro="place"/>
+              <text macro="locators"/>
+            </group>
+            <text macro="issued"/>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <else-if type="book report" match="any">
+          <group delimiter=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <text macro="translator"/>
+            <text macro="edition"/>
+            <group delimiter=", ">
+              <text macro="publisher"/>
+              <text macro="issued"/>
+            </group>
+            <text macro="number-of-pages"/>
+            <text macro="collection-info"/>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <else-if type="chapter entry-dictionary entry-encyclopedia" match="any">
+          <group delimiter=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <choose>
+              <if type="chapter" match="any">
+                <text macro="container-contributors"/>
+              </if>
+            </choose>
+            <text macro="container-title"/>
+            <choose>
+              <if type="chapter" match="any">
+                <text macro="translator"/>
+              </if>
+            </choose>
+            <text macro="edition"/>
+            <group delimiter=", ">
+              <text macro="publisher"/>
+              <text macro="issued"/>
+            </group>
+            <text macro="locators"/>
+            <text macro="collection-info"/>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <else-if type="graphic">
+          <group delimiter=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <group delimiter=", ">
+              <text variable="medium"/>
+              <text variable="dimensions"/>
+            </group>
+            <text variable="archive"/>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <else-if type="broadcast">
+          <group delimiter=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <text macro="contributor"/>
+            <text macro="guest"/>
+            <group delimiter=", ">
+              <group delimiter=": ">
+                <text macro="place"/>
+                <text variable="collection-title"/>
+              </group>
+              <text macro="issued"/>
+            </group>
+            <group delimiter=" ">
+              <text macro="medium"/>
+              <text macro="dimensions"/>
+            </group>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <else-if type="interview software" match="any">
+          <group delimiter=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <choose>
+              <if type="interview">
+                <text macro="contributor"/>
+              </if>
+            </choose>
+            <choose>
+              <if type="software">
+                <text macro="locators"/>
+              </if>
+            </choose>
+            <group delimiter=", ">
+              <text macro="publisher"/>
+              <text macro="issued"/>
+            </group>
+            <text macro="medium"/>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <else-if type="manuscript">
+          <group delimiter=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <text variable="archive"/>
+            <text macro="issued"/>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <else-if type="map">
+          <group delimiter=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <text macro="edition"/>
+            <group delimiter=", ">
+              <text macro="publisher"/>
+              <text macro="issued"/>
+            </group>
+            <group delimiter=", ">
+              <text variable="genre"/>
+              <text variable="scale"/>
+              <text variable="archive"/>
+            </group>
+            <text macro="collection-info"/>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <else-if type="motion_picture song" match="any">
+          <group delimiter=". ">
+            <text macro="title"/>
+            <choose>
+              <if type="motion_picture">
+                <text macro="director"/>
+                <text macro="producer"/>
+              </if>
+              <else>
+                <text macro="composer"/>
+                <text macro="performer"/>
+              </else>
+            </choose>
+            <group delimiter=", ">
+              <text macro="publisher"/>
+              <text macro="issued"/>
+            </group>
+            <group delimiter=" ">
+              <text variable="medium"/>
+              <text macro="dimensions"/>
+            </group>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <else-if type="paper-conference">
+          <group delimiter=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <text macro="container-contributors"/>
+            <text macro="event"/>
+            <text macro="issued"/>
+            <text macro="container-title"/>
+            <group delimiter=", ">
+              <text macro="publisher"/>
+              <text macro="issued"/>
+            </group>
+            <text macro="locators"/>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <else-if type="personal_communication">
+          <group delimiter=". " suffix=", ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <text macro="contributor"/>
+            <text macro="place"/>
+          </group>
+          <group delimiter=". " suffix=". ">
+            <text macro="issued"/>
+            <text variable="genre"/>
+          </group>
+          <text macro="access"/>
+        </else-if>
+        <else-if type="thesis">
+          <group delimiter=". " suffix=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <text macro="issued"/>
+            <text macro="number-of-pages"/>
+          </group>
+          <group delimiter=" &#8211; ">
+            <text variable="genre"/>
+            <group delimiter=", " suffix=". ">
+              <text variable="publisher"/>
+              <text macro="issued"/>
+            </group>
+          </group>
+          <text macro="access"/>
+        </else-if>
+        <else-if type="post post-weblog webpage" match="any">
+          <group delimiter=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <text macro="container-title"/>
+            <text macro="issued"/>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <else-if type="patent">
+          <group delimiter=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <text macro="container-contributors"/>
+            <text macro="contributor"/>
+            <text macro="submitted"/>
+            <text macro="issued"/>
+            <text macro="locators"/>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <else>
+          <group delimiter=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <text macro="container-contributors"/>
+            <text macro="container-title"/>
+            <text variable="collection-title"/>
+            <text macro="locators"/>
+            <group delimiter=", ">
+              <text macro="publisher"/>
+              <text macro="issued"/>
+            </group>
+            <text macro="collection-info"/>
+            <text macro="access"/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>

--- a/nucleo-de-mecanizacao-e-agricultura-de-precisao-abnt.csl
+++ b/nucleo-de-mecanizacao-e-agricultura-de-precisao-abnt.csl
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" demote-non-dropping-particle="never">
+
   <info>
     <title>Núcleo de Mecanização e Agricultura de Precisão - ABNT (Portuguese - Brazil)</title>
     <title-short>NMAP</title-short>
@@ -467,7 +468,7 @@
       <et-al font-style="italic"/>
     </names>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year-suffix" givenname-disambiguation-rule="primary-name" year-suffix-delimiter=", ">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year-suffix" givenname-disambiguation-rule="primary-name" year-suffix-delimiter=", ">
     <sort>
       <key macro="author"/>
       <key macro="title"/>

--- a/nucleo-de-mecanizacao-e-agricultura-de-precisao-abnt.csl
+++ b/nucleo-de-mecanizacao-e-agricultura-de-precisao-abnt.csl
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" demote-non-dropping-particle="never">
-
   <info>
     <title>Núcleo de Mecanização e Agricultura de Precisão - ABNT (Portuguese - Brazil)</title>
     <title-short>NMAP</title-short>


### PR DESCRIPTION
This is the official customized citation style strictly adopted by the Núcleo de Mecanização e Agricultura de Precisão for formatting internal reports and academic manuscripts in precision agriculture. Our laboratory guidelines mandate the suppression of the publisher-place variable to standardize automated metadata extraction from indexing databases, and explicitly require DOI prioritization over generic URLs.