### PR TITLE
Add Pontificia Universidad Católica de Chile - Facultad de Teología CSL style

### DIFF
--- a/teologia-uc-chile.csl
+++ b/teologia-uc-chile.csl
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="es-ES">
   <info>
-    <title>Norma de presentación de referencias bibliográficas de la Facultad de Teología | UC Chile</title>
-    <id>http://www.zotero.org/styles/teologia-uc-chile</id>
-    <link href="http://www.zotero.org/styles/teologia-uc-chile" rel="self"/>
+    <title>Facultad de Teología | UC Chile</title>
+    <id>http://www.zotero.org/styles/teologia_uc_chile</id>
+    <link href="http://www.zotero.org/styles/teologia_uc_chile" rel="self"/>
     <link href="https://guiastematicas.bibliotecas.uc.cl/teologia_uc_chile" rel="documentation"/>
 
     <author>
@@ -14,7 +14,7 @@
     <category field="theology"/>
     <summary>Norma de presentación de cita y referencias bibliográficas de la Facultad de Teología de la Pontificia Universidad Católica de Chile, basado en la Guía de la Monografía Teológica UC (2021, pp.19-22) para trabajos de investigación de pre y postgrado</summary>
     <updated>2026-07-14T13:00:00-00:00</updated>
-    <rights license="https://creativecommons.org/licenses/by-sa/4.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 License</rights>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   
 <macro name="publisher-loc-edition-date">
@@ -50,26 +50,6 @@
 </macro>
 
   <!-- Macros comunes -->
-
-  <macro name="author">
-  <names variable="author">
-
-    <name form="long" and="text" delimiter=" " initialize-with=".">
-      <name-part name="given"/>
-      <name-part name="family" font-variant="small-caps"/>
-    </name>
-    <label form="short" prefix=" y " strip-periods="true"/>
-  </names>
-  </macro>
-
-  <macro name="author-note">
-    <names variable="author">
-    <name form="long" and="text" delimiter=" " initialize-with=".">
-    <name-part name="given"/>
-    <name-part name="family" font-variant="small-caps"/>
-  </name>
-  </names>
-  </macro>
 
     <macro name="author-with-role">
       <choose>
@@ -234,20 +214,6 @@
         <text variable="container-title" font-style="italic"/>
       </else>
     </choose>
-  </macro>
-
-  <macro name="publisher">
-    <group delimiter=", ">
-      <text variable="publisher"/>
-      <text variable="publisher-place"/>
-    </group>
-  </macro>
-
-
-  <macro name="issued">
-    <date variable="issued">
-      <date-part name="year"/>
-    </date>
   </macro>
 
   <macro name="pages">

--- a/teologia-uc-chile.csl
+++ b/teologia-uc-chile.csl
@@ -12,8 +12,8 @@
     </author>
     <category citation-format="note"/>
     <category field="theology"/>
-    <summary>Norma de presentación de cita y referencias bibliográficas de la Facultad de Teología de la Pontificia Universidad Católica de Chile, basado en la Guía de la Monografía Teológica UC (2021, pp.19-22) para trabajos de investigación de pre y postgrado</summary>
-    <updated>2026-07-14</updated>
+    <summary>Norma de presentación de cita y referencias bibliográficas de la Facultad de Teología de la Pontificia Universidad Católica de Chile, basado en la Guía de la Monografía Teológica UC (2021, pp.19-22) para trabajos de investigación de pregrado</summary>
+    <updated>2026-07-14T00:00:00Z</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   

--- a/teologia-uc-chile.csl
+++ b/teologia-uc-chile.csl
@@ -5,7 +5,6 @@
     <id>http://www.zotero.org/styles/teologia-uc-chile</id>
     <link href="http://www.zotero.org/styles/teologia-uc-chile" rel="self"/>
     <link href="https://guiastematicas.bibliotecas.uc.cl/teologia_uc_chile" rel="documentation"/>
-
     <author>
       <name>Xavier Morales</name>
       <email>xavier.morales@uc.cl</email>
@@ -16,175 +15,160 @@
     <updated>2026-08-25T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  
-<macro name="publisher-loc-edition-date">
-  <group prefix=" (" suffix=")">
-    <group delimiter="; ">
-      <group>
-        <text variable="collection-title"/>
-        <text variable="collection-number" prefix=" "/>
-      </group>
-      <group delimiter=", ">
-        <text variable="publisher"/>
-        <group delimiter=" ">
-          <text variable="publisher-place"/>
-          <choose>
-            <if variable="edition">
-              <group>
-                <number variable="edition" form="numeric" vertical-align="sup"/>
+  <macro name="publisher-loc-edition-date">
+    <group prefix=" (" suffix=")">
+      <group delimiter="; ">
+        <group>
+          <text variable="collection-title"/>
+          <text variable="collection-number" prefix=" "/>
+        </group>
+        <group delimiter=", ">
+          <text variable="publisher"/>
+          <group delimiter=" ">
+            <text variable="publisher-place"/>
+            <choose>
+              <if variable="edition">
+                <group>
+                  <number variable="edition" form="numeric" vertical-align="sup"/>
+                  <date variable="issued">
+                    <date-part name="year"/>
+                  </date>
+                </group>
+              </if>
+              <else>
                 <date variable="issued">
                   <date-part name="year"/>
                 </date>
