### PR TITLE
infoclio.ch style: adding support for periodicals

### DIFF
--- a/infoclio-de-kurzbelege.csl
+++ b/infoclio-de-kurzbelege.csl
@@ -25,7 +25,7 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2024-09-04T12:30:00+02:00</updated>
+    <updated>2025-09-10T14:15:00+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
@@ -73,6 +73,7 @@
       <group delimiter=", ">
         <group delimiter=": ">
           <text macro="creator"/>
+          <text macro="periodical-info"/>
           <group delimiter=", ">
             <text macro="title"/>
             <text macro="scientific-editor"/>
@@ -117,22 +118,26 @@
   </macro>
   <macro name="creator">
     <choose>
-      <if variable="director">
-        <!-- special rule to avoid printing the label for directors -->
-        <names variable="director">
-          <name sort-separator=", " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
-        </names>
+      <if type="periodical" match="none">
+        <choose>
+          <if variable="director">
+            <!-- special rule to avoid printing the label for directors -->
+            <names variable="director">
+              <name sort-separator=", " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
+            </names>
+          </if>
+          <else>
+            <names variable="author">
+              <name sort-separator=", " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
+              <label form="short" prefix="&#160;(" suffix=")"/>
+              <substitute>
+                <names variable="editor"/>
+                <names variable="composer"/>
+              </substitute>
+            </names>
+          </else>
+        </choose>
       </if>
-      <else>
-        <names variable="author">
-          <name sort-separator=", " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
-          <label form="short" prefix="&#160;(" suffix=")"/>
-          <substitute>
-            <names variable="editor"/>
-            <names variable="composer"/>
-          </substitute>
-        </names>
-      </else>
     </choose>
   </macro>
   <macro name="creator-for-short-references">
@@ -145,6 +150,19 @@
         <names variable="director"/>
       </substitute>
     </names>
+  </macro>
+  <macro name="periodical-info">
+    <choose>
+      <if type="periodical">
+        <group delimiter=" ">
+          <text variable="container-title"/>
+          <group delimiter="&#160;">
+            <number variable="volume"/>
+            <number variable="issue" prefix="(" suffix=")"/>
+          </group>
+        </group>
+      </if>
+    </choose>
   </macro>
   <macro name="title">
     <group delimiter=" ">
@@ -362,6 +380,16 @@
           </if>
         </choose>
       </if>
+      <else-if type="periodical">
+        <choose>
+          <if variable="volume issue" match="none">
+            <date variable="issued" form="numeric" date-parts="year" prefix="Jg.&#160;"/>
+          </if>
+          <else>
+            <date variable="issued" form="numeric" date-parts="year"/>
+          </else>
+        </choose>
+      </else-if>
       <else>
         <date variable="issued" form="numeric" date-parts="year-month-day"/>
       </else>
@@ -444,19 +472,36 @@
       <if type="webpage post post-weblog dataset" match="any">
         <text macro="url-or-doi"/>
       </if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="page" match="none">
+            <text macro="url-or-doi"/>
+          </if>
+        </choose>
+      </else-if>
     </choose>
   </macro>
   <macro name="url-non-web-documents">
     <choose>
-      <if type="webpage post post-weblog dataset" match="none">
+      <if type="article-journal">
         <choose>
-          <if variable="DOI URL" match="any">
-            <group delimiter=": ">
-              <text term="online" text-case="capitalize-first"/>
-              <text macro="url-or-doi"/>
-            </group>
+          <if variable="page">
+            <text macro="url-or-doi-with-online-term"/>
           </if>
         </choose>
+      </if>
+      <else-if type="webpage post post-weblog dataset" match="none">
+        <text macro="url-or-doi-with-online-term"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="url-or-doi-with-online-term">
+    <choose>
+      <if variable="DOI URL" match="any">
+        <group delimiter=": ">
+          <text term="online" text-case="capitalize-first"/>
+          <text macro="url-or-doi"/>
+        </group>
       </if>
     </choose>
   </macro>
@@ -464,11 +509,7 @@
     <choose>
       <if variable="DOI">
         <group delimiter=", ">
-          <group delimiter="">
-            <text value="&lt;"/>
-            <text variable="DOI" prefix="https://doi.org/"/>
-            <text value="&gt;"/>
-          </group>
+          <text variable="DOI" prefix="&lt;https://doi.org/" suffix="&gt;"/>
           <text macro="accessed"/>
         </group>
       </if>

