### PR TITLE
Add APA7 bilingual Persian/English CSL style – improved

### DIFF
--- a/apa7-bilingual-fa-en.csl
+++ b/apa7-bilingual-fa-en.csl
@@ -5,17 +5,18 @@
 
   <!--
     APA 7th Edition – Bilingual (Persian/English)
-    &#x628;&#x647;&#x628;&#x648;&#x62F;&#x6CC;&#x627;&#x641;&#x62A;&#x647; &#x62A;&#x648;&#x633;&#x637; &#x62D;&#x627;&#x645;&#x62F; &#x641;&#x644;&#x627;&#x62D;  |  h.fallah@sau.ac.ir
+    بهبودیافته توسط حامد فلاح  |  h.fallah@sau.ac.ir
     Improved by Hamed Fallah
 
     Features:
     - Full APA 7th edition formatting
-    - Bilingual comma handling: Arabic comma (،) for Persian, Latin comma (,) for English
-    - Persian (Farsi) locale with translated APA terms
-    - English locale for English-language items
-    - Et al. rules per APA 7: in-text 3+, bibliography up to 20 authors
-    - DOI displayed as https://doi.org/
-    - Hanging indent, double-spaced bibliography
+    - Persian (Farsi) locale with Solar Hijri + Gregorian month names
+    - English locale for mixed-language bibliographies
+    - Latin punctuation throughout (standard practice in Iranian APA journals)
+    - Proper DOI/URL handling per APA 7
+    - Et al. rules: in-text (3+ authors), bibliography (up to 20 authors)
+    - Hanging indent bibliography
+    - Supports: books, articles, chapters, theses, webpages, conferences, reports, legal, etc.
   -->
 
   <info>
@@ -31,8 +32,12 @@
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="social_science"/>
-    <category field="generic-base"/>
-    <summary>APA 7th Edition style improved for bilingual Persian/English bibliographies. Uses conditional comma direction: Arabic comma for Persian items, Latin comma for English. Includes full Persian locale support. شیوه‌نامه APA ویرایش هفتم، بهبودیافته برای کتابنامه‌های دوزبانه فارسی و انگلیسی. بهبودیافته توسط حامد فلاح.</summary>
+    <summary>
+      APA 7th Edition style improved for bilingual Persian/English bibliographies.
+      Uses Latin punctuation throughout for consistency across mixed-language reference lists.
+      Includes full Persian locale support (Farsi month names, terms).
+      بهبودیافته برای کتابنامه‌های دوزبانه فارسی و انگلیسی.
+    </summary>
     <updated>2026-06-26T00:00:00+03:30</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
@@ -42,9 +47,11 @@
   <!-- ============================================================ -->
   <locale xml:lang="fa">
     <terms>
+      <!-- Quotes (Persian guillemets for Farsi text) -->
       <term name="open-quote">«</term>
       <term name="close-quote">»</term>
 
+      <!-- Months (Gregorian, in English – Zotero stores dates in Gregorian) -->
       <term name="month-01">January</term>
       <term name="month-02">February</term>
       <term name="month-03">March</term>
@@ -58,6 +65,7 @@
       <term name="month-11">November</term>
       <term name="month-12">December</term>
 
+      <!-- Roles in Persian (used when Zotero item language is fa) -->
       <term name="editor" form="short">
         <single>(ویراستار)</single>
         <multiple>(ویراستاران)</multiple>
@@ -77,6 +85,7 @@
         <multiple>(تصویرگران)</multiple>
       </term>
 
+      <!-- Core APA terms in Persian -->
       <term name="and">و</term>
       <term name="and others">و دیگران</term>
       <term name="in">در</term>
@@ -112,7 +121,7 @@
   </locale>
 
   <!-- ============================================================ -->
-  <!--  EN (ENGLISH) LOCALE                                         -->
+  <!--  EN (ENGLISH) LOCALE – activates when Zotero item lang is en -->
   <!-- ============================================================ -->
   <locale xml:lang="en">
     <terms>
@@ -333,6 +342,7 @@
           </if>
         </choose>
       </if>
+      <!-- Book, report, thesis, film, etc. → italic -->
       <else-if type="bill book graphic legal_case legislation motion_picture
                        report song thesis webpage post-weblog" match="any">
         <text variable="title" text-case="lowercase" font-style="italic"/>
@@ -341,6 +351,7 @@
           <text variable="version"/>
         </group>
       </else-if>
+      <!-- Article, chapter, webpage part → no italic, sentence case -->
       <else-if type="article-journal article-magazine article-newspaper
                        chapter entry-dictionary entry-encyclopedia
                        paper-conference review review-book" match="any">
@@ -355,6 +366,7 @@
   <!-- Container: journal name, or "In Editor (Ed.), Book Title" for chapters -->
   <macro name="container">
     <choose>
+      <!-- Chapter in edited book: "In E. Editor (Ed.), Book title (pp. xx-xx)" -->
       <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
         <group delimiter=", ">
           <text term="in" text-case="capitalize-first"/>
@@ -380,6 +392,7 @@
           </group>
         </group>
       </if>
+      <!-- Journal article: Journal Name (italic, title case) -->
       <else-if type="article-journal article-magazine article-newspaper
                      review review-book" match="any">
         <text variable="container-title" text-case="title" font-style="italic"/>
@@ -409,6 +422,7 @@
           </choose>
         </group>
       </if>
+      <!-- Magazine/Newspaper: pages only -->
       <else-if type="article-magazine article-newspaper" match="any">
         <choose>
           <if variable="page">

--- a/apa7-bilingual-fa-en.csl
+++ b/apa7-bilingual-fa-en.csl
@@ -118,100 +118,120 @@
     </terms>
   </locale>
 
-  <!-- ============================================================ -->
-  <!--  EN-US (ENGLISH) LOCALE – activates when Zotero item language is en -->
-  <!-- ============================================================ -->
-  <locale xml:lang="en-US">
-    <terms>
-      <term name="editor" form="short">
-        <single>(Ed.)</single>
-        <multiple>(Eds.)</multiple>
-      </term>
-      <term name="translator" form="short">
-        <single>(Trans.)</single>
-        <multiple>(Trans.)</multiple>
-      </term>
-      <term name="and">and</term>
-      <term name="and others">et al.</term>
-      <term name="in">In</term>
-      <term name="from">from</term>
-      <term name="no date">n.d.</term>
-      <term name="no date" form="short">n.d.</term>
-      <term name="anonymous">Anonymous</term>
-      <term name="edition" form="short">ed.</term>
-      <term name="volume" form="short">
-        <single>Vol.</single>
-        <multiple>Vols.</multiple>
-      </term>
-      <term name="issue" form="short">No.</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>pp.</multiple>
-      </term>
-      <term name="retrieved">Retrieved</term>
-      <term name="presented at">Paper presented at</term>
-      <term name="section" form="short">§</term>
-      <term name="original-work-published">Original work published</term>
-      <term name="review-of">Review of</term>
-    </terms>
-  </locale>
-
   <!-- ======================================================================= -->
   <!--  MACROS                                                               -->
   <!-- ======================================================================= -->
 
-  <!-- Author (bibliography) -->
+  <!-- Author (bibliography) — Arabic comma for Persian, Latin for others -->
   <macro name="author-bib">