-              </group>
-            </if>
-            <else>
-              <date variable="issued">
-                <date-part name="year"/>
-              </date>
-            </else>
-          </choose>
+              </else>
+            </choose>
+          </group>
         </group>
       </group>
     </group>
-  </group>
-</macro>
-
+  </macro>
   <!-- Macros comunes -->
-
-    <macro name="author-with-role">
-      <choose>
-        <if type="article-journal">
-          <names variable="author">
-            <name and="text" delimiter=" " initialize-with=".">
-              <name-part name="given"/>
-              <name-part name="family" font-variant="small-caps"/>
-            </name>
-          </names>
-          <text value=","/>
-        </if>
-        <else>
-          <names variable="author">
-            <name and="text" delimiter=" " initialize-with=".">
-              <name-part name="given"/>
-              <name-part name="family" font-variant="small-caps"/>
-            </name>
-          </names>
-        </else>
-      </choose>
-    </macro>
-
-
-<macro name="book-contributor-with-role">
-  <choose>
-    <if variable="author">
-      <text macro="author-with-role"/>
-    </if>
-    <else-if variable="editor">
-      <names variable="editor">
-        <name and="text" delimiter=" " initialize-with=".">
-          <name-part name="given"/>
-          <name-part name="family" font-variant="small-caps"/>
-        </name>
-        <label form="short" prefix=" (" suffix=".)"/>
-      </names>
-    </else-if>
-    <else-if variable="translator">
-      <names variable="translator">
-        <name and="text" delimiter=" " initialize-with=".">
-          <name-part name="given"/>
-          <name-part name="family" font-variant="small-caps"/>
-        </name>
-        <label form="short" prefix=" (" suffix=".)"/>
-      </names>
-    </else-if>
-  </choose>
-</macro>
-
-<macro name="short-author">
-  <choose>
-    <!-- Artículos de revista: F. VERDUGO -->
-    <if type="article-journal">
-      <names variable="author">
-        <name and="text" delimiter=" " initialize-with="." form="long">
-          <name-part name="given"/>
-          <name-part name="family" font-variant="small-caps"/>
-        </name>
-      </names>
-    </if>
-
-    <!-- Libros y capítulos:  -->
-    <else-if type="book chapter" match="any">
-      <names variable="author">
-        <name form="short" font-variant="small-caps"/>
-      </names>
-    </else-if>
-
-    <!-- Otros tipos -->
-    <else>
-      <names variable="author">
-        <name form="short" font-variant="small-caps"/>
-      </names>
-    </else>
-  </choose>
-</macro>
-
+  <macro name="author-with-role">
+    <choose>
+      <if type="article-journal">
+        <names variable="author">
+          <name and="text" delimiter=" " initialize-with=".">
+            <name-part name="given"/>
+            <name-part name="family" font-variant="small-caps"/>
+          </name>
+        </names>
+        <text value=","/>
+      </if>
+      <else>
+        <names variable="author">
+          <name and="text" delimiter=" " initialize-with=".">
+            <name-part name="given"/>
+            <name-part name="family" font-variant="small-caps"/>
+          </name>
+        </names>
+      </else>
+    </choose>
+  </macro>
+  <macro name="book-contributor-with-role">
+    <choose>
+      <if variable="author">
+        <text macro="author-with-role"/>
+      </if>
+      <else-if variable="editor">
+        <names variable="editor">
+          <name and="text" delimiter=" " initialize-with=".">
+            <name-part name="given"/>
+            <name-part name="family" font-variant="small-caps"/>
+          </name>
+          <label form="short" prefix=" (" suffix=".)"/>
+        </names>
+      </else-if>
+      <else-if variable="translator">
+        <names variable="translator">
+          <name and="text" delimiter=" " initialize-with=".">
+            <name-part name="given"/>
+            <name-part name="family" font-variant="small-caps"/>
+          </name>
+          <label form="short" prefix=" (" suffix=".)"/>
+        </names>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="short-author">
+    <choose>
+      <!-- Artículos de revista: F. VERDUGO -->
+      <if type="article-journal">
+        <names variable="author">
+          <name and="text" delimiter=" " initialize-with="." form="long">
+            <name-part name="given"/>
+            <name-part name="family" font-variant="small-caps"/>
+          </name>
+        </names>
+      </if>
+      <!-- Libros y capítulos:  -->
+      <else-if type="book chapter" match="any">
+        <names variable="author">
+          <name form="short" font-variant="small-caps"/>
+        </names>
+      </else-if>
+      <!-- Otros tipos -->
+      <else>
+        <names variable="author">
+          <name form="short" font-variant="small-caps"/>
+        </names>
+      </else>
+    </choose>
+  </macro>
   <macro name="short-title">