--- a/infoclio-de.csl
+++ b/infoclio-de.csl
@@ -25,7 +25,7 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2024-09-04T12:30:00+02:00</updated>
+    <updated>2025-09-10T14:15:00+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
@@ -76,6 +76,7 @@
       <group delimiter=", ">
         <group delimiter=": ">
           <text macro="creator"/>
+          <text macro="periodical-info"/>
           <group delimiter=", ">
             <text macro="title"/>
             <text macro="scientific-editor"/>
@@ -120,22 +121,26 @@
   </macro>
   <macro name="creator">
     <choose>
-      <if variable="director">
-        <!-- special rule to avoid printing the label for directors -->
-        <names variable="director">
-          <name sort-separator=", " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
-        </names>
+      <if type="periodical" match="none">
+        <choose>
+          <if variable="director">
+            <!-- special rule to avoid printing the label for directors -->
+            <names variable="director">
+              <name sort-separator=", " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
+            </names>
+          </if>
+          <else>
+            <names variable="author">
+              <name sort-separator=", " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
+              <label form="short" prefix="&#160;(" suffix=")"/>
+              <substitute>
+                <names variable="editor"/>
+                <names variable="composer"/>
+              </substitute>
+            </names>
+          </else>
+        </choose>
       </if>
-      <else>
-        <names variable="author">
-          <name sort-separator=", " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
-          <label form="short" prefix="&#160;(" suffix=")"/>
-          <substitute>
-            <names variable="editor"/>
-            <names variable="composer"/>
-          </substitute>
-        </names>
-      </else>
     </choose>
   </macro>
   <macro name="creator-for-subsequent">
@@ -148,6 +153,19 @@
         <names variable="director"/>
       </substitute>
     </names>
+  </macro>
+  <macro name="periodical-info">
+    <choose>
+      <if type="periodical">
+        <group delimiter=" ">
+          <text variable="container-title"/>
+          <group delimiter="&#160;">
+            <number variable="volume"/>
+            <number variable="issue" prefix="(" suffix=")"/>
+          </group>
+        </group>
+      </if>
+    </choose>
   </macro>
   <macro name="title">
     <group delimiter=" ">
@@ -365,6 +383,16 @@
           </if>
         </choose>
       </if>
+      <else-if type="periodical">
+        <choose>
+          <if variable="volume issue" match="none">
+            <date variable="issued" form="numeric" date-parts="year" prefix="Jg.&#160;"/>
+          </if>
+          <else>
+            <date variable="issued" form="numeric" date-parts="year"/>
+          </else>
+        </choose>
+      </else-if>
       <else>
         <date variable="issued" form="numeric" date-parts="year-month-day"/>
       </else>
@@ -447,19 +475,36 @@
       <if type="webpage post post-weblog dataset" match="any">
         <text macro="url-or-doi"/>
       </if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="page" match="none">
+            <text macro="url-or-doi"/>
+          </if>
+        </choose>
+      </else-if>
     </choose>
   </macro>
   <macro name="url-non-web-documents">
     <choose>
-      <if type="webpage post post-weblog dataset" match="none">
+      <if type="article-journal">
         <choose>
-          <if variable="DOI URL" match="any">
-            <group delimiter=": ">
-              <text term="online" text-case="capitalize-first"/>
-              <text macro="url-or-doi"/>
-            </group>
+          <if variable="page">
+            <text macro="url-or-doi-with-online-term"/>
           </if>
         </choose>
+      </if>
+      <else-if type="webpage post post-weblog dataset" match="none">
+        <text macro="url-or-doi-with-online-term"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="url-or-doi-with-online-term">
+    <choose>
+      <if variable="DOI URL" match="any">
+        <group delimiter=": ">
+          <text term="online" text-case="capitalize-first"/>
+          <text macro="url-or-doi"/>
+        </group>
       </if>
     </choose>
   </macro>
@@ -467,11 +512,7 @@
     <choose>
       <if variable="DOI">
         <group delimiter=", ">
-          <group delimiter="">
-            <text value="&lt;"/>
-            <text variable="DOI" prefix="https://doi.org/"/>
-            <text value="&gt;"/>
-          </group>
+          <text variable="DOI" prefix="&lt;https://doi.org/" suffix="&gt;"/>
           <text macro="accessed"/>
         </group>
       </if>