-    <names variable="author">
-      <name name-as-sort-order="all"
-            and="text"
-            delimiter=", "
-            delimiter-precedes-last="always"
-            initialize-with=". "
-            sort-separator=", "/>
-      <label form="short" prefix=" (" suffix=")"/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else-if type="article-journal article-magazine article-newspaper
-                       review review-book webpage post-weblog" match="any">
-            <text macro="title"/>
-          </else-if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
-      </substitute>
-    </names>
+    <choose>
+      <if variable="language" match="fa">
+        <names variable="author">
+          <name name-as-sort-order="all"
+                and="text"
+                delimiter="، "
+                delimiter-precedes-last="always"
+                initialize-with=". "
+                sort-separator="، "/>
+          <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
+          <substitute>
+            <names variable="editor"/>
+            <names variable="translator"/>
+            <choose>
+              <if type="report">
+                <text variable="publisher"/>
+                <text macro="title"/>
+              </if>
+              <else-if type="article-journal article-magazine article-newspaper
+                           review review-book webpage post-weblog" match="any">
+                <text macro="title"/>
+              </else-if>
+              <else>
+                <text macro="title"/>
+              </else>
+            </choose>
+          </substitute>
+        </names>
+      </if>
+      <else>
+        <names variable="author">
+          <name name-as-sort-order="all"
+                and="text"
+                delimiter=", "
+                delimiter-precedes-last="always"
+                initialize-with=". "
+                sort-separator=", "/>
+          <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
+          <substitute>
+            <names variable="editor"/>
+            <names variable="translator"/>
+            <choose>
+              <if type="report">
+                <text variable="publisher"/>
+                <text macro="title"/>
+              </if>
+              <else-if type="article-journal article-magazine article-newspaper
+                           review review-book webpage post-weblog" match="any">
+                <text macro="title"/>
+              </else-if>
+              <else>
+                <text macro="title"/>
+              </else>
+            </choose>
+          </substitute>
+        </names>
+      </else>
+    </choose>
   </macro>
 
-  <!-- Author (in-text) -->
+  <!-- Author (in-text) — Arabic comma for Persian, Latin for others -->
   <macro name="author-intext">
-    <names variable="author">
-      <name form="short" and="text" delimiter=", " initialize-with=". "/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else-if type="article-journal article-magazine article-newspaper
-                       review review-book webpage post-weblog" match="any">
-            <text macro="title"/>
-          </else-if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
-      </substitute>
-    </names>
+    <choose>
+      <if variable="language" match="fa">
+        <names variable="author">
+          <name form="short" and="text" delimiter="، " initialize-with=". "/>
+          <substitute>
+            <names variable="editor"/>
+            <names variable="translator"/>
+            <choose>
+              <if type="report">
+                <text variable="publisher"/>
+                <text macro="title"/>
+              </if>
+              <else-if type="article-journal article-magazine article-newspaper
+                           review review-book webpage post-weblog" match="any">
+                <text macro="title"/>
+              </else-if>
+              <else>
+                <text macro="title"/>
+              </else>
+            </choose>
+          </substitute>
+        </names>
+      </if>
+      <else>
+        <names variable="author">
+          <name form="short" and="text" delimiter=", " initialize-with=". "/>
+          <substitute>
+            <names variable="editor"/>
+            <names variable="translator"/>
+            <choose>
+              <if type="report">
+                <text variable="publisher"/>
+                <text macro="title"/>
+              </if>
+              <else-if type="article-journal article-magazine article-newspaper
+                           review review-book webpage post-weblog" match="any">
+                <text macro="title"/>
+              </else-if>
+              <else>
+                <text macro="title"/>
+              </else>
+            </choose>
+          </substitute>
+        </names>
+      </else>
+    </choose>
   </macro>
 
   <!-- Date (bibliography) -->
@@ -511,23 +531,50 @@
       <key macro="author-intext"/>
       <key variable="issued"/>
     </sort>
-    <layout prefix="(" suffix=")" delimiter="; ">
-      <group delimiter=", ">
-        <text macro="author-intext"/>
-        <text macro="date-intext"/>
-        <choose>
-          <if variable="locator">
-            <group delimiter=" ">
+    <layout prefix="(" suffix=")">
+      <!-- Arabic comma for Persian items, Latin for others -->
+      <choose>
+        <if variable="language" match="fa">
+          <group delimiter="؛ ">
+            <group delimiter="، ">
+              <text macro="author-intext"/>
+              <text macro="date-intext"/>
               <choose>
-                <if locator="page" match="none">
-                  <label variable="locator" form="short"/>
+                <if variable="locator">
+                  <group delimiter=" ">
+                    <choose>
+                      <if locator="page" match="none">
+                        <label variable="locator" form="short"/>
+                      </if>
+                    </choose>
+                    <text variable="locator"/>
+                  </group>
                 </if>
               </choose>
-              <text variable="locator"/>
             </group>
-          </if>
-        </choose>
-      </group>
+          </group>
+        </if>
+        <else>
+          <group delimiter="; ">
+            <group delimiter=", ">
+              <text macro="author-intext"/>
+              <text macro="date-intext"/>
+              <choose>
+                <if variable="locator">
+                  <group delimiter=" ">
+                    <choose>
+                      <if locator="page" match="none">
+                        <label variable="locator" form="short"/>
+                      </if>
+                    </choose>
+                    <text variable="locator"/>
+                  </group>
+                </if>
+              </choose>
+            </group>
+          </group>
+        </else>
+      </choose>
     </layout>
   </citation>
 

--- a/apa7-bilingual-fa-en.csl
+++ b/apa7-bilingual-fa-en.csl
@@ -122,116 +122,58 @@
   <!--  MACROS                                                               -->
   <!-- ======================================================================= -->
 
-  <!-- Author (bibliography) — Arabic comma for Persian, Latin for others -->
+  <!-- Author (bibliography) -->
   <macro name="author-bib">
-    <choose>
-      <if variable="language" match="fa">
-        <names variable="author">
-          <name name-as-sort-order="all"
-                and="text"
-                delimiter="، "
-                delimiter-precedes-last="always"
-                initialize-with=". "
-                sort-separator="، "/>
-          <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
-          <substitute>
-            <names variable="editor"/>
-            <names variable="translator"/>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-                <text macro="title"/>
-              </if>
-              <else-if type="article-journal article-magazine article-newspaper
-                           review review-book webpage post-weblog" match="any">
-                <text macro="title"/>
-              </else-if>
-              <else>
-                <text macro="title"/>
-              </else>
-            </choose>
-          </substitute>
-        </names>
-      </if>
-      <else>
-        <names variable="author">
-          <name name-as-sort-order="all"
-                and="text"
-                delimiter=", "
-                delimiter-precedes-last="always"
-                initialize-with=". "
-                sort-separator=", "/>
-          <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
-          <substitute>
-            <names variable="editor"/>
-            <names variable="translator"/>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-                <text macro="title"/>
-              </if>
-              <else-if type="article-journal article-magazine article-newspaper
-                           review review-book webpage post-weblog" match="any">
-                <text macro="title"/>
-              </else-if>
-              <else>
-                <text macro="title"/>
-              </else>
-            </choose>
-          </substitute>
-        </names>
-      </else>
-    </choose>
+    <names variable="author">
+      <name name-as-sort-order="all"
+            and="text"
+            delimiter=", "
+            delimiter-precedes-last="always"
+            initialize-with=". "
+            sort-separator=", "/>
+      <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="report">
+            <text variable="publisher"/>
+            <text macro="title"/>
+          </if>
+          <else-if type="article-journal article-magazine article-newspaper
+                       review review-book webpage post-weblog" match="any">
+            <text macro="title"/>
+          </else-if>
+          <else>
+            <text macro="title"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
   </macro>
 
-  <!-- Author (in-text) — Arabic comma for Persian, Latin for others -->
+  <!-- Author (in-text) -->
   <macro name="author-intext">
