### PR TITLE
Fix first case citations and page rendering in Bluebook Inline

### DIFF
--- a/bluebook-inline.csl
+++ b/bluebook-inline.csl
@@ -17,12 +17,21 @@
       <name>Nancy Sims</name>
       <email>nsims@umich.edu</email>
     </contributor>
+    <contributor>
+      <name>William Barnhart</name>
+      <email>williambbarnhart@gmail.com</email>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="law"/>
     <summary>Bluebook citation formatting for in-text citations.</summary>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2026-07-18T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+  <locale>
+    <terms>
+      <term name="ibid">id.</term>
+    </terms>
+  </locale>
   <!-- sets up basics of dealing with authors -->
   <macro name="source-short">
     <choose>
@@ -75,19 +84,19 @@
         <text variable="title" font-style="italic" suffix=", "/>
         <text variable="volume" suffix=" "/>
         <text variable="container-title" font-variant="small-caps" suffix=" "/>
-        <text variable="page"/>
+        <text variable="page-first"/>
         <text variable="locator" prefix=", "/>
         <date variable="issued" prefix=" (" suffix=")">
           <date-part name="year"/>
         </date>
       </if>
       <else-if type="legal_case">
-        <text variable="title" suffix=", " font-variant="normal"/>
+        <text variable="title" suffix=", " font-style="italic"/>
         <text variable="number" suffix=", "/>
         <group delimiter=" ">
           <text variable="volume"/>
           <text variable="container-title"/>
-          <text variable="page"/>
+          <text variable="page-first"/>
         </group>
         <text variable="locator" prefix=", "/>
         <group prefix=" (" suffix=")" delimiter=" ">
@@ -155,7 +164,7 @@
         <text variable="title" suffix=", " font-style="italic"/>
         <text variable="volume" suffix=" "/>
         <text macro="container" suffix=" "/>
-        <text variable="page"/>
+        <text variable="page-first"/>
         <text variable="locator" prefix=", "/>
       </else-if>
       <else>
@@ -199,16 +208,16 @@
       <choose>
         <if position="ibid">
           <group delimiter=" ">
-            <text value="id." text-case="capitalize-first" font-style="italic"/>
+            <text term="ibid" text-case="capitalize-first" font-style="italic"/>
             <text macro="at_page"/>
             <!-- period will not show up - this is for find-and-replace later. -->
           </group>
         </if>
-        <else-if position="subsequent" type="legal_case" match="any">
+        <else-if position="subsequent" type="legal_case" match="all">
           <!--CSL does not currently support reference to number of repeats, so cannot follow proper Bluebook repeat rule; choice is either short form, or long form.-->
           <group delimiter=" ">
             <text macro="source-short"/>
-            <text variable="locator" prefix="at "/>
+            <text macro="at_page"/>
           </group>
         </else-if>
         <else-if position="subsequent">


### PR DESCRIPTION
### Description
The subsequent-case branch in `bluebook-inline` used `match="any"` on a condition testing both `position="subsequent"` and `type="legal_case"`, so **every** case citation — including the first — took the short form, omitting the first page and the court/year parenthetical. Requiring both conditions (`match="all"`) restores full first citations.

Also aligns full citations with Bluebook and the `bluebook-law-review` style:
- case names in full cites are italicized per Bluepages B2;
- journal articles, cases, and chapters cite the first page (`page-first`) with pincites rendered separately;
- the subsequent-case pincite goes through the `at_page` macro like the other short forms;
- the hardcoded `<text value="id."` becomes an `ibid` locale term override.

Verified with citeproc-js (first cite now `<i>United States v. Carroll Towing Co.</i>, 159 F.2d 169, 173–174 (2d Cir. 1947)`; subsequent `<i>Carroll Towing Co.</i>, 159 F.2d at 180`; `<i>Id.</i> at 175`).

Known remaining gap (pre-existing, not addressed): the *supra* branch renders `first-reference-note-number`, which is meaningless in an in-text style with no footnotes.

### Checklist
- [ ] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`. (n/a — update to an existing style not derived from a template)
- [x] Check that you've added a link to the style guidelines with `rel="documentation"`.
- [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update.
- [x] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [x] Check that you've not used `<text value="...` if not absolutely necessary (replaced a hardcoded `id.` with the `ibid` term).
- [x] Check that you've not changed line 1 of the style.