-  <choose>
-    <if type="article-journal">
-      <text variable="title" form="short" prefix="&quot;" suffix="…&quot;," strip-periods="true"/>
-    </if>
-    <else>
-      <choose>
-        <if variable="title-short">
-          <text variable="title-short" font-style="italic"/>
-        </if>
-        <else>
-          <text variable="title" form="short" font-style="italic"/>
-        </else>
-      </choose>
-    </else>
-  </choose>
-</macro>
-
+    <choose>
+      <if type="article-journal">
+        <text variable="title" form="short" prefix="&quot;" suffix="…&quot;," strip-periods="true"/>
+      </if>
+      <else>
+        <choose>
+          <if variable="title-short">
+            <text variable="title-short" font-style="italic"/>
+          </if>
+          <else>
+            <text variable="title" form="short" font-style="italic"/>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
   <macro name="original-title">
     <text variable="original-title" prefix=" [" suffix="]"/>
   </macro>
-
-  
   <macro name="editor">
     <names variable="editor">
       <name and="text" delimiter=", " name-as-sort-order="all"/>
       <label form="short" prefix=" (" suffix=".)" text-case="title"/>
     </names>
   </macro>
-
-<macro name="editor-with-role">
-  <names variable="editor">
-    <name and="text" delimiter=" " initialize-with=".">
-      <name-part name="given"/>
-      <name-part name="family" font-variant="small-caps"/>
-    </name>
-    <label form="short" prefix=" (" suffix=".)"/>
-  </names>
-</macro>
-
-<macro name="title">
-  <choose>
-    <if type="article-journal chapter paper-conference webpage" match="any">
-      <text variable="title" prefix="&quot;" suffix="&quot;, "/>
-    </if>
-    <else-if type="book chapter paper-conference" match="any">
-      <group>
+  <macro name="editor-with-role">
+    <names variable="editor">
+      <name and="text" delimiter=" " initialize-with=".">
+        <name-part name="given"/>
+        <name-part name="family" font-variant="small-caps"/>
+      </name>
+      <label form="short" prefix=" (" suffix=".)"/>
+    </names>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="article-journal chapter paper-conference webpage" match="any">
+        <text variable="title" prefix="&quot;" suffix="&quot;, "/>
+      </if>
+      <else-if type="book chapter paper-conference" match="any">
+        <group>
+          <text variable="title" font-style="italic"/>
+          <text variable="volume" prefix=", "/>
+        </group>
+      </else-if>
+      <else>
         <text variable="title" font-style="italic"/>
-        <text variable="volume" prefix=", "/>
-      </group>
-    </else-if>
-    <else>
-      <text variable="title" font-style="italic"/>
-    </else>
-  </choose>
-</macro>
-
+      </else>
+    </choose>
+  </macro>
   <macro name="container">
     <choose>
       <if type="chapter paper-conference" match="any">
@@ -215,15 +199,12 @@
       </else>
     </choose>
   </macro>
-
   <macro name="pages">
     <text variable="page"/>
   </macro>
-
   <macro name="locator">
     <text variable="locator"/>
   </macro>
-
   <macro name="access">
     <group delimiter=", ">
       <text variable="URL"/>
@@ -234,10 +215,8 @@
       </date>
     </group>
   </macro>
-
   <!-- Citas -->
-
-   <citation disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1">
+  <citation disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1">
     <sort>
       <key variable="author"/>
       <key variable="issued"/>
@@ -254,10 +233,8 @@
         </if>
         <else>
           <choose>
-
-          <!-- Si es article-journal -->
- 
-             <if type="article-journal">
+            <!-- Si es article-journal -->
+            <if type="article-journal">
               <group delimiter=", ">
                 <text macro="author-with-role"/>
                 <text macro="title"/>
@@ -274,7 +251,6 @@
               </group>
               <text variable="locator" prefix=" "/>
             </if>
-
             <else>
               <choose>
                 <if type="chapter paper-conference" match="any">
@@ -317,9 +293,7 @@
       </choose>
     </layout>
   </citation>
-
   <!-- Bibliografía -->
-
   <bibliography hanging-indent="true">
     <sort>
       <key variable="author"/>
@@ -343,8 +317,7 @@
             <text macro="pages" prefix=" "/>
           </group>
         </if>
-
-         <else-if type="article-journal">
+        <else-if type="article-journal">
           <group delimiter=" ">
             <text macro="author-with-role"/>
             <text macro="title"/>
@@ -359,47 +332,40 @@
             <text variable="page"/>
           </group>
         </else-if>
-
         <else>