-    <choose>
-      <if variable="language" match="fa">
-        <names variable="author">
-          <name form="short" and="text" delimiter="، " initialize-with=". "/>
-          <substitute>
-            <names variable="editor"/>
-            <names variable="translator"/>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-                <text macro="title"/>
-              </if>
-              <else-if type="article-journal article-magazine article-newspaper
-                           review review-book webpage post-weblog" match="any">
-                <text macro="title"/>
-              </else-if>
-              <else>
-                <text macro="title"/>
-              </else>
-            </choose>
-          </substitute>
-        </names>
-      </if>
-      <else>
-        <names variable="author">
-          <name form="short" and="text" delimiter=", " initialize-with=". "/>
-          <substitute>
-            <names variable="editor"/>
-            <names variable="translator"/>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-                <text macro="title"/>
-              </if>
-              <else-if type="article-journal article-magazine article-newspaper
-                           review review-book webpage post-weblog" match="any">
-                <text macro="title"/>
-              </else-if>
-              <else>
-                <text macro="title"/>
-              </else>
-            </choose>
-          </substitute>
-        </names>
-      </else>
-    </choose>
+    <names variable="author">
+      <name form="short" and="text" delimiter=", " initialize-with=". "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="report">
+            <text variable="publisher"/>
+            <text macro="title"/>
+          </if>
+          <else-if type="article-journal article-magazine article-newspaper
+                       review review-book webpage post-weblog" match="any">
+            <text macro="title"/>
+          </else-if>
+          <else>
+            <text macro="title"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
   </macro>
 
   <!-- Date (bibliography) -->
@@ -531,50 +473,23 @@
       <key macro="author-intext"/>
       <key variable="issued"/>
     </sort>
-    <layout prefix="(" suffix=")">
-      <!-- Arabic comma for Persian items, Latin for others -->
-      <choose>
-        <if variable="language" match="fa">
-          <group delimiter="؛ ">
-            <group delimiter="، ">
-              <text macro="author-intext"/>
-              <text macro="date-intext"/>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="author-intext"/>
+        <text macro="date-intext"/>
+        <choose>
+          <if variable="locator">
+            <group delimiter=" ">
               <choose>
-                <if variable="locator">
-                  <group delimiter=" ">
-                    <choose>
-                      <if locator="page" match="none">
-                        <label variable="locator" form="short"/>
-                      </if>
-                    </choose>
-                    <text variable="locator"/>
-                  </group>
+                <if locator="page" match="none">
+                  <label variable="locator" form="short"/>
                 </if>
               </choose>
+              <text variable="locator"/>
             </group>
-          </group>
-        </if>
-        <else>
-          <group delimiter="; ">
-            <group delimiter=", ">
-              <text macro="author-intext"/>
-              <text macro="date-intext"/>
-              <choose>
-                <if variable="locator">
-                  <group delimiter=" ">
-                    <choose>
-                      <if locator="page" match="none">
-                        <label variable="locator" form="short"/>
-                      </if>
-                    </choose>
-                    <text variable="locator"/>
-                  </group>
-                </if>
-              </choose>
-            </group>
-          </group>
-        </else>
-      </choose>
+          </if>
+        </choose>
+      </group>
     </layout>
   </citation>
 

--- a/apa7-bilingual-fa-en.csl
+++ b/apa7-bilingual-fa-en.csl
@@ -41,9 +41,9 @@
   </info>
 
   <!-- ============================================================ -->
-  <!--  FA (PERSIAN) LOCALE                                         -->
+  <!--  FA-IR (PERSIAN) LOCALE                                     -->
   <!-- ============================================================ -->
-  <locale xml:lang="fa">
+  <locale xml:lang="fa-IR">
     <terms>
       <!-- Quotes (Persian guillemets for Farsi text) -->
       <term name="open-quote">«</term>
@@ -119,9 +119,9 @@
   </locale>
 
   <!-- ============================================================ -->
-  <!--  EN (ENGLISH) LOCALE – activates when Zotero item lang is en -->
+  <!--  EN-US (ENGLISH) LOCALE – activates when Zotero item language is en -->
   <!-- ============================================================ -->
-  <locale xml:lang="en">
+  <locale xml:lang="en-US">
     <terms>
       <term name="editor" form="short">
         <single>(Ed.)</single>
@@ -306,11 +306,11 @@
   <!-- Container: journal name, or "In Editor (Ed.), Book Title" for chapters -->
   <macro name="container">
     <choose>
-      <!-- Chapter in edited book: "In E. Editor (Ed.), Book title (pp. xx-xx)" -->
+      <!-- Chapter in edited book: "In E. Editor (Ed.), Book title (xth ed., pp. xx-xx)" -->
       <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
-        <group delimiter=", ">
+        <group delimiter=" ">
           <text term="in" text-case="capitalize-first"/>
-          <names variable="editor translator" delimiter=", ">
+          <names variable="editor translator" delimiter=", " suffix=",">
             <name and="text" initialize-with=". " delimiter=", "
                   name-as-sort-order="all" sort-separator=", "/>
             <label form="short" prefix=" (" suffix=")"/>
@@ -391,18 +391,22 @@
     </group>
   </macro>
 
-  <!-- Edition -->
+  <!-- Edition (not printed for chapters — already in container) -->
   <macro name="edition">
     <choose>
-      <if is-numeric="edition">
-        <group delimiter=" " prefix=" (" suffix=")">
-          <number variable="edition" form="ordinal"/>
-          <text term="edition" form="short"/>
-        </group>
+      <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="none">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" " prefix=" (" suffix=")">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition" form="short"/>
+            </group>
+          </if>
+          <else-if variable="edition">
+            <text variable="edition" prefix=" (" suffix=")" text-case="capitalize-first"/>
+          </else-if>
+        </choose>
       </if>
-      <else-if variable="edition">
-        <text variable="edition" prefix=" (" suffix=")" text-case="capitalize-first"/>
-      </else-if>
     </choose>
   </macro>
 

