### PR TITLE
Apply Bluebook Rule 10.9 five-footnote rule to case short forms

### DIFF
--- a/bluebook-law-review-with-abstract.csl
+++ b/bluebook-law-review-with-abstract.csl
@@ -10,10 +10,14 @@
       <name>Jessica Pierucci</name>
       <uri>https://orcid.org/0000-0002-1619-0289</uri>
     </contributor>
+    <contributor>
+      <name>William Barnhart</name>
+      <email>williambbarnhart@gmail.com</email>
+    </contributor>
     <category citation-format="note"/>
     <category field="law"/>
     <summary>The Bluebook legal citation style for law reviews with abstracts included.</summary>
-    <updated>2025-06-18T11:17:10+00:00</updated>
+    <updated>2026-07-18T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -273,7 +277,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1">
+  <citation et-al-min="4" et-al-use-first="1" near-note-distance="5">
     <layout suffix="." delimiter="; ">
       <choose>
         <if position="ibid-with-locator">
@@ -286,22 +290,45 @@
           <text term="ibid" text-case="capitalize-first" font-style="italic"/>
         </else-if>
         <else-if position="subsequent">
-          <group delimiter=", ">
-            <group delimiter=" ">
+          <choose>
+            <!-- subsequent case citations use the short form, not supra, and only
+                 within five footnotes of the preceding cite (Rule 10.9) -->
+            <if type="legal_case">
               <choose>
-                <if type="book" match="any">
-                  <text variable="volume"/>
+                <if position="near-note">
+                  <group delimiter=", ">
+                    <text variable="title" form="short" font-style="italic"/>
+                    <group delimiter=" ">
+                      <text variable="volume"/>
+                      <text variable="container-title" form="short"/>
+                      <text macro="at_page"/>
+                    </group>
+                  </group>
                 </if>
+                <else>
+                  <text macro="source"/>
+                </else>
               </choose>
-              <text macro="author-short"/>
-            </group>
-            <group delimiter=" ">
-              <text value="supra" font-style="italic"/>
-              <text value="note"/>
-              <text variable="first-reference-note-number"/>
-              <text macro="at_page"/>
-            </group>
-          </group>
+            </if>
+            <else>
+              <group delimiter=", ">
+                <group delimiter=" ">
+                  <choose>
+                    <if type="book" match="any">
+                      <text variable="volume"/>
+                    </if>
+                  </choose>
+                  <text macro="author-short"/>
+                </group>
+                <group delimiter=" ">
+                  <text value="supra" font-style="italic"/>
+                  <text value="note"/>
+                  <text variable="first-reference-note-number"/>
+                  <text macro="at_page"/>
+                </group>
+              </group>
+            </else>
+          </choose>
         </else-if>
         <else>
           <group delimiter=", ">

--- a/bluebook-law-review.csl
+++ b/bluebook-law-review.csl
@@ -23,10 +23,14 @@
       <name>Shay Elbaum</name>
       <email>selbaum@law.harvard.edu</email>
     </contributor>
+    <contributor>
+      <name>William Barnhart</name>
+      <email>williambbarnhart@gmail.com</email>
+    </contributor>
     <category citation-format="note"/>
     <category field="law"/>
     <summary>The Bluebook legal citation style for law reviews.</summary>
-    <updated>2025-05-06T00:00:00+00:00</updated>
+    <updated>2026-07-18T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -314,7 +318,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1">
+  <citation et-al-min="4" et-al-use-first="1" near-note-distance="5">
     <layout suffix="." delimiter="; ">
       <choose>
         <if position="ibid-with-locator">
@@ -330,14 +334,21 @@
           <choose>
             <!-- subsequent legal citations do not use supra -->
             <if type="legal_case">
-              <group delimiter=", ">
-                <text variable="title" form="short" font-style="italic"/>
-                <group delimiter=" ">
-                  <text variable="volume"/>
-                  <text variable="container-title" form="short"/>
-                  <text macro="at_page"/>
-                </group>
-              </group>
+              <choose>
+                <if position="near-note">
+                  <group delimiter=", ">
+                    <text variable="title" form="short" font-style="italic"/>
+                    <group delimiter=" ">
+                      <text variable="volume"/>
+                      <text variable="container-title" form="short"/>
+                      <text macro="at_page"/>
+                    </group>
+                  </group>
+                </if>
+                <else>
+                  <text macro="source"/>
+                </else>
+              </choose>
             </if>
             <else-if type="legislation">
               <group delimiter=" ">


### PR DESCRIPTION
### Description
Bluebook Rule 10.9 permits a short-form case citation only when the case was cited, in full or short form, in the same or one of the preceding five footnotes; otherwise the full citation must be repeated. Both note styles (`bluebook-law-review`, `bluebook-law-review-with-abstract`) short-cited every subsequent case reference regardless of distance. This uses CSL's `near-note` position with an explicit `near-note-distance="5"` to fall back to the full citation when the preceding cite is too far back.

`bluebook-law-review-with-abstract` additionally sent subsequent case citations through `supra note N`, which Rule 10.9 does not allow for cases; it now uses the same short form as `bluebook-law-review`.

Verified with citeproc-js across sequential footnote clusters: case cited at note 1 → short form at note 3 (`Carroll Towing Co., 159 F.2d at 173`) → full citation again at note 12 (nine notes later) → short form again at note 14. Articles/books still use *supra* as before.

### Checklist
- [x] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`. (already present where applicable; `bluebook-law-review` is not derived from a template)
- [x] Check that you've added a link to the style guidelines with `rel="documentation"`.
- [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update.
- [x] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [x] Check that you've not used `<text value="...` if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.