--- a/infoclio-fr-nocaps.csl
+++ b/infoclio-fr-nocaps.csl
@@ -25,7 +25,7 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2024-09-04T12:30:00+02:00</updated>
+    <updated>2025-09-10T14:15:00+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -83,6 +83,7 @@
     <group delimiter=". ">
       <group delimiter=", ">
         <text macro="creator"/>
+        <text macro="periodical-info"/>
         <text macro="title"/>
         <text macro="scientific-editor"/>
         <group delimiter=": ">
@@ -125,22 +126,26 @@
   </macro>
   <macro name="creator">
     <choose>
-      <if variable="director">
-        <!-- special rule to avoid printing the label for directors -->
-        <names variable="director">
-          <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
-        </names>
+      <if type="periodical" match="none">
+        <choose>
+          <if variable="director">
+            <!-- special rule to avoid printing the label for directors -->
+            <names variable="director">
+              <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
+            </names>
+          </if>
+          <else>
+            <names variable="author">
+              <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
+              <label form="short" prefix="&#160;(" suffix=")"/>
+              <substitute>
+                <names variable="editor"/>
+                <names variable="composer"/>
+              </substitute>
+            </names>
+          </else>
+        </choose>
       </if>
-      <else>
-        <names variable="author">
-          <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
-          <label form="short" prefix="&#160;(" suffix=")"/>
-          <substitute>
-            <names variable="editor"/>
-            <names variable="composer"/>
-          </substitute>
-        </names>
-      </else>
     </choose>
   </macro>
   <macro name="creator-for-subsequent">
@@ -154,6 +159,19 @@
       </substitute>
     </names>
   </macro>
+  <macro name="periodical-info">
+    <choose>
+      <if type="periodical">
+        <group delimiter=" ">
+          <text variable="container-title" font-style="italic"/>
+          <group delimiter="&#160;">
+            <number variable="volume"/>
+            <number variable="issue" prefix="(" suffix=")"/>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
   <macro name="title">
     <choose>
       <if type="book thesis graphic" match="any">
@@ -166,6 +184,17 @@
           </choose>
         </group>
       </if>
+      <else-if type="periodical">
+        <choose>
+          <if variable="container-title title" match="all">
+            <!-- when citing a single issue -->
+            <text variable="title" quotes="true"/>
+          </if>
+          <else>
+            <text variable="title" font-style="italic"/>
+          </else>
+        </choose>
+      </else-if>
       <else-if type="article article-magazine article-newspaper article-journal entry entry-dictionary entry-encyclopedia report chapter paper-conference post post-weblog webpage song broadcast dataset" match="any">
         <text variable="title" quotes="true"/>
       </else-if>
@@ -438,6 +467,16 @@
       <if type="book chapter paper-conference thesis" match="any">
         <date variable="issued" form="numeric" date-parts="year"/>
       </if>
+      <else-if type="periodical">
+        <choose>
+          <if variable="volume issue" match="none">
+            <date variable="issued" form="numeric" date-parts="year" prefix="années "/>
+          </if>
+          <else>
+            <date variable="issued" form="numeric" date-parts="year"/>
+          </else>
+        </choose>
+      </else-if>
       <else>
         <date variable="issued" form="numeric" date-parts="year-month-day"/>
       </else>
@@ -520,19 +559,36 @@
       <if type="webpage post post-weblog dataset" match="any">
         <text macro="url-or-doi"/>
       </if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="page" match="none">
+            <text macro="url-or-doi"/>
+          </if>
+        </choose>
+      </else-if>
     </choose>
   </macro>
   <macro name="url-non-web-documents">
     <choose>
-      <if type="webpage post post-weblog dataset" match="none">
+      <if type="article-journal">
         <choose>
-          <if variable="DOI URL" match="any">
-            <group delimiter=": ">
-              <text term="online" text-case="capitalize-first"/>
-              <text macro="url-or-doi"/>
-            </group>
+          <if variable="page">
+            <text macro="url-or-doi-with-online-term"/>
           </if>
         </choose>