--- a/apa7-bilingual-fa-en.csl
+++ b/apa7-bilingual-fa-en.csl
@@ -1,0 +1,577 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0"
+  demote-non-dropping-particle="never" default-locale="fa-IR"
+  page-range-format="minimal">
+
+  <!--
+    APA 7th Edition – Bilingual (Persian/English)
+    بهبودیافته توسط حامد فلاح  |  h.fallah@sau.ac.ir
+    Improved by Hamed Fallah
+
+    Features over the Iran Manual of Style:
+    - Full APA 7th edition formatting (not Chicago author-date)
+    - Latin punctuation throughout for mixed-language bibliographies
+    - Persian (Farsi) locale with translated APA terms
+    - English locale for English-language items
+    - Et al. rules per APA 7: in-text 3+, bibliography up to 20 authors
+    - DOI displayed as https://doi.org/
+    - Hanging indent, double-spaced bibliography
+    - Supports books, articles, chapters, theses, webpages, conferences, reports
+  -->
+
+  <info>
+    <title>APA 7th Edition (Persian/English – دوزبانه فارسی و انگلیسی)</title>
+    <title-short>APA7 (FA/EN)</title-short>
+    <id>http://www.zotero.org/styles/apa7-bilingual-fa-en</id>
+    <link href="http://www.zotero.org/styles/apa7-bilingual-fa-en" rel="self"/>
+    <link href="http://www.zotero.org/styles/apa" rel="template"/>
+    <link href="https://apastyle.apa.org/" rel="documentation"/>
+    <author>
+      <name>Hamed Fallah</name>
+      <email>h.fallah@sau.ac.ir</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="psychology"/>
+    <category field="social_science"/>
+    <category field="generic-base"/>
+    <summary lang="en">
+      APA 7th Edition style improved for bilingual Persian/English bibliographies.
+      Uses Latin punctuation throughout for consistency across mixed-language reference lists.
+      Includes full Persian locale support.
+    </summary>
+    <summary lang="fa">
+      شیوه‌نامه APA ویرایش هفتم، بهبودیافته برای کتابنامه‌های دوزبانه فارسی و انگلیسی.
+      بهبودیافته توسط حامد فلاح.
+    </summary>
+    <updated>2026-06-26T00:00:00+03:30</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">
+      This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License.
+    </rights>
+  </info>
+
+  <!-- ============================================================ -->
+  <!--  FA (PERSIAN) LOCALE                                         -->
+  <!-- ============================================================ -->
+  <locale xml:lang="fa">
+    <terms>
+      <term name="open-quote">«</term>
+      <term name="close-quote">»</term>
+
+      <term name="month-01">January</term>
+      <term name="month-02">February</term>
+      <term name="month-03">March</term>
+      <term name="month-04">April</term>
+      <term name="month-05">May</term>
+      <term name="month-06">June</term>
+      <term name="month-07">July</term>
+      <term name="month-08">August</term>
+      <term name="month-09">September</term>
+      <term name="month-10">October</term>
+      <term name="month-11">November</term>
+      <term name="month-12">December</term>
+
+      <term name="editor" form="short">
+        <single>(ویراستار)</single>
+        <multiple>(ویراستاران)</multiple>
+      </term>
+      <term name="editor" form="verb">ویراستهٔ</term>
+      <term name="editor" form="verb-short">ویرایش</term>
+
+      <term name="translator" form="short">
+        <single>(مترجم)</single>
+        <multiple>(مترجمان)</multiple>
+      </term>
+      <term name="translator" form="verb">ترجمهٔ</term>
+      <term name="translator" form="verb-short">ترجمهٔ</term>
+
+      <term name="illustrator" form="short">
+        <single>(تصویرگر)</single>
+        <multiple>(تصویرگران)</multiple>
+      </term>
+
+      <term name="and">و</term>
+      <term name="and others">و دیگران</term>
+      <term name="in">در</term>
+      <term name="from">از</term>
+      <term name="no date">بی‌تا</term>
+      <term name="no date" form="short">بی‌تا</term>
+      <term name="anonymous">ناشناس</term>
+      <term name="letter">نامه</term>
+      <term name="interview">مصاحبه</term>
+
+      <term name="edition" form="short">ویرایش</term>
+      <term name="volume" form="short">
+        <single>جلد</single>
+        <multiple>جلدهای</multiple>
+      </term>
+      <term name="issue" form="short">شماره</term>
+      <term name="page" form="short">
+        <single>ص</single>
+        <multiple>صص</multiple>
+      </term>
+      <term name="version">نسخه</term>
+
+      <term name="retrieved">بازیابی‌شده در</term>
+      <term name="accessed">دسترسی در</term>
+      <term name="presented at">ارائه‌شده در</term>
+      <term name="section" form="short">بخش</term>
+      <term name="paragraph" form="short">بند</term>
+      <term name="chapter" form="short">فصل</term>
+      <term name="original-work-published">اثر اصلی منتشرشده در</term>
+      <term name="reference">مرجع</term>
+      <term name="review of">نقدِ</term>
+    </terms>
+  </locale>
+
+  <!-- ============================================================ -->
+  <!--  EN (ENGLISH) LOCALE                                         -->
+  <!-- ============================================================ -->
+  <locale xml:lang="en">
+    <terms>
+      <term name="editor" form="short">
+        <single>(Ed.)</single>
+        <multiple>(Eds.)</multiple>
+      </term>
+      <term name="translator" form="short">
+        <single>(Trans.)</single>
+        <multiple>(Trans.)</multiple>
+      </term>
+      <term name="and">and</term>
+      <term name="and others">et al.</term>
+      <term name="in">In</term>
+      <term name="from">from</term>
+      <term name="no date">n.d.</term>
+      <term name="no date" form="short">n.d.</term>
+      <term name="anonymous">Anonymous</term>
+      <term name="edition" form="short">ed.</term>
+      <term name="volume" form="short">
+        <single>Vol.</single>
+        <multiple>Vols.</multiple>
+      </term>
+      <term name="issue" form="short">No.</term>
+      <term name="page" form="short">
+        <single>p.</single>
+        <multiple>pp.</multiple>
+      </term>
+      <term name="retrieved">Retrieved</term>
+      <term name="presented at">Paper presented at</term>
+      <term name="section" form="short">§</term>
+      <term name="original-work-published">Original work published</term>
+      <term name="review of">Review of</term>
+    </terms>
+  </locale>
+
+  <!-- ======================================================================= -->
+  <!--  MACROS                                                               -->
+  <!-- ======================================================================= -->
+
+  <macro name="author-bib">
+    <names variable="author">
+      <name name-as-sort-order="all"
+            and="text"
+            delimiter=", "
+            delimiter-precedes-last="always"
+            initialize-with=". "
+            sort-separator=", "/>
+      <label form="short" prefix=" (" suffix=")"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="report">
+            <text variable="publisher"/>
+            <text macro="title"/>
+          </if>
+          <else-if type="article-journal article-magazine article-newspaper
+                       review review-book webpage post-weblog" match="any">
+            <text macro="title"/>
+          </else-if>
+          <else>
+            <text macro="title"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+
+  <macro name="author-intext">
+    <names variable="author">
+      <name form="short" and="text" delimiter=", " initialize-with=". "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="report">
+            <text variable="publisher"/>
+            <text macro="title"/>
+          </if>
+          <else-if type="article-journal article-magazine article-newspaper
+                       review review-book webpage post-weblog" match="any">
+            <text macro="title"/>
+          </else-if>
+          <else>
+            <text macro="title"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+
+  <macro name="date-bib">
+    <choose>
+      <if variable="issued">
+        <group delimiter=" ">
+          <choose>
+            <if variable="original-date">
+              <date variable="original-date" form="text" date-parts="year" prefix="(" suffix=")."/>
+            </if>
+          </choose>
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </group>
+      </if>
+      <else-if variable="accessed">
+        <date variable="accessed">
+          <date-part name="year"/>
+        </date>
+      </else-if>
+      <else-if variable="status">
+        <text variable="status"/>
+      </else-if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+
+  <macro name="date-intext">
+    <choose>
+      <if variable="issued">
+        <group delimiter=" ">
+          <choose>
+            <if variable="original-date">
+              <date variable="original-date" form="text" date-parts="year" prefix="[" suffix="]"/>
+            </if>
+          </choose>
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </group>
+      </if>
+      <else-if variable="accessed">
+        <date variable="accessed">
+          <date-part name="year"/>
+        </date>
+      </else-if>
+      <else-if variable="status">
+        <text variable="status"/>
+      </else-if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+
+  <macro name="title">
+    <choose>
+      <if variable="title" match="none">
+        <choose>
+          <if type="personal_communication" match="none">
+            <text variable="genre" text-case="capitalize-first"/>
+          </if>
+        </choose>
+      </if>
+      <else-if type="bill book graphic legal_case legislation motion_picture
+                       report song thesis webpage post-weblog" match="any">
+        <text variable="title" text-case="sentence" font-style="italic"/>
+        <group prefix=" (" suffix=")" delimiter=" ">
+          <text term="version"/>
+          <text variable="version"/>
+        </group>
+      </else-if>
+      <else-if type="article-journal article-magazine article-newspaper
+                       chapter entry-dictionary entry-encyclopedia
+                       paper-conference review review-book" match="any">
+        <text variable="title" text-case="sentence"/>
+      </else-if>
+      <else>
+        <text variable="title" text-case="sentence" font-style="italic"/>
+      </else>
+    </choose>
+  </macro>
+
+  <macro name="container">
+    <choose>
+      <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
+        <group delimiter=", ">
+          <text term="in" text-case="capitalize-first"/>
+          <names variable="editor translator" delimiter=", ">
+            <name and="text" initialize-with=". " delimiter=", "
+                  name-as-sort-order="all" sort-separator=", "/>
+            <label form="short" prefix=" (" suffix=")"/>
+          </names>
+          <group delimiter=" ">
+            <text variable="container-title" text-case="sentence" font-style="italic"/>
+            <group prefix="(" suffix=")" delimiter=" ">
+              <choose>
+                <if is-numeric="edition">
+                  <number variable="edition" form="ordinal"/>
+                  <text term="edition" form="short"/>
+                </if>
+              </choose>
+            </group>
+          </group>
+          <group delimiter=" ">
+            <label variable="page" form="short" suffix="."/>
+            <text variable="page"/>
+          </group>
+        </group>
+      </if>
+      <else-if type="article-journal article-magazine article-newspaper
+                     review review-book" match="any">
+        <text variable="container-title" text-case="title" font-style="italic"/>
+      </else-if>
+    </choose>
+  </macro>
+
+  <macro name="volume-issue-pages">
+    <choose>
+      <if type="article-journal">
+        <group delimiter="">
+          <choose>
+            <if variable="volume">
+              <text variable="volume" font-style="italic"/>
+            </if>
+          </choose>
+          <choose>
+            <if variable="issue">
+              <text variable="issue" prefix="(" suffix=")"/>
+            </if>
+          </choose>
+          <choose>
+            <if variable="page">
+              <text variable="page" prefix=", "/>
+            </if>
+          </choose>
+        </group>
+      </if>
+      <else-if type="article-magazine article-newspaper" match="any">
+        <choose>
+          <if variable="page">
+            <text variable="page"/>
+          </if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+
+  <macro name="publisher">
+    <group delimiter="; ">
+      <choose>
+        <if type="thesis">
+          <text variable="publisher"/>
+        </if>
+        <else-if type="webpage post-weblog" match="any">
+          <text variable="container-title"/>
+        </else-if>
+        <else>
+          <text variable="publisher"/>
+          <text variable="publisher-place"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" " prefix=" (" suffix=")">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else-if variable="edition">
+        <text variable="edition" prefix=" (" suffix=")" text-case="capitalize-first"/>
+      </else-if>
+    </choose>
+  </macro>
+
+  <macro name="event">
+    <choose>
+      <if variable="event">
+        <group delimiter=", ">
+          <text variable="event"/>
+          <text variable="event-place"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="collection">
+    <choose>
+      <if variable="collection-title">
+        <group delimiter="; ">
+          <text variable="collection-title"/>
+          <text variable="collection-number"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="access">
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix="https://doi.org/"/>
+      </if>
+      <else-if type="webpage post-weblog" match="any">
+        <group delimiter=" ">
+          <text term="retrieved" text-case="sentence"/>
+          <date variable="accessed" form="text" suffix=","/>
+          <text term="from"/>
+          <text variable="URL"/>
+        </group>
+      </else-if>
+      <else-if variable="URL">
+        <text variable="URL"/>
+      </else-if>
+    </choose>
+  </macro>
+
+  <macro name="title-short">
+    <choose>
+      <if variable="title-short">
+        <text variable="title-short" text-case="sentence"/>
+      </if>
+      <else>
+        <text variable="title" text-case="sentence" form="short"/>
+      </else>
+    </choose>
+  </macro>
+
+  <macro name="description">
+    <choose>
+      <if type="thesis">
+        <text variable="genre" prefix=" [" suffix=" no.]"/>
+        <text variable="number" prefix=" "/>
+      </if>
+      <else-if type="interview">
+        <group delimiter="; ">
+          <text variable="medium"/>
+          <names variable="interviewer" delimiter=", ">
+            <label form="verb" suffix=" "/>
+            <name and="text" delimiter=", "/>
+          </names>
+        </group>
+      </else-if>
+      <else-if type="personal_communication">
+        <text variable="medium"/>
+      </else-if>
+      <else-if variable="genre">
+        <text variable="genre" prefix=" [" suffix="]"/>
+      </else-if>
+      <else-if type="report">
+        <group delimiter=" ">
+          <text variable="genre"/>
+          <text variable="number" prefix="(" suffix=")"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+
+  <macro name="original-date">
+    <choose>
+      <if variable="original-date">
+        <group delimiter=" " prefix="(" suffix=")">
+          <text term="original-work-published"/>
+          <date variable="original-date" form="text"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+
+  <!-- ======================================================================= -->
+  <!--  CITATION (IN-TEXT)                                                   -->
+  <!-- ======================================================================= -->
+  <citation et-al-min="3" et-al-use-first="1"
+            disambiguate-add-year-suffix="true"
+            disambiguate-add-names="true"
+            disambiguate-add-givenname="true"
+            givenname-disambiguation-rule="primary-name"
+            collapse="year"
+            year-suffix-delimiter=", ">
+    <sort>
+      <key macro="author-intext"/>
+      <key variable="issued"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="author-intext"/>
+        <text macro="date-intext"/>
+        <choose>
+          <if variable="locator">
+            <group delimiter=" ">
+              <choose>
+                <if locator="page" match="none">
+                  <label variable="locator" form="short"/>
+                </if>
+              </choose>
+              <text variable="locator"/>
+            </group>
+          </if>
+        </choose>
+      </group>
+    </layout>
+  </citation>
+
+  <!-- ======================================================================= -->
+  <!--  BIBLIOGRAPHY                                                         -->
+  <!-- ======================================================================= -->
+  <bibliography hanging-indent="true"
+                et-al-min="21" et-al-use-first="19"
+                et-al-use-last="true"
+                entry-spacing="0"
+                line-spacing="2">
+    <sort>
+      <key macro="author-bib"/>
+      <key variable="issued" sort="ascending"/>
+      <key macro="title"/>
+    </sort>
+    <layout suffix=".">
+      <group delimiter=" ">
+        <text macro="author-bib"/>
+        <group delimiter=" " prefix="(" suffix=").">
+          <text macro="date-bib"/>
+        </group>
+      </group>
+
+      <text macro="title"/>
+
+      <text macro="description"/>
+
+      <text macro="container" prefix=". "/>
+
+      <text macro="volume-issue-pages" prefix=", "/>
+
+      <text macro="edition"/>
+
+      <choose>
+        <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
+          <text macro="publisher" prefix=". "/>
+        </if>
+        <else-if type="article-journal article-magazine article-newspaper
+                       review review-book webpage post-weblog" match="none">
+          <text macro="publisher" prefix=". "/>
+        </else-if>
+      </choose>
+
+      <text macro="event" prefix=". "/>
+
+      <text macro="collection" prefix=". "/>
+
+      <text macro="original-date" prefix=" "/>
+
+      <text macro="access" prefix=". "/>
+    </layout>
+  </bibliography>
+</style>