-
-         <group>
-          <choose>
-            <if type="book">
-              <text macro="book-contributor-with-role" suffix=", "/>
-            </if>
-            <else>
-              <text macro="author-with-role" suffix=", "/>
-            </else>
-          </choose>
-          <group delimiter=" ">
-            <text macro="title"/>
-            <text macro="publisher-loc-edition-date"/>
+          <group>
+            <choose>
+              <if type="book">
+                <text macro="book-contributor-with-role" suffix=", "/>
+              </if>
+              <else>
+                <text macro="author-with-role" suffix=", "/>
+              </else>
+            </choose>
+            <group delimiter=" ">
+              <text macro="title"/>
+              <text macro="publisher-loc-edition-date"/>
+            </group>
+            <choose>
+              <if type="book">
+                <!-- No mostrar el editor otra vez -->
+              </if>
+              <else>
+                <text macro="editor" prefix=", "/>
+              </else>
+            </choose>
+            <text macro="container" prefix=", "/>
+            <text macro="pages" prefix=", "/>
+            <text macro="access" prefix=", "/>
+            <text macro="original-title" prefix=", "/>
           </group>
-          <choose>
-            <if type="book">
-              <!-- No mostrar el editor otra vez -->
-            </if>
-            <else>
-              <text macro="editor" prefix=", "/>
-            </else>
-          </choose>
-          <text macro="container" prefix=", "/>
-          <text macro="pages" prefix=", "/>
-          <text macro="access" prefix=", "/>
-          <text macro="original-title" prefix=", "/>
-        </group>
-
         </else>
       </choose>
     </layout>
   </bibliography>
-
   <locale xml:lang="es-ES">
-  <terms>
-    <term name="et-al">y otros</term>
-  </terms>
-</locale>
-
+    <terms>
+      <term name="et-al">y otros</term>
+    </terms>
+  </locale>
 </style>
-
-

--- a/teologia-uc-chile.csl
+++ b/teologia-uc-chile.csl
@@ -206,10 +206,10 @@
       <group delimiter=": ">
         <text term="accessed"/>
         <date variable="accessed">
-        <date-part name="day" suffix="/"/>
-        <date-part name="month" suffix="/"/>
-        <date-part name="year"/>
-      </date>
+          <date-part name="day" suffix="/"/>
+          <date-part name="month" suffix="/"/>
+          <date-part name="year"/>
+        </date>
       </group>
     </group>
   </macro>
@@ -300,18 +300,18 @@
     <layout suffix=".">
       <choose>
         <if type="chapter paper-conference" match="any">
-            <text macro="author-with-role" suffix=", "/>
-            <text macro="title"/>
-            <group>
-              <text term="in" text-case="lowercase" suffix=" "/>
-              <text macro="editor-with-role" suffix=", "/>
-              <group delimiter=", ">
-                <text variable="container-title" font-style="italic"/>
-                <text variable="volume"/>
-              </group>
-              <text macro="publisher-loc-edition-date"/>
+          <text macro="author-with-role" suffix=", "/>
+          <text macro="title"/>
+          <group>
+            <text term="in" text-case="lowercase" suffix=" "/>
+            <text macro="editor-with-role" suffix=", "/>
+            <group delimiter=", ">
+              <text variable="container-title" font-style="italic"/>
+              <text variable="volume"/>
             </group>
-            <text macro="pages" prefix=" "/>
+            <text macro="publisher-loc-edition-date"/>
+          </group>
+          <text macro="pages" prefix=" "/>
         </if>
         <else-if type="article-journal">
           <group delimiter=" ">

--- a/teologia-uc-chile.csl
+++ b/teologia-uc-chile.csl
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="es-ES">
   <info>
-    <title>Facultad de Teología | UC Chile</title>
-    <id>http://www.zotero.org/styles/teologia_uc_chile</id>
-    <link href="http://www.zotero.org/styles/teologia_uc_chile" rel="self"/>
+    <title>Facultad de Teología UC Chile</title>
+    <id>http://www.zotero.org/styles/teologia-uc-chile</id>
+    <link href="http://www.zotero.org/styles/teologia-uc-chile" rel="self"/>
     <link href="https://guiastematicas.bibliotecas.uc.cl/teologia_uc_chile" rel="documentation"/>
 
     <author>
@@ -13,7 +13,7 @@
     <category citation-format="note"/>
     <category field="theology"/>
     <summary>Norma de presentación de cita y referencias bibliográficas de la Facultad de Teología de la Pontificia Universidad Católica de Chile, basado en la Guía de la Monografía Teológica UC (2021, pp.19-22) para trabajos de investigación de pre y postgrado</summary>
-    <updated>2026-07-14T13:00:00-00:00</updated>
+    <updated>2026-07-14</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   

--- a/teologia-uc-chile.csl
+++ b/teologia-uc-chile.csl
@@ -15,12 +15,17 @@
     <updated>2026-08-25T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+  <locale xml:lang="es">
