### PR TITLE
Update pontifical-biblical-institute.csl

### DIFF
--- a/pontifical-biblical-institute.csl
+++ b/pontifical-biblical-institute.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" initialize-with-hyphen="true" page-range-format="expanded" demote-non-dropping-particle="sort-only" name-delimiter=" &#8211; " names-delimiter=" &#8211; " delimiter-precedes-last="always" et-al-min="4" et-al-use-first="1" name-form="long" initialize-with="." sort-separator=", ">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" initialize-with-hyphen="true" page-range-format="expanded" demote-non-dropping-particle="sort-only" name-delimiter=" – " names-delimiter=" – " delimiter-precedes-last="always" et-al-min="4" et-al-use-first="1" name-form="long" initialize-with="." sort-separator=", ">
   <!-- Polyglot -->
   <info>
     <title>Pontifical Biblical Institute</title>
@@ -13,6 +13,10 @@
     <contributor>
       <name>Patrick O'Brien</name>
       <email>info@citationstyler.com</email>
+    </contributor>
+    <contributor>
+      <name>Erasmo Barresi</name>
+      <email>erasmobarresi@gmail.com</email>
     </contributor>
     <category citation-format="note"/>
     <category field="theology"/>
@@ -400,16 +404,23 @@
     <choose>
       <if type="book chapter" match="any">
         <choose>
-          <if is-numeric="volume">
-            <number variable="volume" form="roman" text-case="uppercase"/>
-          </if>
-          <else>
-            <text variable="volume"/>
-          </else>
-        </choose>
-        <choose>
-          <if variable="volume locator" match="all">
-            <text value=","/>
+          <if variable="volume">
+            <choose>
+              <if is-numeric="volume">
+                <number variable="volume" form="roman" text-case="uppercase"/>
+              </if>
+              <else>
+                <text variable="volume"/>
+              </else>
+            </choose>
+            <choose>
+              <if variable="page locator" match="any">
+                <text value=","/>
+              </if>
+              <else-if variable="URL accessed" match="all">
+                <text value=","/>
+              </else-if>
+            </choose>
           </if>
         </choose>
       </if>
@@ -667,7 +678,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography subsequent-author-substitute="&#8211;&#8211;&#8211;&#8211;">
+  <bibliography subsequent-author-substitute="––––">
     <sort>
       <key macro="contributors-reviewers-bibliography"/>
       <key macro="contributors-bibliography"/>
@@ -687,14 +698,7 @@
       </group>
       <group delimiter=", ">
         <text macro="number-of-volumes" prefix=" "/>
-        <choose>
-          <if variable="page URL" match="any">
-            <text macro="volume-number" prefix=" " suffix=","/>
-          </if>
-          <else>
-            <text macro="volume-number" prefix=" "/>
-          </else>
-        </choose>
+        <text macro="volume-number" prefix=" "/>
       </group>
       <text macro="container-review"/>
       <group delimiter=", ">

--- a/pontifical-biblical-institute.csl
+++ b/pontifical-biblical-institute.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" initialize-with-hyphen="true" page-range-format="expanded" demote-non-dropping-particle="sort-only" name-delimiter=" – " names-delimiter=" – " delimiter-precedes-last="always" et-al-min="4" et-al-use-first="1" name-form="long" initialize-with="." sort-separator=", ">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" initialize-with-hyphen="true" page-range-format="expanded" demote-non-dropping-particle="sort-only" name-delimiter=" &#8211; " names-delimiter=" &#8211; " delimiter-precedes-last="always" et-al-min="4" et-al-use-first="1" name-form="long" initialize-with="." sort-separator=", ">
   <!-- Polyglot -->
   <info>
     <title>Pontifical Biblical Institute</title>
@@ -678,7 +678,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography subsequent-author-substitute="––––">
+  <bibliography subsequent-author-substitute="&#8211;&#8211;&#8211;&#8211;">
     <sort>
       <key macro="contributors-reviewers-bibliography"/>
       <key macro="contributors-bibliography"/>

--- a/pontifical-biblical-institute.csl
+++ b/pontifical-biblical-institute.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" initialize-with-hyphen="true" page-range-format="expanded" demote-non-dropping-particle="sort-only" name-delimiter=" – " names-delimiter=" – " delimiter-precedes-last="always" et-al-min="4" et-al-use-first="1" name-form="long" initialize-with="." sort-separator=", ">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" initialize-with-hyphen="true" page-range-format="expanded" demote-non-dropping-particle="sort-only" name-delimiter=" &#8211; " names-delimiter=" &#8211; " delimiter-precedes-last="always" et-al-min="4" et-al-use-first="1" name-form="long" initialize-with="." sort-separator=", ">
   <!-- Polyglot -->
   <info>
     <title>Pontifical Biblical Institute</title>
@@ -667,7 +667,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography subsequent-author-substitute="––––">
+  <bibliography subsequent-author-substitute="&#8211;&#8211;&#8211;&#8211;">
     <sort>
       <key macro="contributors-reviewers-bibliography"/>
       <key macro="contributors-bibliography"/>

--- a/pontifical-biblical-institute.csl
+++ b/pontifical-biblical-institute.csl
@@ -17,7 +17,7 @@
     <category citation-format="note"/>
     <category field="theology"/>
     <summary>The Pontifical Biblical Institute (Pontificio Istituto Biblico) style</summary>
-    <updated>2026-06-02T14:35:49+00:00</updated>
+    <updated>2026-06-02T07:21:14+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -687,7 +687,14 @@
       </group>
       <group delimiter=", ">
         <text macro="number-of-volumes" prefix=" "/>
-        <text macro="volume-number" prefix=" "/>
+        <choose>
+          <if variable="page URL" match="any">
+            <text macro="volume-number" prefix=" " suffix=","/>
+          </if>
+          <else>
+            <text macro="volume-number" prefix=" "/>
+          </else>
+        </choose>
       </group>
       <text macro="container-review"/>
       <group delimiter=", ">


### PR DESCRIPTION
## CSL Styles Pull Request Template
You're about to create a pull request to the CSL **styles** repository.  
If you haven't done so already, see <https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md> for instructions on how to contribute, and <https://github.com/citation-style-language/styles/blob/master/STYLE_REQUIREMENTS.md> for the requirements a style must meet before acceptance.  
In addition, please fill out the pull request template below.


### Description
The issue is discussed here: https://forums.zotero.org/discussion/130546/style-error-pontifical-biblical-institute

Since then, I've come across and read the CSL primer on citationstyles.org, and I've realized that the CSL language is not too hard to understand! (though it takes time to understand a long CSL file like this one) Therefore, I propose this change.

The logic of the change is this: in a bibliography, the volume number should be followed by a comma but only if further information (page range or URL) follows in the same entry. The macro called "container-review" is excluded from this reasoning because it already generates a comma as prefix (prefix=", ").

### Checklist
- [ ] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  [not applicable, I think]
- [x] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update.
- [ ] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`). [I'm not sure what this means.]
- [x] Check that you've not used `<text value="...` if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.