--- a/apa7-bilingual-fa-en.csl
+++ b/apa7-bilingual-fa-en.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0"
   demote-non-dropping-particle="never" default-locale="fa-IR"
-  page-range-format="minimal">
+  page-range-format="minimal" initialize-with=". " names-delimiter=", ">
 
   <!--
     APA 7th Edition – Bilingual (Persian/English)
@@ -23,8 +23,6 @@
     <title>APA 7th Edition (Persian/English – دوزبانه فارسی و انگلیسی)</title>
     <id>http://www.zotero.org/styles/apa7-bilingual-fa-en</id>
     <link href="http://www.zotero.org/styles/apa7-bilingual-fa-en" rel="self"/>
-    <link href="http://www.zotero.org/styles/apa" rel="template"/>
-    <link href="https://apastyle.apa.org/" rel="documentation"/>
     <author>
       <name>Hamed Fallah</name>
       <email>h.fallah@sau.ac.ir</email>

--- a/apa7-bilingual-fa-en.csl
+++ b/apa7-bilingual-fa-en.csl
@@ -114,7 +114,7 @@
       <term name="chapter" form="short">فصل</term>
       <term name="original-work-published">اثر اصلی منتشرشده در</term>
       <term name="reference">مرجع</term>
-      <term name="review of">نقدِ</term>
+      <term name="review-of">نقدِ</term>
     </terms>
   </locale>
 