+    <terms>
+      <term name="accessed">consulta</term>
+    </terms>
+  </locale>
   <macro name="publisher-loc-edition-date">
     <group prefix=" (" suffix=")">
       <group delimiter="; ">
-        <group>
+        <group delimiter=" ">
           <text variable="collection-title"/>
-          <text variable="collection-number" prefix=" "/>
+          <text variable="collection-number"/>
         </group>
         <group delimiter=", ">
           <text variable="publisher"/>
@@ -79,7 +84,7 @@
             <name-part name="given"/>
             <name-part name="family" font-variant="small-caps"/>
           </name>
-          <label form="short" prefix=" (" suffix=".)"/>
+          <label form="short" prefix=" (" suffix=")"/>
         </names>
       </else-if>
       <else-if variable="translator">
@@ -88,7 +93,7 @@
             <name-part name="given"/>
             <name-part name="family" font-variant="small-caps"/>
           </name>
-          <label form="short" prefix=" (" suffix=".)"/>
+          <label form="short" prefix=" (" suffix=")"/>
         </names>
       </else-if>
     </choose>
@@ -121,17 +126,10 @@
   <macro name="short-title">
     <choose>
       <if type="article-journal">
-        <text variable="title" form="short" prefix="&quot;" suffix="…&quot;," strip-periods="true"/>
+        <text variable="title" form="short" quotes="true" suffix="…" strip-periods="true"/>
       </if>
       <else>
-        <choose>
-          <if variable="title-short">
-            <text variable="title-short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" font-style="italic"/>
-          </else>
-        </choose>
+        <text variable="title" form="short" font-style="italic"/>
       </else>
     </choose>
   </macro>
@@ -141,7 +139,7 @@
   <macro name="editor">
     <names variable="editor">
       <name and="text" delimiter=", " name-as-sort-order="all"/>
-      <label form="short" prefix=" (" suffix=".)" text-case="title"/>
+      <label form="short" prefix=" (" suffix=")" text-case="title"/>
     </names>
   </macro>
   <macro name="editor-with-role">
@@ -150,7 +148,7 @@
         <name-part name="given"/>
         <name-part name="family" font-variant="small-caps"/>
       </name>
-      <label form="short" prefix=" (" suffix=".)"/>
+      <label form="short" prefix=" (" suffix=")"/>
     </names>
   </macro>
   <macro name="title">
@@ -159,9 +157,9 @@
         <text variable="title" prefix="&quot;" suffix="&quot;, "/>
       </if>
       <else-if type="book chapter paper-conference" match="any">
-        <group>
+        <group delimiter=", ">
           <text variable="title" font-style="italic"/>
-          <text variable="volume" prefix=", "/>
+          <text variable="volume"/>
         </group>
       </else-if>
       <else>
@@ -202,17 +200,17 @@
   <macro name="pages">
     <text variable="page"/>
   </macro>
-  <macro name="locator">
-    <text variable="locator"/>
-  </macro>
   <macro name="access">
     <group delimiter=", ">
       <text variable="URL"/>
-      <date variable="accessed" prefix="consulta: ">
+      <group delimiter=": ">
+        <text term="accessed"/>
+        <date variable="accessed">
         <date-part name="day" suffix="/"/>
         <date-part name="month" suffix="/"/>
         <date-part name="year"/>
       </date>
+      </group>
     </group>
   </macro>
   <!-- Citas -->
@@ -227,7 +225,7 @@
           <group delimiter=", ">
             <text macro="short-author"/>
             <text macro="short-title"/>
-            <text macro="locator"/>
+            <text variable="locator"/>
             <text macro="original-title"/>
           </group>
         </if>
@@ -302,7 +300,6 @@
     <layout suffix=".">
       <choose>
         <if type="chapter paper-conference" match="any">
-          <group>
             <text macro="author-with-role" suffix=", "/>
             <text macro="title"/>
             <group>
@@ -315,7 +312,6 @@
               <text macro="publisher-loc-edition-date"/>
             </group>
             <text macro="pages" prefix=" "/>
-          </group>
         </if>
         <else-if type="article-journal">
           <group delimiter=" ">

--- a/teologia-uc-chile.csl
+++ b/teologia-uc-chile.csl
@@ -2,8 +2,8 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="es-ES">
   <info>
     <title>Norma de presentación de referencias bibliográficas de la Facultad de Teología | UC Chile</title>
-    <id>http://www.zotero.org/styles/teologia_uc_chile</id>
-    <link href="http://www.zotero.org/styles/teologia_uc_chile" rel="self"/>
+    <id>http://www.zotero.org/styles/teologia-uc-chile</id>
+    <link href="http://www.zotero.org/styles/teologia-uc-chile" rel="self"/>
     <link href="https://guiastematicas.bibliotecas.uc.cl/teologia_uc_chile" rel="documentation"/>
 
     <author>

