### PR TITLE
Update lettres-et-sciences-humaines-fr.csl

### DIFF
--- a/lettres-et-sciences-humaines-fr.csl
+++ b/lettres-et-sciences-humaines-fr.csl
@@ -12,7 +12,7 @@
     <category citation-format="note"/>
     <category field="humanities"/>
     <category field="literature"/>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2021-02-12T04:50:30+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -27,10 +27,10 @@
       <term name="interviewer" form="verb">entretien réalisé par</term>
       <term name="in">in&#160;</term>
       <term name="edition">édition</term>
-      <term name="accessed">consulté le</term>
+      <term name="accessed">consulté le </term>
       <term name="at">disponible sur&#160;:</term>
       <term name="et-al">[et al.]</term>
-      <term name="ibid">ibidem</term>
+      <term name="ibid">ibid.</term>
     </terms>
   </locale>
   <macro name="contributors">
@@ -61,6 +61,9 @@
         <text macro="title"/>
       </substitute>
     </names>
+  </macro>
+  <macro name="title-short">
+     <text variable="title" form="short" text-case="capitalize-first" quotes="false" font-style="italic"/>
   </macro>
   <macro name="contributors-sort">
     <names variable="author">
@@ -160,6 +163,14 @@
       </else-if>
     </choose>
   </macro>
+  <macro name="collection">
+    <group>
+      <group delimiter=", ">
+        <text variable="collection-title" text-case="capitalize-first" quotes="true"/>
+        <text variable="collection-number"/>
+      </group>
+    </group>
+  </macro>
   <macro name="publisher-thesis">
     <choose>
       <if variable="publisher">
@@ -190,6 +201,7 @@
   </macro>
   <macro name="publisher-book">
     <text macro="publisher" suffix=", "/>
+    <text macro="collection" suffix=", "/>
     <date variable="issued">
       <date-part name="year"/>
     </date>
@@ -211,6 +223,7 @@
   </macro>
   <macro name="publisher-book-magazine-newspaper">
     <text macro="publisher" suffix=", "/>
+    <text macro="collection" suffix=", "/>
     <date variable="issued">
       <date-part name="day" suffix=" "/>
       <date-part name="month" form="long" suffix=" "/>
@@ -234,6 +247,7 @@
   </macro>
   <macro name="publisher-book-journal">
     <text macro="publisher" suffix=", "/>
+    <text macro="collection" suffix=", "/>
     <date variable="issued">
       <date-part name="month" form="long" suffix=" "/>
       <date-part name="year"/>
@@ -281,14 +295,7 @@
       </else>
     </choose>
   </macro>
-  <macro name="collection">
-    <group>
-      <group delimiter=", " prefix="(" suffix=")">
-        <text variable="collection-title" text-case="capitalize-first" quotes="true"/>
-        <text variable="collection-number"/>
-      </group>
-    </group>
-  </macro>
+  
   <macro name="access">
     <group>
       <text term="accessed" text-case="capitalize-first"/>
@@ -331,7 +338,7 @@
                 <text variable="edition" text-case="capitalize-first"/>
                 <text macro="editor" text-case="capitalize-first"/>
                 <text macro="publisher-book-magazine-newspaper"/>
-                <text macro="collection"/>
+                <!--<text macro="collection"/>-->
                 <text variable="page" prefix="p.&#160;"/>
               </group>
             </else-if>
@@ -344,7 +351,7 @@
                 <text variable="edition" text-case="capitalize-first"/>
                 <text macro="editor" text-case="capitalize-first"/>
                 <text macro="publisher-book-journal"/>
-                <text macro="collection"/>
+                <!--<text macro="collection"/>-->
                 <text variable="page" prefix="p.&#160;"/>
               </group>
             </else-if>
@@ -361,10 +368,10 @@
                 <text macro="container-contributors"/>
                 <text macro="volume" text-case="capitalize-first"/>
                 <text macro="translator" text-case="capitalize-first"/>
-                <text macro="editor" text-case="capitalize-first"/>
+                <!--<text macro="editor" text-case="capitalize-first"/>-->
                 <text variable="edition" text-case="capitalize-first"/>
                 <text macro="publisher-book"/>
-                <text macro="collection"/>
+                <!--<text macro="collection"/>-->
                 <text variable="page" prefix="p.&#160;"/>
               </group>
             </else-if>
@@ -377,7 +384,7 @@
                 <text macro="editor" text-case="capitalize-first"/>
                 <text variable="edition" text-case="capitalize-first"/>
                 <text macro="publisher-book"/>
-                <text macro="collection"/>
+                <!--<text macro="collection"/>-->
                 <text variable="page" prefix="p.&#160;"/>
               </group>
             </else>