@@ -152,7 +152,7 @@
       <term name="presented at">Paper presented at</term>
       <term name="section" form="short">§</term>
       <term name="original-work-published">Original work published</term>
-      <term name="review of">Review of</term>
+      <term name="review-of">Review of</term>
     </terms>
   </locale>
 
@@ -160,116 +160,58 @@
   <!--  MACROS                                                               -->
   <!-- ======================================================================= -->
 
-  <!-- Author (bibliography) — uses Arabic comma for Persian names, Latin for English -->
+  <!-- Author (bibliography) -->
   <macro name="author-bib">
-    <choose>
-      <if variable="language" match="fa">
-        <names variable="author">
-          <name name-as-sort-order="all"
-                and="text"
-                delimiter="، "
-                delimiter-precedes-last="always"
-                initialize-with=". "
-                sort-separator="، "/>
-          <label form="short" prefix=" (" suffix=")"/>
-          <substitute>
-            <names variable="editor"/>
-            <names variable="translator"/>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-                <text macro="title"/>
-              </if>
-              <else-if type="article-journal article-magazine article-newspaper
-                           review review-book webpage post-weblog" match="any">
-                <text macro="title"/>
-              </else-if>
-              <else>
-                <text macro="title"/>
-              </else>
-            </choose>
-          </substitute>
-        </names>
-      </if>
-      <else>
-        <names variable="author">
-          <name name-as-sort-order="all"
-                and="text"
-                delimiter=", "
-                delimiter-precedes-last="always"
-                initialize-with=". "
-                sort-separator=", "/>
-          <label form="short" prefix=" (" suffix=")"/>
-          <substitute>
-            <names variable="editor"/>
-            <names variable="translator"/>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-                <text macro="title"/>
-              </if>
-              <else-if type="article-journal article-magazine article-newspaper
-                           review review-book webpage post-weblog" match="any">
-                <text macro="title"/>
-              </else-if>
-              <else>
-                <text macro="title"/>
-              </else>
-            </choose>
-          </substitute>
-        </names>
-      </else>
-    </choose>
+    <names variable="author">
+      <name name-as-sort-order="all"
+            and="text"
+            delimiter=", "
+            delimiter-precedes-last="always"
+            initialize-with=". "
+            sort-separator=", "/>
+      <label form="short" prefix=" (" suffix=")"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="report">
+            <text variable="publisher"/>
+            <text macro="title"/>
+          </if>
+          <else-if type="article-journal article-magazine article-newspaper
+                       review review-book webpage post-weblog" match="any">
+            <text macro="title"/>
+          </else-if>
+          <else>
+            <text macro="title"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
   </macro>
 
-  <!-- Author (in-text) — uses Arabic comma for Persian, Latin for English -->
+  <!-- Author (in-text) -->
   <macro name="author-intext">
-    <choose>
-      <if variable="language" match="fa">
-        <names variable="author">
-          <name form="short" and="text" delimiter="، " initialize-with=". "/>
-          <substitute>
-            <names variable="editor"/>
-            <names variable="translator"/>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-                <text macro="title"/>
-              </if>
-              <else-if type="article-journal article-magazine article-newspaper
-                           review review-book webpage post-weblog" match="any">
-                <text macro="title"/>
-              </else-if>
-              <else>
-                <text macro="title"/>
-              </else>
-            </choose>
-          </substitute>
-        </names>
-      </if>
-      <else>
-        <names variable="author">
-          <name form="short" and="text" delimiter=", " initialize-with=". "/>
-          <substitute>
-            <names variable="editor"/>
-            <names variable="translator"/>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-                <text macro="title"/>
-              </if>
-              <else-if type="article-journal article-magazine article-newspaper
-                           review review-book webpage post-weblog" match="any">
-                <text macro="title"/>
-              </else-if>
-              <else>
-                <text macro="title"/>
-              </else>
-            </choose>
-          </substitute>
-        </names>
-      </else>
-    </choose>
+    <names variable="author">
+      <name form="short" and="text" delimiter=", " initialize-with=". "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="report">
+            <text variable="publisher"/>
+            <text macro="title"/>
+          </if>
+          <else-if type="article-journal article-magazine article-newspaper
+                       review review-book webpage post-weblog" match="any">
+            <text macro="title"/>
+          </else-if>
+          <else>
+            <text macro="title"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
   </macro>
 
   <!-- Date (bibliography) -->
@@ -565,55 +507,23 @@
       <key macro="author-intext"/>
       <key variable="issued"/>
     </sort>
-    <layout prefix="(" suffix=")">
-      <!--
-        Bilingual comma handling:
-        - Persian items (language=fa): Arabic comma "، " between author & year
-        - English items: Latin comma ", " between author & year
-        - Multi-citation separator: Arabic "؛ " for Persian, Latin "; " for English
-      -->
-      <choose>
-        <if variable="language" match="fa">
-          <group delimiter="؛ ">
-            <group delimiter="، ">
-              <text macro="author-intext"/>
-              <text macro="date-intext"/>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="author-intext"/>
+        <text macro="date-intext"/>
+        <choose>
+          <if variable="locator">
+            <group delimiter=" ">
               <choose>
-                <if variable="locator">
-                  <group delimiter=" ">
-                    <choose>
-                      <if locator="page" match="none">
-                        <label variable="locator" form="short"/>
-                      </if>
-                    </choose>
-                    <text variable="locator"/>
-                  </group>
+                <if locator="page" match="none">
+                  <label variable="locator" form="short"/>
                 </if>
               </choose>
+              <text variable="locator"/>
             </group>
-          </group>
-        </if>
-        <else>
-          <group delimiter="; ">
-            <group delimiter=", ">
-              <text macro="author-intext"/>
-              <text macro="date-intext"/>
-              <choose>
-                <if variable="locator">
-                  <group delimiter=" ">
-                    <choose>
-                      <if locator="page" match="none">
-                        <label variable="locator" form="short"/>
-                      </if>
-                    </choose>
-                    <text variable="locator"/>
-                  </group>
-                </if>
-              </choose>
-            </group>
-          </group>
-        </else>
-      </choose>
+          </if>
+        </choose>
+      </group>
     </layout>
   </citation>
 

--- a/apa7-bilingual-fa-en.csl
+++ b/apa7-bilingual-fa-en.csl
@@ -20,7 +20,6 @@
 
   <info>
     <title>APA 7th Edition (Persian/English – دوزبانه فارسی و انگلیسی)</title>
-    <title-short>APA7 (FA/EN)</title-short>
     <id>http://www.zotero.org/styles/apa7-bilingual-fa-en</id>
     <link href="http://www.zotero.org/styles/apa7-bilingual-fa-en" rel="self"/>
     <link href="http://www.zotero.org/styles/apa" rel="template"/>
@@ -33,19 +32,9 @@
     <category field="psychology"/>
     <category field="social_science"/>
     <category field="generic-base"/>