+      </if>
+      <else-if type="webpage post post-weblog dataset" match="none">
+        <text macro="url-or-doi-with-online-term"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="url-or-doi-with-online-term">
+    <choose>
+      <if variable="DOI URL" match="any">
+        <group delimiter=": ">
+          <text term="online" text-case="capitalize-first"/>
+          <text macro="url-or-doi"/>
+        </group>
       </if>
     </choose>
   </macro>
@@ -540,11 +596,7 @@
     <choose>
       <if variable="DOI">
         <group delimiter=", ">
-          <group delimiter="">
-            <text value="&lt;"/>
-            <text variable="DOI" prefix="https://doi.org/"/>
-            <text value="&gt;"/>
-          </group>
+          <text variable="DOI" prefix="&lt;https://doi.org/" suffix="&gt;"/>
           <text macro="accessed"/>
         </group>
       </if>

--- a/infoclio-fr-smallcaps.csl
+++ b/infoclio-fr-smallcaps.csl
@@ -24,7 +24,7 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2024-09-04T12:30:00+02:00</updated>
+    <updated>2025-09-10T14:15:00+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -82,6 +82,7 @@
     <group delimiter=". ">
       <group delimiter=", ">
         <text macro="creator"/>
+        <text macro="periodical-info"/>
         <text macro="title"/>
         <text macro="scientific-editor"/>
         <group delimiter=": ">
@@ -124,26 +125,30 @@
   </macro>
   <macro name="creator">
     <choose>
-      <if variable="director">
-        <!-- special rule to avoid printing the label for directors -->
-        <names variable="director">
-          <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3">
-            <name-part name="family" font-variant="small-caps"/>
-          </name>
-        </names>
+      <if type="periodical" match="none">
+        <choose>
+          <if variable="director">
+            <!-- special rule to avoid printing the label for directors -->
+            <names variable="director">
+              <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3">
+                <name-part name="family" font-variant="small-caps"/>
+              </name>
+            </names>
+          </if>
+          <else>
+            <names variable="author">
+              <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3">
+                <name-part name="family" font-variant="small-caps"/>
+              </name>
+              <label form="short" prefix="&#160;(" suffix=")"/>
+              <substitute>
+                <names variable="editor"/>
+                <names variable="composer"/>
+              </substitute>
+            </names>
+          </else>
+        </choose>
       </if>
-      <else>
-        <names variable="author">
-          <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3">
-            <name-part name="family" font-variant="small-caps"/>
-          </name>
-          <label form="short" prefix="&#160;(" suffix=")"/>
-          <substitute>
-            <names variable="editor"/>
-            <names variable="composer"/>
-          </substitute>
-        </names>
-      </else>
     </choose>
   </macro>
   <macro name="creator-for-subsequent">
@@ -159,6 +164,19 @@
       </substitute>
     </names>
   </macro>
+  <macro name="periodical-info">
+    <choose>
+      <if type="periodical">
+        <group delimiter=" ">
+          <text variable="container-title" font-style="italic"/>
+          <group delimiter="&#160;">
+            <number variable="volume"/>
+            <number variable="issue" prefix="(" suffix=")"/>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
   <macro name="title">
     <choose>
       <if type="book thesis graphic" match="any">
@@ -171,6 +189,17 @@
           </choose>
         </group>
       </if>
+      <else-if type="periodical">
+        <choose>
+          <if variable="container-title title" match="all">
+            <!-- when citing a single issue -->
+            <text variable="title" quotes="true"/>
+          </if>
+          <else>
+            <text variable="title" font-style="italic"/>
+          </else>
+        </choose>
+      </else-if>
       <else-if type="article article-magazine article-newspaper article-journal entry entry-dictionary entry-encyclopedia report chapter paper-conference post post-weblog webpage song broadcast dataset" match="any">
         <text variable="title" quotes="true"/>
       </else-if>
@@ -447,6 +476,16 @@
       <if type="book chapter paper-conference thesis" match="any">
         <date variable="issued" form="numeric" date-parts="year"/>
       </if>
+      <else-if type="periodical">
+        <choose>
+          <if variable="volume issue" match="none">
+            <date variable="issued" form="numeric" date-parts="year" prefix="années "/>
+          </if>
+          <else>
+            <date variable="issued" form="numeric" date-parts="year"/>
+          </else>
+        </choose>
+      </else-if>
       <else>
         <date variable="issued" form="numeric" date-parts="year-month-day"/>
       </else>
