### PR TITLE
Render section/paragraph pincites with §/¶ instead of "at" in Bluebook styles

### DIFF
--- a/bluebook-inline.csl
+++ b/bluebook-inline.csl
@@ -17,10 +17,14 @@
       <name>Nancy Sims</name>
       <email>nsims@umich.edu</email>
     </contributor>
+    <contributor>
+      <name>William Barnhart</name>
+      <email>williambbarnhart@gmail.com</email>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="law"/>
     <summary>Bluebook citation formatting for in-text citations.</summary>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2026-07-18T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <!-- sets up basics of dealing with authors -->
@@ -169,10 +173,20 @@
   </macro>
   <!-- sets up citing to specific page numbers for id and supra cites -->
   <macro name="at_page">
-    <group delimiter=" ">
-      <text value="at"/>
-      <text variable="locator"/>
-    </group>
+    <choose>
+      <if locator="section paragraph" match="any">
+        <group delimiter=" ">
+          <label variable="locator" form="symbol"/>
+          <text variable="locator"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text value="at"/>
+          <text variable="locator"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <!-- sets up the "in" in front of book sections, etc. -->
   <macro name="container">

--- a/bluebook-law-review-with-abstract.csl
+++ b/bluebook-law-review-with-abstract.csl
@@ -10,10 +10,14 @@
       <name>Jessica Pierucci</name>
       <uri>https://orcid.org/0000-0002-1619-0289</uri>
     </contributor>
+    <contributor>
+      <name>William Barnhart</name>
+      <email>williambbarnhart@gmail.com</email>
+    </contributor>
     <category citation-format="note"/>
     <category field="law"/>
     <summary>The Bluebook legal citation style for law reviews with abstracts included.</summary>
-    <updated>2025-06-18T11:17:10+00:00</updated>
+    <updated>2026-07-18T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -249,10 +253,20 @@
     </choose>
   </macro>
   <macro name="at_page">
-    <group delimiter=" ">
-      <text value="at"/>
-      <text variable="locator"/>
-    </group>
+    <choose>
+      <if locator="section paragraph" match="any">
+        <group delimiter=" ">
+          <label variable="locator" form="symbol"/>
+          <text variable="locator"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text value="at"/>
+          <text variable="locator"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="container">
     <choose>

--- a/bluebook-law-review.csl
+++ b/bluebook-law-review.csl
@@ -23,10 +23,14 @@
       <name>Shay Elbaum</name>
       <email>selbaum@law.harvard.edu</email>
     </contributor>
+    <contributor>
+      <name>William Barnhart</name>
+      <email>williambbarnhart@gmail.com</email>
+    </contributor>
     <category citation-format="note"/>
     <category field="law"/>
     <summary>The Bluebook legal citation style for law reviews.</summary>
-    <updated>2025-05-06T00:00:00+00:00</updated>
+    <updated>2026-07-18T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -287,10 +291,20 @@
     </choose>
   </macro>
   <macro name="at_page">
-    <group delimiter=" ">
-      <text value="at"/>
-      <text variable="locator"/>
-    </group>
+    <choose>
+      <if locator="section paragraph" match="any">
+        <group delimiter=" ">
+          <label variable="locator" form="symbol"/>
+          <text variable="locator"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text value="at"/>
+          <text variable="locator"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="container">
     <choose>


### PR DESCRIPTION
### Description
Bluebook Rule 3.3 cites sections and paragraphs with the §/¶ symbol and no "at" (e.g. `Id. § 1983`), reserving "at" for page pincites. The `at_page` macro used by the *id.* and *supra* short forms in all three Bluebook styles rendered every locator as `at <locator>` regardless of its label, producing `Id. at 1983` for a section pincite. This renders section/paragraph locators with the symbol-form label instead; the label pluralizes contextually, so ranges correctly render `§§`/`¶¶` per Rule 3.3(b) (verified that section ranges are not digit-collapsed).

Verified with citeproc-js: `Id. § 1983`, `Id. §§ 1983–1985`, `Id. ¶ 12`, while page pincites keep `Id. at 173`.

Observed adjacent (pre-existing, untouched here): the *supra* form lacks Bluebook's comma after the note number (`supra note 6 at 42` vs `supra note 6, at 42`, Rule 4.2) — candidate for a follow-up PR.

### Checklist
- [x] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`. (already present where applicable; the other styles are not derived from a template)
- [x] Check that you've added a link to the style guidelines with `rel="documentation"`.
- [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update.
- [x] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [x] Check that you've not used `<text value="...` if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.