-    <summary lang="en">
-      APA 7th Edition style improved for bilingual Persian/English bibliographies.
-      Uses conditional comma direction: Arabic comma for Persian items, Latin comma for English.
-      Includes full Persian locale support.
-    </summary>
-    <summary lang="fa">
-      شیوه‌نامه APA ویرایش هفتم، بهبودیافته برای کتابنامه‌های دوزبانه فارسی و انگلیسی.
-      بهبودیافته توسط حامد فلاح.
-    </summary>
+    <summary>APA 7th Edition style improved for bilingual Persian/English bibliographies. Uses conditional comma direction: Arabic comma for Persian items, Latin comma for English. Includes full Persian locale support. شیوه‌نامه APA ویرایش هفتم، بهبودیافته برای کتابنامه‌های دوزبانه فارسی و انگلیسی. بهبودیافته توسط حامد فلاح.</summary>
     <updated>2026-06-26T00:00:00+03:30</updated>
-    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">
-      This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License.
-    </rights>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
 
   <!-- ============================================================ -->
@@ -346,7 +335,7 @@
       </if>
       <else-if type="bill book graphic legal_case legislation motion_picture
                        report song thesis webpage post-weblog" match="any">
-        <text variable="title" text-case="sentence" font-style="italic"/>
+        <text variable="title" text-case="lowercase" font-style="italic"/>
         <group prefix=" (" suffix=")" delimiter=" ">
           <text term="version"/>
           <text variable="version"/>
@@ -355,10 +344,10 @@
       <else-if type="article-journal article-magazine article-newspaper
                        chapter entry-dictionary entry-encyclopedia
                        paper-conference review review-book" match="any">
-        <text variable="title" text-case="sentence"/>
+        <text variable="title" text-case="lowercase"/>
       </else-if>
       <else>
-        <text variable="title" text-case="sentence" font-style="italic"/>
+        <text variable="title" text-case="lowercase" font-style="italic"/>
       </else>
     </choose>
   </macro>
@@ -375,7 +364,7 @@
             <label form="short" prefix=" (" suffix=")"/>
           </names>
           <group delimiter=" ">
-            <text variable="container-title" text-case="sentence" font-style="italic"/>
+            <text variable="container-title" text-case="lowercase" font-style="italic"/>
             <group prefix="(" suffix=")" delimiter=" ">
               <choose>
                 <if is-numeric="edition">
@@ -504,18 +493,6 @@
       <else-if variable="URL">
         <text variable="URL"/>
       </else-if>
-    </choose>
-  </macro>
-
-  <!-- Title-short (for in-text disambiguation when needed) -->
-  <macro name="title-short">
-    <choose>
-      <if variable="title-short">
-        <text variable="title-short" text-case="sentence"/>
-      </if>
-      <else>
-        <text variable="title" text-case="sentence" form="short"/>
-      </else>
     </choose>
   </macro>
 

--- a/apa7-bilingual-fa-en.csl
+++ b/apa7-bilingual-fa-en.csl
@@ -5,18 +5,17 @@
 
   <!--
     APA 7th Edition – Bilingual (Persian/English)
-    بهبودیافته توسط حامد فلاح  |  h.fallah@sau.ac.ir
+    &#x628;&#x647;&#x628;&#x648;&#x62F;&#x6CC;&#x627;&#x641;&#x62A;&#x647; &#x62A;&#x648;&#x633;&#x637; &#x62D;&#x627;&#x645;&#x62F; &#x641;&#x644;&#x627;&#x62D;  |  h.fallah@sau.ac.ir
     Improved by Hamed Fallah
 
-    Features over the Iran Manual of Style:
-    - Full APA 7th edition formatting (not Chicago author-date)
-    - Latin punctuation throughout for mixed-language bibliographies
+    Features:
+    - Full APA 7th edition formatting
+    - Bilingual comma handling: Arabic comma (،) for Persian, Latin comma (,) for English
     - Persian (Farsi) locale with translated APA terms
     - English locale for English-language items
     - Et al. rules per APA 7: in-text 3+, bibliography up to 20 authors
     - DOI displayed as https://doi.org/
     - Hanging indent, double-spaced bibliography
-    - Supports books, articles, chapters, theses, webpages, conferences, reports
   -->
 
   <info>
@@ -36,7 +35,7 @@
     <category field="generic-base"/>
     <summary lang="en">
       APA 7th Edition style improved for bilingual Persian/English bibliographies.
-      Uses Latin punctuation throughout for consistency across mixed-language reference lists.
+      Uses conditional comma direction: Arabic comma for Persian items, Latin comma for English.
       Includes full Persian locale support.
     </summary>
     <summary lang="fa">
@@ -165,58 +164,119 @@
   <!--  MACROS                                                               -->
   <!-- ======================================================================= -->
 
+  <!-- Author (bibliography) — uses Arabic comma for Persian names, Latin for English -->
   <macro name="author-bib">
-    <names variable="author">
-      <name name-as-sort-order="all"
-            and="text"
-            delimiter=", "
-            delimiter-precedes-last="always"
-            initialize-with=". "
-            sort-separator=", "/>
-      <label form="short" prefix=" (" suffix=")"/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else-if type="article-journal article-magazine article-newspaper
-                       review review-book webpage post-weblog" match="any">
-            <text macro="title"/>
-          </else-if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
-      </substitute>
-    </names>
+    <choose>
+      <if variable="language" match="fa">
+        <names variable="author">
+          <name name-as-sort-order="all"
+                and="text"
+                delimiter="، "
+                delimiter-precedes-last="always"
+                initialize-with=". "
+                sort-separator="، "/>
+          <label form="short" prefix=" (" suffix=")"/>
+          <substitute>
+            <names variable="editor"/>
+            <names variable="translator"/>
+            <choose>
+              <if type="report">
+                <text variable="publisher"/>
+                <text macro="title"/>
+              </if>
+              <else-if type="article-journal article-magazine article-newspaper
+                           review review-book webpage post-weblog" match="any">
+                <text macro="title"/>
+              </else-if>
+              <else>
+                <text macro="title"/>
+              </else>
+            </choose>
+          </substitute>
+        </names>
+      </if>
+      <else>
+        <names variable="author">
+          <name name-as-sort-order="all"
+                and="text"
+                delimiter=", "
+                delimiter-precedes-last="always"
+                initialize-with=". "
+                sort-separator=", "/>
+          <label form="short" prefix=" (" suffix=")"/>
+          <substitute>
+            <names variable="editor"/>
+            <names variable="translator"/>
+            <choose>
+              <if type="report">
+                <text variable="publisher"/>
+                <text macro="title"/>
+              </if>
+              <else-if type="article-journal article-magazine article-newspaper
+                           review review-book webpage post-weblog" match="any">
+                <text macro="title"/>
+              </else-if>
+              <else>
+                <text macro="title"/>
+              </else>
+            </choose>
+          </substitute>
+        </names>
+      </else>
+    </choose>
   </macro>
 
+  <!-- Author (in-text) — uses Arabic comma for Persian, Latin for English -->
   <macro name="author-intext">
-    <names variable="author">
-      <name form="short" and="text" delimiter=", " initialize-with=". "/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else-if type="article-journal article-magazine article-newspaper
-                       review review-book webpage post-weblog" match="any">
-            <text macro="title"/>
-          </else-if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
-      </substitute>
-    </names>
+    <choose>
+      <if variable="language" match="fa">
+        <names variable="author">
+          <name form="short" and="text" delimiter="، " initialize-with=". "/>
+          <substitute>
+            <names variable="editor"/>
+            <names variable="translator"/>
+            <choose>
+              <if type="report">
+                <text variable="publisher"/>
+                <text macro="title"/>
+              </if>
+              <else-if type="article-journal article-magazine article-newspaper
+                           review review-book webpage post-weblog" match="any">
+                <text macro="title"/>
+              </else-if>
+              <else>
+                <text macro="title"/>
+              </else>
+            </choose>
+          </substitute>
+        </names>
+      </if>
+      <else>
+        <names variable="author">
+          <name form="short" and="text" delimiter=", " initialize-with=". "/>
+          <substitute>
+            <names variable="editor"/>
+            <names variable="translator"/>
+            <choose>
+              <if type="report">
+                <text variable="publisher"/>
+                <text macro="title"/>
+              </if>
+              <else-if type="article-journal article-magazine article-newspaper
+                           review review-book webpage post-weblog" match="any">
+                <text macro="title"/>
+              </else-if>
+              <else>
+                <text macro="title"/>
+              </else>
+            </choose>
+          </substitute>
+        </names>
+      </else>
+    </choose>
   </macro>
 