@@ -399,15 +406,19 @@
         <else-if position="ibid">
           <text term="ibid" form="long" font-style="italic" text-case="capitalize-first" suffix="."/>
         </else-if>
-        <else-if position="subsequent">
-          <group>
-            <text macro="contributors-notes" font-variant="normal" suffix=", "/>
+       
+          <else-if position="subsequent">
+          <group delimiter=", ">
+            <text macro="contributors-notes"/>
+            <text macro="title-short"/>
+            
             <text value="op.&#160;cit." font-style="italic"/>
+            <group delimiter="&#160;">
+              <label variable="locator" form="short"/>
+              <text variable="locator"/>
+            </group>
           </group>
-          <group>
-            <label variable="locator" form="short" prefix=", "/>
-            <text variable="locator" prefix="&#160;"/>
-          </group>
+        
         </else-if>
       </choose>
     </layout>
@@ -441,10 +452,10 @@
             <text macro="container-contributors"/>
             <text macro="volume" text-case="capitalize-first"/>
             <text macro="translator" text-case="capitalize-first"/>
-            <text macro="editor" text-case="capitalize-first"/>
+            <!--<text macro="editor" text-case="capitalize-first"/>-->
             <text variable="edition" text-case="capitalize-first"/>
             <text macro="publisher-book"/>
-            <text macro="collection"/>
+            <!--<text macro="collection"/>-->
             <text variable="page" prefix="p.&#160;"/>
           </group>
         </else-if>
@@ -457,7 +468,7 @@
             <text variable="edition" text-case="capitalize-first"/>
             <text macro="editor" text-case="capitalize-first"/>
             <text macro="publisher-book-magazine-newspaper"/>
-            <text macro="collection"/>
+            <!--<text macro="collection"/>-->
             <text variable="page" prefix="p.&#160;"/>
           </group>
         </else-if>
@@ -470,7 +481,7 @@
             <text variable="edition" text-case="capitalize-first"/>
             <text macro="editor" text-case="capitalize-first"/>
             <text macro="publisher-book-journal"/>
-            <text macro="collection"/>
+            <!--<text macro="collection"/>-->
             <text variable="page" prefix="p.&#160;"/>
           </group>
         </else-if>
@@ -483,7 +494,7 @@
             <text variable="edition" text-case="capitalize-first"/>
             <text macro="editor" text-case="capitalize-first"/>
             <text macro="publisher-book"/>
-            <text macro="collection"/>
+            <!--<text macro="collection"/>-->
             <text variable="page" prefix="p.&#160;"/>
           </group>
         </else>

--- a/lettres-et-sciences-humaines-fr.csl
+++ b/lettres-et-sciences-humaines-fr.csl
@@ -63,7 +63,7 @@
     </names>
   </macro>
   <macro name="title-short">
-     <text variable="title" form="short" text-case="capitalize-first" quotes="false" font-style="italic"/>
+    <text variable="title" form="short" text-case="capitalize-first" quotes="false" font-style="italic"/>
   </macro>
   <macro name="contributors-sort">
     <names variable="author">
@@ -295,7 +295,6 @@
       </else>
     </choose>
   </macro>
-  
   <macro name="access">
     <group>
       <text term="accessed" text-case="capitalize-first"/>
@@ -406,19 +405,16 @@
         <else-if position="ibid">
           <text term="ibid" form="long" font-style="italic" text-case="capitalize-first" suffix="."/>
         </else-if>
-       
-          <else-if position="subsequent">
+        <else-if position="subsequent">
           <group delimiter=", ">
             <text macro="contributors-notes"/>
             <text macro="title-short"/>
-            
             <text value="op.&#160;cit." font-style="italic"/>
             <group delimiter="&#160;">
               <label variable="locator" form="short"/>
               <text variable="locator"/>
             </group>
           </group>
-        
         </else-if>
       </choose>
     </layout>


### PR DESCRIPTION
Voici le CSL du style de citation Lettres et sciences humaines avec les modifications suivantes :
- `ibid.` et non `ibidem`
- consulté le + espace avant la date. Exemple : `Consulté le 28 mai 2026` et non `Consulté le 28mai 2026`
- ne pas répéter les noms des éditeurs pour les chapitres d'ouvrage. Exemple :
`Jean-Louis Backès, « Gide et Nietzsche », in Gilbert Merlio, Paolo D’Iorio, (éds.). Le Rayonnement européen de Nietzsche, éds. Gilbert Merlio et Paolo D’Iorio, Paris, Klincksieck, « Germanistique », 2004.`
- afficher la collection après la maison d'édition, et non après la date
- ne pas mettre `op. cit.` quand il s'agit d'une oeuvre différente (de l'auteur précédemment cité).