--- a/teologia-uc-chile.csl
+++ b/teologia-uc-chile.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="es-ES">
   <info>
-    <title>Facultad de Teología UC Chile</title>
+    <title>Pontificia Universidad Católica de Chile - Facultad de Teología (Español)</title>
     <id>http://www.zotero.org/styles/teologia-uc-chile</id>
     <link href="http://www.zotero.org/styles/teologia-uc-chile" rel="self"/>
     <link href="https://guiastematicas.bibliotecas.uc.cl/teologia_uc_chile" rel="documentation"/>
@@ -13,7 +13,7 @@
     <category citation-format="note"/>
     <category field="theology"/>
     <summary>Norma de presentación de cita y referencias bibliográficas de la Facultad de Teología de la Pontificia Universidad Católica de Chile, basado en la Guía de la Monografía Teológica UC (2021, pp.19-22) para trabajos de investigación de pregrado</summary>
-    <updated>2026-07-14T00:00:00Z</updated>
+    <updated>2026-08-25T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   

--- a/teologia-uc-chile.csl
+++ b/teologia-uc-chile.csl
@@ -55,13 +55,12 @@
   <macro name="author-with-role">
     <choose>
       <if type="article-journal">
-        <names variable="author">
+        <names variable="author" suffix=",">
           <name and="text" delimiter=" " initialize-with=".">
             <name-part name="given"/>
             <name-part name="family" font-variant="small-caps"/>
           </name>
         </names>
-        <text value=","/>
       </if>
       <else>
         <names variable="author">