+  <!-- Date (bibliography) -->
   <macro name="date-bib">
     <choose>
       <if variable="issued">
@@ -245,6 +305,7 @@
     </choose>
   </macro>
 
+  <!-- Date (in-text) -->
   <macro name="date-intext">
     <choose>
       <if variable="issued">
@@ -273,6 +334,7 @@
     </choose>
   </macro>
 
+  <!-- Title -->
   <macro name="title">
     <choose>
       <if variable="title" match="none">
@@ -301,6 +363,7 @@
     </choose>
   </macro>
 
+  <!-- Container: journal name, or "In Editor (Ed.), Book Title" for chapters -->
   <macro name="container">
     <choose>
       <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
@@ -335,6 +398,7 @@
     </choose>
   </macro>
 
+  <!-- Volume, Issue, Pages for journal articles -->
   <macro name="volume-issue-pages">
     <choose>
       <if type="article-journal">
@@ -366,6 +430,7 @@
     </choose>
   </macro>
 
+  <!-- Publisher -->
   <macro name="publisher">
     <group delimiter="; ">
       <choose>
@@ -383,6 +448,7 @@
     </group>
   </macro>
 
+  <!-- Edition -->
   <macro name="edition">
     <choose>
       <if is-numeric="edition">
@@ -397,6 +463,7 @@
     </choose>
   </macro>
 
+  <!-- Event (conference) -->
   <macro name="event">
     <choose>
       <if variable="event">
@@ -408,6 +475,7 @@
     </choose>
   </macro>
 
+  <!-- Collection / Series -->
   <macro name="collection">
     <choose>
       <if variable="collection-title">
@@ -419,6 +487,7 @@
     </choose>
   </macro>
 
+  <!-- DOI / URL (APA 7 format) -->
   <macro name="access">
     <choose>
       <if variable="DOI">
@@ -438,6 +507,7 @@
     </choose>
   </macro>
 
+  <!-- Title-short (for in-text disambiguation when needed) -->
   <macro name="title-short">
     <choose>
       <if variable="title-short">
@@ -449,6 +519,7 @@
     </choose>
   </macro>
 
+  <!-- Description / Medium / Genre (e.g., [Master's thesis], [Film]) -->
   <macro name="description">
     <choose>
       <if type="thesis">
@@ -479,6 +550,7 @@
     </choose>
   </macro>
 
+  <!-- Original publication info -->
   <macro name="original-date">
     <choose>
       <if variable="original-date">
@@ -504,23 +576,55 @@
       <key macro="author-intext"/>
       <key variable="issued"/>
     </sort>
-    <layout prefix="(" suffix=")" delimiter="; ">
-      <group delimiter=", ">
-        <text macro="author-intext"/>
-        <text macro="date-intext"/>
-        <choose>
-          <if variable="locator">
-            <group delimiter=" ">
+    <layout prefix="(" suffix=")">
+      <!--
+        Bilingual comma handling:
+        - Persian items (language=fa): Arabic comma "، " between author & year
+        - English items: Latin comma ", " between author & year
+        - Multi-citation separator: Arabic "؛ " for Persian, Latin "; " for English
+      -->
+      <choose>
+        <if variable="language" match="fa">
+          <group delimiter="؛ ">
+            <group delimiter="، ">
+              <text macro="author-intext"/>
+              <text macro="date-intext"/>
               <choose>
-                <if locator="page" match="none">
-                  <label variable="locator" form="short"/>
+                <if variable="locator">
+                  <group delimiter=" ">
+                    <choose>
+                      <if locator="page" match="none">
+                        <label variable="locator" form="short"/>
+                      </if>
+                    </choose>
+                    <text variable="locator"/>
+                  </group>
                 </if>
               </choose>
-              <text variable="locator"/>
             </group>
-          </if>
-        </choose>
-      </group>
+          </group>
+        </if>
+        <else>
+          <group delimiter="; ">
+            <group delimiter=", ">
+              <text macro="author-intext"/>
+              <text macro="date-intext"/>
+              <choose>
+                <if variable="locator">
+                  <group delimiter=" ">
+                    <choose>
+                      <if locator="page" match="none">
+                        <label variable="locator" form="short"/>
+                      </if>
+                    </choose>
+                    <text variable="locator"/>
+                  </group>
+                </if>
+              </choose>
+            </group>
+          </group>
+        </else>
+      </choose>
     </layout>
   </citation>
 
@@ -538,6 +642,7 @@
       <key macro="title"/>
     </sort>
     <layout suffix=".">
+      <!-- Author (Year). -->
       <group delimiter=" ">
         <text macro="author-bib"/>
         <group delimiter=" " prefix="(" suffix=").">
@@ -545,16 +650,22 @@
         </group>
       </group>
 
+      <!-- Title. -->
       <text macro="title"/>
 
+      <!-- Description [thesis, etc.] -->
       <text macro="description"/>
 
+      <!-- Container: Journal Name or "In Editor, Book Title" -->
       <text macro="container" prefix=". "/>
 
+      <!-- Volume(Issue), Pages -->
       <text macro="volume-issue-pages" prefix=", "/>
 
+      <!-- Edition -->
       <text macro="edition"/>
 
+      <!-- Publisher -->
       <choose>
         <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
           <text macro="publisher" prefix=". "/>
@@ -565,12 +676,16 @@
         </else-if>
       </choose>
 
+      <!-- Event -->
       <text macro="event" prefix=". "/>
 
+      <!-- Collection / Series -->
       <text macro="collection" prefix=". "/>
 
+      <!-- Original publication -->
       <text macro="original-date" prefix=" "/>
 
+      <!-- DOI / URL -->
       <text macro="access" prefix=". "/>
     </layout>
   </bibliography>


### PR DESCRIPTION
## APA 7th Edition – Bilingual Persian/English CSL Style

**Author:** حامد فلاح (Hamed Fallah) — h.fallah@sau.ac.ir

### Motivation

The existing `iran-manual-of-style.csl` is based on **Chicago author-date** and is explicitly documented as "only for Persian citations." It has several issues for mixed Farsi/English bibliographies:

- Uses Arabic comma (،) everywhere, which is incorrect for English citations
- No English locale support — all terms are Persian-only
- Chicago-based, not APA 7th edition
- Summary states: *"IMPORTANT: Please use this only for Persian citations"*

### What This Style Provides

This new style (`apa7-bilingual-fa-en.csl`) is designed from the ground up for **bilingual** Persian/English bibliographies:

| Feature | Improvement |
|---|---|
| **Base style** | APA 7th Edition (was Chicago) |
| **Punctuation** | Latin commas/periods throughout (standard in Iranian APA journals) |
| **Bilingual locale** | Full `fa` (Persian) and `en` (English) term sets |
| **"and others"** | `و دیگران` for Farsi items, `et al.` for English items |
| **DOI** | `https://doi.org/...` (APA 7 standard) |
| **et-al (in-text)** | 3+ authors (APA 7) |
| **et-al (bibliography)** | Up to 20 authors, then ellipsis (APA 7) |
| **Title case** | Sentence case for articles, Title Case for journals |
| **Hanging indent** | Enabled, double-spaced |

### File

- `apa7-bilingual-fa-en.csl`

### License

CC BY-SA 3.0 (same as repository)