### PR TITLE
Add page-range-format="minimal-two" to Bluebook styles

### DIFF
--- a/bluebook-inline.csl
+++ b/bluebook-inline.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="minimal-two" default-locale="en-US">
   <info>
     <title>Bluebook Inline</title>
     <id>http://www.zotero.org/styles/bluebook-inline</id>
@@ -17,10 +17,14 @@
       <name>Nancy Sims</name>
       <email>nsims@umich.edu</email>
     </contributor>
+    <contributor>
+      <name>William Barnhart</name>
+      <email>williambbarnhart@gmail.com</email>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="law"/>
     <summary>Bluebook citation formatting for in-text citations.</summary>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2026-07-18T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <!-- sets up basics of dealing with authors -->

--- a/bluebook-law-review-with-abstract.csl
+++ b/bluebook-law-review-with-abstract.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="minimal-two" default-locale="en-US">
   <info>
     <title>Bluebook Law Review (with abstract)</title>
     <id>http://www.zotero.org/styles/bluebook-law-review-with-abstract</id>
@@ -10,10 +10,14 @@
       <name>Jessica Pierucci</name>
       <uri>https://orcid.org/0000-0002-1619-0289</uri>
     </contributor>
+    <contributor>
+      <name>William Barnhart</name>
+      <email>williambbarnhart@gmail.com</email>
+    </contributor>
     <category citation-format="note"/>
     <category field="law"/>
     <summary>The Bluebook legal citation style for law reviews with abstracts included.</summary>
-    <updated>2025-06-18T11:17:10+00:00</updated>
+    <updated>2026-07-18T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>

--- a/bluebook-law-review.csl
+++ b/bluebook-law-review.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="minimal-two" default-locale="en-US">
   <info>
     <title>Bluebook Law Review</title>
     <id>http://www.zotero.org/styles/bluebook-law-review</id>
@@ -23,10 +23,14 @@
       <name>Shay Elbaum</name>
       <email>selbaum@law.harvard.edu</email>
     </contributor>
+    <contributor>
+      <name>William Barnhart</name>
+      <email>williambbarnhart@gmail.com</email>
+    </contributor>
     <category citation-format="note"/>
     <category field="law"/>
     <summary>The Bluebook legal citation style for law reviews.</summary>
-    <updated>2025-05-06T00:00:00+00:00</updated>
+    <updated>2026-07-18T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>


### PR DESCRIPTION
### Description
Bluebook Rule 3.2(a) requires page ranges to drop repetitious digits while
retaining at least the last two (e.g. `173-174` should render as `173-74`).
The three Bluebook styles (`bluebook-law-review`,
`bluebook-law-review-with-abstract`, `bluebook-inline`) did not set
`page-range-format`, so pincite ranges passed through unchanged. CSL's
`minimal-two` page-range format implements exactly this rule; citeproc-js
also applies it to page-type locators, which is where these styles render
pincites.

Verified with citeproc-js: a case cite with locator `173-174` now renders as
`United States v. Carroll Towing Co., 159 F.2d 169, 173–74 (2d Cir. 1947).`,
while ranges without repetitious digits (e.g. `32-38`) are unaffected.
`<updated>` timestamps bumped.

### Checklist
- [x] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`. (n/a — already present in `bluebook-law-review-with-abstract`; the other two styles are not derived from a template)
- [x] Check that you've added a link to the style guidelines with `rel="documentation"`.
- [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update.
- [x] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [x] Check that you've not used `<text value="...` if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.