--- a/teologia_uc_chile
+++ b/teologia_uc_chile
@@ -1,0 +1,439 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="es-ES">
+  <info>
+    <title>Norma de presentación de referencias bibliográficas de la Facultad de Teología | UC Chile</title>
+    <id>http://www.zotero.org/styles/teologia_uc_chile</id>
+    <link href="http://www.zotero.org/styles/teologia_uc_chile" rel="self"/>
+    <link href="https://guiastematicas.bibliotecas.uc.cl/teologia_uc_chile" rel="documentation"/>
+
+    <author>
+      <name>Xavier Morales</name>
+      <email>xavier.morales@uc.cl</email>
+    </author>
+    <category citation-format="note"/>
+    <category field="theology"/>
+    <summary>Norma de presentación de cita y referencias bibliográficas de la Facultad de Teología de la Pontificia Universidad Católica de Chile, basado en la Guía de la Monografía Teológica UC (2021, pp.19-22) para trabajos de investigación de pre y postgrado</summary>
+    <updated>2026-07-14T13:00:00-00:00</updated>
+    <rights license="https://creativecommons.org/licenses/by-sa/4.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 License</rights>
+  </info>
+  
+<macro name="publisher-loc-edition-date">
+  <group prefix=" (" suffix=")">
+    <group delimiter="; ">
+      <group>
+        <text variable="collection-title"/>
+        <text variable="collection-number" prefix=" "/>
+      </group>
+      <group delimiter=", ">
+        <text variable="publisher"/>
+        <group delimiter=" ">
+          <text variable="publisher-place"/>
+          <choose>
+            <if variable="edition">
+              <group>
+                <number variable="edition" form="numeric" vertical-align="sup"/>
+                <date variable="issued">
+                  <date-part name="year"/>
+                </date>
+              </group>
+            </if>
+            <else>
+              <date variable="issued">
+                <date-part name="year"/>
+              </date>
+            </else>
+          </choose>
+        </group>
+      </group>
+    </group>
+  </group>
+</macro>
+
+  <!-- Macros comunes -->
+
+  <macro name="author">
+  <names variable="author">
+
+    <name form="long" and="text" delimiter=" " initialize-with=".">
+      <name-part name="given"/>
+      <name-part name="family" font-variant="small-caps"/>
+    </name>
+    <label form="short" prefix=" y " strip-periods="true"/>
+  </names>
+  </macro>
+
+  <macro name="author-note">
+    <names variable="author">
+    <name form="long" and="text" delimiter=" " initialize-with=".">
+    <name-part name="given"/>
+    <name-part name="family" font-variant="small-caps"/>
+  </name>
+  </names>
+  </macro>
+
+    <macro name="author-with-role">
+      <choose>
+        <if type="article-journal">
+          <names variable="author">
+            <name and="text" delimiter=" " initialize-with=".">
+              <name-part name="given"/>
+              <name-part name="family" font-variant="small-caps"/>
+            </name>
+          </names>
+          <text value=","/>
+        </if>
+        <else>
+          <names variable="author">
+            <name and="text" delimiter=" " initialize-with=".">
+              <name-part name="given"/>
+              <name-part name="family" font-variant="small-caps"/>
+            </name>
+          </names>
+        </else>
+      </choose>
+    </macro>
+
+
+<macro name="book-contributor-with-role">
+  <choose>
+    <if variable="author">
+      <text macro="author-with-role"/>
+    </if>
+    <else-if variable="editor">
+      <names variable="editor">
+        <name and="text" delimiter=" " initialize-with=".">
+          <name-part name="given"/>
+          <name-part name="family" font-variant="small-caps"/>
+        </name>
+        <label form="short" prefix=" (" suffix=".)"/>
+      </names>
+    </else-if>
+    <else-if variable="translator">
+      <names variable="translator">
+        <name and="text" delimiter=" " initialize-with=".">
+          <name-part name="given"/>
+          <name-part name="family" font-variant="small-caps"/>
+        </name>
+        <label form="short" prefix=" (" suffix=".)"/>
+      </names>
+    </else-if>
+  </choose>
+</macro>
+
+<macro name="short-author">
+  <choose>
+    <!-- Artículos de revista: F. VERDUGO -->
+    <if type="article-journal">
+      <names variable="author">
+        <name and="text" delimiter=" " initialize-with="." form="long">
+          <name-part name="given"/>
+          <name-part name="family" font-variant="small-caps"/>
+        </name>
+      </names>
+    </if>
+
+    <!-- Libros y capítulos:  -->
+    <else-if type="book chapter" match="any">
+      <names variable="author">
+        <name form="short" font-variant="small-caps"/>
+      </names>
+    </else-if>
+
+    <!-- Otros tipos -->
+    <else>
+      <names variable="author">
+        <name form="short" font-variant="small-caps"/>
+      </names>
+    </else>
+  </choose>
+</macro>
+
+  <macro name="short-title">
+  <choose>
+    <if type="article-journal">
+      <text variable="title" form="short" prefix="&quot;" suffix="…&quot;," strip-periods="true"/>
+    </if>
+    <else>
+      <choose>
+        <if variable="title-short">
+          <text variable="title-short" font-style="italic"/>
+        </if>
+        <else>
+          <text variable="title" form="short" font-style="italic"/>
+        </else>
+      </choose>
+    </else>
+  </choose>
+</macro>
+
+  <macro name="original-title">
+    <text variable="original-title" prefix=" [" suffix="]"/>
+  </macro>
+
+  
+  <macro name="editor">
+    <names variable="editor">
+      <name and="text" delimiter=", " name-as-sort-order="all"/>
+      <label form="short" prefix=" (" suffix=".)" text-case="title"/>
+    </names>
+  </macro>
+
+<macro name="editor-with-role">
+  <names variable="editor">
+    <name and="text" delimiter=" " initialize-with=".">
+      <name-part name="given"/>
+      <name-part name="family" font-variant="small-caps"/>
+    </name>
+    <label form="short" prefix=" (" suffix=".)"/>
+  </names>
+</macro>
+
+<macro name="title">
+  <choose>
+    <if type="article-journal chapter paper-conference webpage" match="any">
+      <text variable="title" prefix="&quot;" suffix="&quot;, "/>
+    </if>
+    <else-if type="book chapter paper-conference" match="any">
+      <group>
+        <text variable="title" font-style="italic"/>
+        <text variable="volume" prefix=", "/>
+      </group>
+    </else-if>
+    <else>
+      <text variable="title" font-style="italic"/>
+    </else>
+  </choose>
+</macro>
+
+  <macro name="container">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <group>
+          <text term="in" text-case="lowercase" suffix=" "/>
+          <text macro="editor-with-role"/>
+          <group delimiter=", ">
+            <text variable="container-title" font-style="italic"/>
+            <text variable="volume"/>
+          </group>
+          <text variable="container-title" font-style="italic"/>
+        </group>
+      </if>
+      <else-if type="article-journal">
+        <group delimiter=" ">
+          <text variable="container-title" font-style="italic"/>
+          <group delimiter="/">
+            <text variable="volume"/>
+            <text variable="issue"/>
+          </group>
+          <date variable="issued" prefix="(" suffix=")">
+            <date-part name="year"/>
+          </date>
+        </group>
+      </else-if>
+      <else>
+        <text variable="container-title" font-style="italic"/>
+      </else>
+    </choose>
+  </macro>
+
+  <macro name="publisher">
+    <group delimiter=", ">
+      <text variable="publisher"/>
+      <text variable="publisher-place"/>
+    </group>
+  </macro>
+
+
+  <macro name="issued">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
+
+  <macro name="pages">
+    <text variable="page"/>
+  </macro>
+
+  <macro name="locator">
+    <text variable="locator"/>
+  </macro>
+
+  <macro name="access">
+    <group delimiter=", ">
+      <text variable="URL"/>
+      <date variable="accessed" prefix="consulta: ">
+        <date-part name="day" suffix="/"/>
+        <date-part name="month" suffix="/"/>
+        <date-part name="year"/>
+      </date>
+    </group>
+  </macro>
+
+  <!-- Citas -->
+
+   <citation disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1">
+    <sort>
+      <key variable="author"/>
+      <key variable="issued"/>
+    </sort>
+    <layout suffix=".">
+      <choose>
+        <if position="subsequent">
+          <group delimiter=", ">
+            <text macro="short-author"/>
+            <text macro="short-title"/>
+            <text macro="locator"/>
+            <text macro="original-title"/>
+          </group>
+        </if>
+        <else>
+          <choose>
+
+          <!-- Si es article-journal -->
+ 
+             <if type="article-journal">
+              <group delimiter=", ">
+                <text macro="author-with-role"/>
+                <text macro="title"/>
+              </group>
+              <group delimiter=" ">
+                <text variable="container-title" font-style="italic"/>
+                <group delimiter="/">
+                  <text variable="volume"/>
+                  <text variable="issue"/>
+                </group>
+                <date variable="issued" prefix="(" suffix=")">
+                  <date-part name="year"/>
+                </date>
+              </group>
+              <text variable="locator" prefix=" "/>
+            </if>
+
+            <else>
+              <choose>
+                <if type="chapter paper-conference" match="any">
+                  <group>
+                    <text macro="author-with-role" suffix=", "/>
+                    <text macro="title"/>
+                    <group>
+                      <text term="in" text-case="lowercase" suffix=" "/>
+                      <text macro="editor-with-role" suffix=", "/>
+                      <group delimiter=", ">
+                        <text variable="container-title" font-style="italic"/>
+                        <text variable="volume"/>
+                      </group>
+                      <text macro="publisher-loc-edition-date"/>
+                    </group>
+                    <text macro="pages" prefix=" "/>
+                  </group>
+                </if>
+                <else>
+                  <group delimiter=", ">
+                    <choose>
+                      <if type="book">
+                        <text macro="book-contributor-with-role"/>
+                      </if>
+                      <else>
+                        <text macro="author-with-role"/>
+                      </else>
+                    </choose>
+                    <group delimiter=" ">
+                      <text macro="title"/>
+                      <text macro="publisher-loc-edition-date"/>
+                    </group>
+                  </group>
+                  <text variable="locator" prefix=" "/>
+                </else>
+              </choose>
+            </else>
+          </choose>
+        </else>
+      </choose>
+    </layout>
+  </citation>
+
+  <!-- Bibliografía -->
+
+  <bibliography hanging-indent="true">
+    <sort>
+      <key variable="author"/>
+      <key variable="issued"/>
+    </sort>
+    <layout suffix=".">
+      <choose>
+        <if type="chapter paper-conference" match="any">
+          <group>
+            <text macro="author-with-role" suffix=", "/>
+            <text macro="title"/>
+            <group>
+              <text term="in" text-case="lowercase" suffix=" "/>
+              <text macro="editor-with-role" suffix=", "/>
+              <group delimiter=", ">
+                <text variable="container-title" font-style="italic"/>
+                <text variable="volume"/>
+              </group>
+              <text macro="publisher-loc-edition-date"/>
+            </group>
+            <text macro="pages" prefix=" "/>
+          </group>
+        </if>
+
+         <else-if type="article-journal">
+          <group delimiter=" ">
+            <text macro="author-with-role"/>
+            <text macro="title"/>
+            <text variable="container-title" font-style="italic"/>
+            <group delimiter="/">
+              <text variable="volume"/>
+              <text variable="issue"/>
+            </group>
+            <date variable="issued" prefix="(" suffix=")">
+              <date-part name="year"/>
+            </date>
+            <text variable="page"/>
+          </group>
+        </else-if>
+
+        <else>
+
+         <group>
+          <choose>
+            <if type="book">
+              <text macro="book-contributor-with-role" suffix=", "/>
+            </if>
+            <else>
+              <text macro="author-with-role" suffix=", "/>
+            </else>
+          </choose>
+          <group delimiter=" ">
+            <text macro="title"/>
+            <text macro="publisher-loc-edition-date"/>
+          </group>
+          <choose>
+            <if type="book">
+              <!-- No mostrar el editor otra vez -->
+            </if>
+            <else>
+              <text macro="editor" prefix=", "/>
+            </else>
+          </choose>
+          <text macro="container" prefix=", "/>
+          <text macro="pages" prefix=", "/>
+          <text macro="access" prefix=", "/>
+          <text macro="original-title" prefix=", "/>
+        </group>
+
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+
+  <locale xml:lang="es-ES">
+  <terms>
+    <term name="et-al">y otros</term>
+  </terms>
+</locale>
+
+</style>
+
+


### PR DESCRIPTION
This pull request submits an updated CSL style for the Faculty of Theology of the Pontificia Universidad Católica de Chile.

The style is based on the official citation guidelines available through the documentation link included in the CSL metadata.

Main updates:
- updated the CSL metadata;
- corrected the file name, style ID, and self link;
- reviewed the citation and bibliography formatting;
- added the official documentation link;
- checked the style against the current CSL requirements.