@@ -529,19 +568,36 @@
       <if type="webpage post post-weblog dataset" match="any">
         <text macro="url-or-doi"/>
       </if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="page" match="none">
+            <text macro="url-or-doi"/>
+          </if>
+        </choose>
+      </else-if>
     </choose>
   </macro>
   <macro name="url-non-web-documents">
     <choose>
-      <if type="webpage post post-weblog dataset" match="none">
+      <if type="article-journal">
         <choose>
-          <if variable="DOI URL" match="any">
-            <group delimiter=": ">
-              <text term="online" text-case="capitalize-first"/>
-              <text macro="url-or-doi"/>
-            </group>
+          <if variable="page">
+            <text macro="url-or-doi-with-online-term"/>
           </if>
         </choose>
+      </if>
+      <else-if type="webpage post post-weblog dataset" match="none">
+        <text macro="url-or-doi-with-online-term"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="url-or-doi-with-online-term">
+    <choose>
+      <if variable="DOI URL" match="any">
+        <group delimiter=": ">
+          <text term="online" text-case="capitalize-first"/>
+          <text macro="url-or-doi"/>
+        </group>
       </if>
     </choose>
   </macro>
@@ -549,11 +605,7 @@
     <choose>
       <if variable="DOI">
         <group delimiter=", ">
-          <group delimiter="">
-            <text value="&lt;"/>
-            <text variable="DOI" prefix="https://doi.org/"/>
-            <text value="&gt;"/>
-          </group>
+          <text variable="DOI" prefix="&lt;https://doi.org/" suffix="&gt;"/>
           <text macro="accessed"/>
         </group>
       </if>


### PR DESCRIPTION
This is an update to the infoclio.ch styles intended for history students and scholars - originally submitted in https://github.com/citation-style-language/styles/pull/234 and last updated in https://github.com/citation-style-language/styles/pull/7191.

This update brings following changes:

1. **Adding support for items of type `periodical`**, allowing users to cite specific issues or even a journal as a whole. Examples:

    Citing the journal:
    > Schweizerische Zeitschrift für Geschichte. Online: <https://www.sgg-ssh.ch/community/publikationen/>, Stand: 14.01.2025.

    A specific issue:
    >  Schweizerische Zeitschrift für Geschichte 74 (2), 2024. Online: <https://www.sgg-ssh.ch/szg/szg-rsh-rss-74-2024-no-2/>, Stand: 02.12.2024.

2. **Differentiating styling for journal articles depending on whether the variable `page` is filled out**:
    - No changes if a journal article has no DOI or URL. E.g., for `infoclio-de.csl`:
      
      > Bourdieu, Pierre: Die biographische Illusion, in: Bios 3 (1), 1990, S. 75-81.

    - No changes either if a journal article has both `page` and DOI or URL. The complete reference, ending with a period, is followed by the keyword “Online:” and the URL/DOI.
      
      > Gauchat, L.: Le nom de la ville d’Oron à l’époque romaine, in: Anzeiger für schweizerische Geschichte 18, 1920, S. 1–11. Online: <<https://doi.org/10.5169/seals-64626>>, Stand: 18.03.2014.

    - **NEW:** When the journal article has no page indication but it has a DOI or URL, it is considered to be an [online-only journal article](https://www.infoclio.ch/de/zitierstil#onlinezeitschriftenartikel), cited slightly differently: the URL/DOI is now part of the reference, and it is not separated by a period nor the word “Online:”.
      
      > Mason, Darielle: Timing the Timeless: Stella Kramrisch’s “Unknown India”, in: 21: Inquiries into Art, History, and the Visual 5 (4), 20.12.2024, <<https://doi.org/10.11588/xxi.2024.4.107515>>, Stand: 10.02.2025.

    (Actually, the style guide has made this distinction between journal articles that exist only online and those that also have a paper form for a long time. This change allows users to respect the guide.)

Many thanks for your work maintaining the styles repository.

cc @janbaumanninfoclio 

### Checklist
- [X] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.
- [X] Check that you've added a link to the style guidelines with `rel="documentation"`.
- [X] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update.
- [X] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [X] Check that you've not used `<text value="...` if not absolutely necessary.
- [X] Check that you've not changed line 1 of the style.

