### PR TITLE
Update copernicus-publications.csl

### DIFF
--- a/copernicus-publications.csl
+++ b/copernicus-publications.csl
@@ -318,13 +318,13 @@
             <text macro="editor"/>
             <group prefix=", ">
               <text variable="container-title" form="short"/>
-                <group>
-                  <text variable="volume"/>
-                  <text macro="published-date"/>
-                </group>
-                <text variable="archive"/>
-                <text macro="pages"/>
-                <text macro="doi"/>
+              <group>
+                <text variable="volume"/>
+                <text macro="published-date"/>
+              </group>
+              <text variable="archive"/>
+              <text macro="pages"/>
+              <text macro="doi"/>
             </group>
           </else>
         </choose>

--- a/copernicus-publications.csl
+++ b/copernicus-publications.csl
@@ -224,122 +224,111 @@
           <text macro="title"/>
         </group>
         <choose>
-          <if type="webpage article" match="none">
-            <choose>
-              <if type="book" match="any">
-                <group delimiter=", " prefix=" ">
-                  <text macro="edition"/>
-                  <text macro="editor"/>
-                  <text variable="genre"/>
-                  <text macro="publisher"/>
-                  <text macro="number-of-pages"/>
-                  <text macro="doi"/>
-                </group>
-              </if>
-              <else-if type="chapter">
-                <group delimiter=", " prefix=" ">
-                  <text macro="container"/>
-                  <text macro="publisher"/>
-                  <text variable="page"/>
-                  <text macro="doi"/>
-                </group>
-              </else-if>
-              <else-if type="dataset software" match="any">
-                <group delimiter=", " prefix=" ">
-                  <choose>
-                    <if type="dataset">
-                      <text variable="archive" suffix=" [dataset]"/>
-                    </if>
-                    <else>
-                      <text variable="archive" suffix=" [code]"/>
-                    </else>
-                  </choose>
-                  <text macro="access"/>
-                </group>
-              </else-if>
-              <else-if type="paper-conference">
-                <group delimiter=", " prefix=" ">
-                  <text macro="container_conference"/>
-                  <text variable="event"/>
-                  <text variable="event-place"/>
-                  <date variable="event-date">
-                    <date-part name="day" suffix=" " range-delimiter="-"/>
-                    <date-part name="month" suffix=" "/>
-                    <date-part name="year"/>
-                  </date>
-                  <text variable="note"/>
-                  <text variable="page"/>
-                  <text macro="doi"/>
-                </group>
-              </else-if>
-              <else-if type="thesis">
-                <group delimiter=", " prefix=" ">
-                  <text variable="genre"/>
-                  <text macro="publisher"/>
-                  <text macro="number-of-pages"/>
-                  <text macro="doi"/>
-                </group>
-              </else-if>
-              <else-if type="map report" match="any">
-                <group delimiter=", " prefix=" ">
-                  <text variable="container-title"/>
-                  <text variable="collection-title"/>
-                  <text variable="number"/>
-                  <text macro="publisher"/>
-                  <text macro="number-of-pages"/>
-                  <text macro="access"/>
-                </group>
-              </else-if>
-              <else-if type="article-journal" match="any">
-                <group delimiter=", " prefix=" ">
-                  <text variable="container-title" form="short"/>
-                  <text variable="volume"/>
-                  <text variable="page"/>
-                  <text macro="doi"/>
-                </group>
-              </else-if>
-              <else>
-                <text macro="editor"/>
-                <group prefix=", ">
-                  <text variable="container-title" form="short"/>
-                  <group delimiter=", ">
-                    <group>
-                      <text variable="volume"/>
-                      <text macro="published-date"/>
-                    </group>
-                    <text variable="archive"/>
-                    <text macro="pages"/>
-                    <text macro="doi"/>
-                  </group>
-                </group>
-              </else>
-            </choose>
-            <text macro="year-date" suffix="."/>
+          <if type="book" match="any">
+            <group delimiter=", ">
+              <text macro="edition"/>
+              <text macro="editor"/>
+              <text variable="genre"/>
+              <text macro="publisher"/>
+              <text macro="number-of-pages"/>
+              <text macro="doi"/>
+            </group>
           </if>
+          <else-if type="chapter">
+            <group delimiter=", " prefix=" ">
+              <text macro="container"/>
+              <text macro="publisher"/>
+              <text variable="page"/>
+              <text macro="doi"/>
+            </group>
+          </else-if>
+          <else-if type="dataset software" match="any">
+            <group delimiter=", ">
+              <choose>
+                <if type="dataset">
+                  <text variable="archive" suffix=" [dataset]"/>
+                </if>
+                <else>
+                  <text variable="archive" suffix=" [code]"/>
+                </else>
+              </choose>
+              <text macro="access"/>
+            </group>
+          </else-if>
+          <else-if type="paper-conference">
+            <group delimiter=", ">
+              <text macro="container_conference"/>
+              <text variable="event"/>
+              <text variable="event-place"/>
+              <date variable="event-date">
+                <date-part name="day" suffix=" " range-delimiter="-"/>
+                <date-part name="month" suffix=" "/>
+                <date-part name="year"/>
+              </date>
+              <text variable="page"/>
+              <text macro="doi"/>
+            </group>
+          </else-if>
+          <else-if type="thesis">
+            <group delimiter=", ">
+              <text variable="genre"/>
+              <text macro="publisher"/>
+              <text macro="number-of-pages"/>
+              <text macro="doi"/>
+            </group>
+          </else-if>
+          <else-if type="map report" match="any">
+            <group delimiter=", ">
+              <text variable="container-title"/>
+              <text variable="collection-title"/>
+              <text variable="number"/>
+              <text macro="publisher"/>
+              <text macro="number-of-pages"/>
+              <text macro="access"/>
+            </group>
+          </else-if>
+          <else-if type="webpage post post-weblog" match="any">
+            <group delimiter=", " suffix=".">
+              <text macro="access"/>
+              <date variable="issued">
+                <date-part name="year"/>
+              </date>
+            </group>
+          </else-if>
+          <else-if type="article">
+            <group delimiter=", " suffix=".">
+              <text variable="archive" suffix=" [preprint]"/>
+              <text macro="access"/>
+              <date variable="issued">
+                <date-part name="day" suffix=" "/>
+                <date-part name="month" suffix=" "/>
+                <date-part name="year"/>
+              </date>
+            </group>
+          </else-if>
+          <else-if type="article-journal" match="any">
+            <group delimiter=", " prefix=" ">
+              <text variable="container-title" form="short"/>
+              <text variable="volume"/>
+              <text variable="page"/>
+              <text macro="doi"/>
+            </group>
+          </else-if>
           <else>
-            <choose>
-              <if type="webpage">
-                <group delimiter=", " prefix=" " suffix=".">
-                  <text macro="access"/>
-                  <date variable="issued">
-                    <date-part name="year"/>
-                  </date>
+            <text macro="editor"/>
+            <group prefix=", ">
+              <text variable="container-title" form="short"/>
+                <group>
+                  <text variable="volume"/>
+                  <text macro="published-date"/>
                 </group>
-              </if>
-              <else-if type="article">
-                <group delimiter=", " prefix=" " suffix=".">
-                  <text variable="archive" suffix=" [preprint]"/>
-                  <text macro="access"/>
-                  <date variable="issued">
-                    <date-part name="day" suffix=" "/>
-                    <date-part name="month" suffix=" "/>
-                    <date-part name="year"/>
-                  </date>
-                </group>
-              </else-if>
-            </choose>
+                <text variable="archive"/>
+                <text macro="pages"/>
+                <text macro="doi"/>
+            </group>
           </else>
         </choose>
+        <text macro="year-date" suffix="."/>
       </group>
     </layout>
   </bibliography>

--- a/copernicus-publications.csl
+++ b/copernicus-publications.csl
@@ -212,14 +212,28 @@
                 <text macro="doi"/>
               </group>
             </else-if>
-            <else-if type="dataset">
+            <else-if type="dataset software">
               <group delimiter=", " prefix=" ">
                 <group delimiter=" ">
                   <text macro="title"/>
                   <text variable="version" prefix="(" suffix=")"/>
                 </group>
-                <text variable="archive" suffix=" [dataset]"/>
-                <text macro="doi"/>
+                <choose>
+                  <if type="dataset">
+                    <text variable="archive" suffix=" [dataset]"/>
+                  </if>
+                  <else>
+                    <text variable="archive" suffix=" [code]"/>
+                  </else>
+                </choose>
+                <choose>
+                  <if match="any" variable="DOI">
+                    <text macro="doi"/>
+                  </if>
+                  <else>
+                    <text variable="URL"/>
+                  </else>
+                </choose>
               </group>
             </else-if>
             <else-if type="paper-conference">

--- a/copernicus-publications.csl
+++ b/copernicus-publications.csl
@@ -71,25 +71,6 @@
       </substitute>
     </names>
   </macro>
-  <macro name="access">
-    <choose>
-      <if variable="DOI" match="none">
-        <choose>
-          <if variable="URL">
-            <text variable="URL"/>
-            <group delimiter=": " prefix=", ">
-              <text term="accessed"/>
-              <date variable="accessed">
-                <date-part name="day" suffix=" "/>
-                <date-part name="month" suffix=" "/>
-                <date-part name="year"/>
-              </date>
-            </group>
-          </if>
-        </choose>
-      </if>
-    </choose>
-  </macro>
   <macro name="title">
     <text variable="title"/>
   </macro>
@@ -106,6 +87,18 @@
           <date-part name="year"/>
         </date>
       </if>
+      <else-if type="webpage">
+        <choose>
+          <if variable="accessed">
+            <date variable="accessed">
+              <date-part name="year"/>
+            </date>
+          </if>
+          <else>
+            <text term="no date" form="short"/>
+          </else>
+        </choose>
+      </else-if>
       <else>
         <text term="no date" form="short"/>
       </else>
@@ -157,6 +150,38 @@
     <text term="in" suffix=": "/>
     <text variable="container-title"/>
   </macro>
+  <macro name="access">
+    <choose>
+      <if variable="DOI" match="any">
+        <text macro="doi"/>
+      </if>
+      <else>
+        <choose>
+          <if variable="URL">
+	          <text variable="URL"/>
+            <choose>
+              <if type="webpage">
+                <text macro="accessed-date" prefix=", "/>
+              </if>
+              <else>
+                <text macro="accessed-date" prefix=" (" suffix=")"/>
+              </else>
+            </choose>
+          </if>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="accessed-date">
+    <group delimiter=": ">
+      <text term="accessed"/>
+        <date variable="accessed">
+          <date-part name="day" suffix=" "/>
+          <date-part name="month" suffix=" "/>
+          <date-part name="year"/>
+        </date>
+    </group>
+  </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year-suffix" year-suffix-delimiter=", ">
     <sort>
       <key macro="author"/>
@@ -171,8 +196,15 @@
               <text macro="year-date"/>
             </if>
             <else>
-              <text macro="title"/>
-              <date date-parts="year" form="text" variable="accessed"/>
+              <choose>
+                <if variable="author" match="any">
+                  <text macro="author-short"/>
+                </if>
+                <else>
+                  <text macro="title"/>
+                </else>
+              </choose>
+              <text macro="year-date"/>
             </else>
           </choose>
         </group>
@@ -189,11 +221,11 @@
       <key variable="title"/>
     </sort>
     <layout>
+      <group delimiter=" " suffix=":">
+        <text macro="author"/>
+      </group>
       <choose>
         <if type="webpage article" match="none">
-          <group delimiter=" " suffix=":">
-            <text macro="author"/>
-          </group>
           <choose>
             <if type="book" match="any">
               <group delimiter=", " prefix=" ">
@@ -215,28 +247,21 @@
                 <text macro="doi"/>
               </group>
             </else-if>
-            <else-if type="dataset software">
+            <else-if type="dataset software" match="any">
               <group delimiter=", " prefix=" ">
                 <group delimiter=" ">
                   <text macro="title"/>
                   <text variable="version" prefix="(" suffix=")"/>
-                </group>
+	              </group>
                 <choose>
-                  <if type="dataset">
+		              <if type="dataset">
                     <text variable="archive" suffix=" [dataset]"/>
-                  </if>
-                  <else>
-                    <text variable="archive" suffix=" [code]"/>
+		              </if>
+		              <else>
+	                  <text variable="archive" suffix=" [code]"/>
                   </else>
-                </choose>
-                <choose>
-                  <if match="any" variable="DOI">
-                    <text macro="doi"/>
-                  </if>
-                  <else>
-                    <text variable="URL"/>
-                  </else>
-                </choose>
+		            </choose>
+                <text macro="access"/>
               </group>
             </else-if>
             <else-if type="paper-conference">
@@ -268,9 +293,11 @@
               <group delimiter=", " prefix=" ">
                 <text macro="title"/>
                 <text variable="container-title"/>
+                <text variable="collection-title"/>
+                <text variable="number"/>
                 <text macro="publisher"/>
                 <text variable="number-of-pages" suffix=" pp."/>
-                <text macro="doi"/>
+		            <text macro="access"/>
               </group>
             </else-if>
             <else-if type="article-journal" match="any">
@@ -305,25 +332,20 @@
         </if>
         <else>
           <choose>
-            <if type="webpage" match="any">
-              <text variable="title" suffix=": "/>
-              <text macro="access" prefix=" " suffix="."/>
-            </if>
-            <else-if type="article" match="any">
-              <group delimiter=" " suffix=":">
-                <text macro="author"/>
-              </group>
+            <if type="webpage">
+              <group delimiter=", " prefix=" " suffix=".">
+	              <text variable="title"/>
+		            <text macro="access"/>
+		            <date variable="issued">
+		              <date-part name="year"/>
+		            </date>
+	            </group>
+	          </if>
+            <else-if type="article">
               <group delimiter=", " prefix=" " suffix=".">
                 <text variable="title"/>
                 <text variable="archive" suffix=" [preprint]"/>
-                <choose>
-                  <if match="any" variable="DOI">
-                    <text macro="doi"/>
-                  </if>
-                  <else>
-                    <text variable="URL"/>
-                  </else>
-                </choose>
+                <text macro="access"/>
                 <date variable="issued">
                   <date-part name="day" suffix=" "/>
                   <date-part name="month" suffix=" "/>

--- a/copernicus-publications.csl
+++ b/copernicus-publications.csl
@@ -25,7 +25,7 @@
     <category citation-format="author-date"/>
     <category field="science"/>
     <summary>The Copernicus generic style</summary>
-    <updated>2026-07-28T10:43:11+00:00</updated>
+    <updated>2026-07-40T21:43:11+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">

--- a/copernicus-publications.csl
+++ b/copernicus-publications.csl
@@ -48,7 +48,6 @@
       <label form="short" text-case="capitalize-first" prefix=" (" suffix=")"/>
       <substitute>
         <names variable="editor collection-editor"/>
-        <text macro="anon"/>
       </substitute>
     </names>
   </macro>
@@ -59,8 +58,8 @@
         <names variable="editor"/>
         <names variable="translator"/>
         <names variable="collection-editor"/>
-        <text macro="anon"/>
         <text macro="title"/>
+        <text macro="anon"/>
       </substitute>
     </names>
   </macro>

--- a/copernicus-publications.csl
+++ b/copernicus-publications.csl
@@ -25,7 +25,7 @@
     <category citation-format="author-date"/>
     <category field="science"/>
     <summary>The Copernicus generic style</summary>
-    <updated>2023-06-05T10:43:11+00:00</updated>
+    <updated>2026-07-28T10:43:11+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">

--- a/copernicus-publications.csl
+++ b/copernicus-publications.csl
@@ -25,7 +25,7 @@
     <category citation-format="author-date"/>
     <category field="science"/>
     <summary>The Copernicus generic style</summary>
-    <updated>2026-07-40T21:43:11+00:00</updated>
+    <updated>2026-08-06T14:37:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -60,6 +60,7 @@
         <names variable="translator"/>
         <names variable="collection-editor"/>
         <text macro="anon"/>
+        <text macro="title"/>
       </substitute>
     </names>
   </macro>
@@ -73,6 +74,11 @@
   </macro>
   <macro name="title">
     <text variable="title"/>
+    <choose>
+      <if type="dataset software" match="any">
+        <text variable="version" prefix=" (" suffix=")"/>
+      </if>
+    </choose>
   </macro>
   <macro name="publisher">
     <group delimiter=", ">
@@ -87,7 +93,7 @@
           <date-part name="year"/>
         </date>
       </if>
-      <else-if type="webpage">
+      <else-if type="webpage post post-weblog" match="any">
         <choose>
           <if variable="accessed">
             <date variable="accessed">
@@ -158,7 +164,7 @@
       <else>
         <choose>
           <if variable="URL">
-	          <text variable="URL"/>
+            <text variable="URL"/>
             <choose>
               <if type="webpage">
                 <text macro="accessed-date" prefix=", "/>
@@ -175,11 +181,17 @@
   <macro name="accessed-date">
     <group delimiter=": ">
       <text term="accessed"/>
-        <date variable="accessed">
-          <date-part name="day" suffix=" "/>
-          <date-part name="month" suffix=" "/>
-          <date-part name="year"/>
-        </date>
+      <date variable="accessed">
+        <date-part name="day" suffix=" "/>
+        <date-part name="month" suffix=" "/>
+        <date-part name="year"/>
+      </date>
+    </group>
+  </macro>
+  <macro name="number-of-pages">
+    <group delimiter=" ">
+      <text variable="number-of-pages"/>
+      <label variable="number-of-pages" form="short"/>
     </group>
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year-suffix" year-suffix-delimiter=", ">
@@ -189,30 +201,16 @@
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
-        <group delimiter=", ">
-          <choose>
-            <if type="webpage" match="none">
-              <text macro="author-short"/>
-              <text macro="year-date"/>
-            </if>
-            <else>
-              <choose>
-                <if variable="author" match="any">
-                  <text macro="author-short"/>
-                </if>
-                <else>
-                  <text macro="title"/>
-                </else>
-              </choose>
-              <text macro="year-date"/>
-            </else>
-          </choose>
+        <text macro="author-short"/>
+        <text macro="year-date"/>
+        <group delimiter=" ">
+          <label variable="locator" form="short"/>
+          <text variable="locator"/>
         </group>
-        <text variable="locator" prefix="p."/>
       </group>
     </layout>
   </citation>
-  <bibliography et-al-min="100" et-al-use-first="99">
+  <bibliography>
     <sort>
       <key macro="author" names-min="1" names-use-first="1"/>
       <key macro="author-count" names-min="3" names-use-first="3"/>
@@ -221,141 +219,129 @@
       <key variable="title"/>
     </sort>
     <layout>
-      <group delimiter=" " suffix=":">
-        <text macro="author"/>
-      </group>
-      <choose>
-        <if type="webpage article" match="none">
-          <choose>
-            <if type="book" match="any">
-              <group delimiter=", " prefix=" ">
-                <text macro="title"/>
-                <text macro="edition"/>
-                <text macro="editor"/>
-                <text variable="genre"/>
-                <text macro="publisher"/>
-                <text variable="number-of-pages" suffix=" pp."/>
-                <text macro="doi"/>
-              </group>
-            </if>
-            <else-if type="chapter">
-              <group delimiter=", " prefix=" ">
-                <text macro="title"/>
-                <text macro="container"/>
-                <text macro="publisher"/>
-                <text variable="page"/>
-                <text macro="doi"/>
-              </group>
-            </else-if>
-            <else-if type="dataset software" match="any">
-              <group delimiter=", " prefix=" ">
-                <group delimiter=" ">
-                  <text macro="title"/>
-                  <text variable="version" prefix="(" suffix=")"/>
-	              </group>
-                <choose>
-		              <if type="dataset">
-                    <text variable="archive" suffix=" [dataset]"/>
-		              </if>
-		              <else>
-	                  <text variable="archive" suffix=" [code]"/>
-                  </else>
-		            </choose>
-                <text macro="access"/>
-              </group>
-            </else-if>
-            <else-if type="paper-conference">
-              <group delimiter=", " prefix=" ">
-                <text macro="title"/>
-                <text macro="container_conference"/>
-                <text variable="event"/>
-                <text variable="event-place"/>
-                <date variable="event-date">
-                  <date-part name="day" suffix=" " range-delimiter="-"/>
-                  <date-part name="month" suffix=" "/>
-                  <date-part name="year"/>
-                </date>
-                <text variable="note"/>
-                <text variable="page"/>
-                <text macro="doi"/>
-              </group>
-            </else-if>
-            <else-if type="thesis">
-              <group delimiter=", " prefix=" ">
-                <text macro="title"/>
-                <text variable="genre"/>
-                <text macro="publisher"/>
-                <text variable="number-of-pages" suffix=" pp."/>
-                <text macro="doi"/>
-              </group>
-            </else-if>
-            <else-if type="map report" match="any">
-              <group delimiter=", " prefix=" ">
-                <text macro="title"/>
-                <text variable="container-title"/>
-                <text variable="collection-title"/>
-                <text variable="number"/>
-                <text macro="publisher"/>
-                <text variable="number-of-pages" suffix=" pp."/>
-		            <text macro="access"/>
-              </group>
-            </else-if>
-            <else-if type="article-journal" match="any">
-              <group delimiter=", " prefix=" ">
-                <text variable="title"/>
-                <text variable="container-title" form="short"/>
-                <text variable="volume"/>
-                <text variable="page"/>
-                <text macro="doi"/>
-              </group>
-            </else-if>
-            <else>
-              <group delimiter=", " suffix="," prefix=" ">
-                <text macro="title"/>
-                <text macro="editor"/>
-              </group>
-              <group prefix=" ">
-                <text variable="container-title" form="short"/>
-                <group prefix=", " delimiter=", ">
-                  <group>
-                    <text variable="volume"/>
-                    <text macro="published-date"/>
-                  </group>
-                  <text variable="archive"/>
-                  <text macro="pages"/>
+      <group delimiter=", ">
+        <group delimiter=": ">
+          <text macro="author"/>
+          <text macro="title"/>
+        </group>
+        <choose>
+          <if type="webpage article" match="none">
+            <choose>
+              <if type="book" match="any">
+                <group delimiter=", " prefix=" ">
+                  <text macro="edition"/>
+                  <text macro="editor"/>
+                  <text variable="genre"/>
+                  <text macro="publisher"/>
+                  <text macro="number-of-pages"/>
                   <text macro="doi"/>
                 </group>
-              </group>
-            </else>
-          </choose>
-          <text macro="year-date" prefix=", " suffix="."/>
-        </if>
-        <else>
-          <choose>
-            <if type="webpage">
-              <group delimiter=", " prefix=" " suffix=".">
-	              <text variable="title"/>
-		            <text macro="access"/>
-		            <date variable="issued">
-		              <date-part name="year"/>
-		            </date>
-	            </group>
-	          </if>
-            <else-if type="article">
-              <group delimiter=", " prefix=" " suffix=".">
-                <text variable="title"/>
-                <text variable="archive" suffix=" [preprint]"/>
-                <text macro="access"/>
-                <date variable="issued">
-                  <date-part name="day" suffix=" "/>
-                  <date-part name="month" suffix=" "/>
-                  <date-part name="year"/>
-                </date>
-              </group>
-            </else-if>
-          </choose>
-        </else>
-      </choose>
+              </if>
+              <else-if type="chapter">
+                <group delimiter=", " prefix=" ">
+                  <text macro="container"/>
+                  <text macro="publisher"/>
+                  <text variable="page"/>
+                  <text macro="doi"/>
+                </group>
+              </else-if>
+              <else-if type="dataset software" match="any">
+                <group delimiter=", " prefix=" ">
+                  <choose>
+                    <if type="dataset">
+                      <text variable="archive" suffix=" [dataset]"/>
+                    </if>
+                    <else>
+                      <text variable="archive" suffix=" [code]"/>
+                    </else>
+                  </choose>
+                  <text macro="access"/>
+                </group>
+              </else-if>
+              <else-if type="paper-conference">
+                <group delimiter=", " prefix=" ">
+                  <text macro="container_conference"/>
+                  <text variable="event"/>
+                  <text variable="event-place"/>
+                  <date variable="event-date">
+                    <date-part name="day" suffix=" " range-delimiter="-"/>
+                    <date-part name="month" suffix=" "/>
+                    <date-part name="year"/>
+                  </date>
+                  <text variable="note"/>
+                  <text variable="page"/>
+                  <text macro="doi"/>
+                </group>
+              </else-if>
+              <else-if type="thesis">
+                <group delimiter=", " prefix=" ">
+                  <text variable="genre"/>
+                  <text macro="publisher"/>
+                  <text macro="number-of-pages"/>
+                  <text macro="doi"/>
+                </group>
+              </else-if>
+              <else-if type="map report" match="any">
+                <group delimiter=", " prefix=" ">
+                  <text variable="container-title"/>
+                  <text variable="collection-title"/>
+                  <text variable="number"/>
+                  <text macro="publisher"/>
+                  <text macro="number-of-pages"/>
+                  <text macro="access"/>
+                </group>
+              </else-if>
+              <else-if type="article-journal" match="any">
+                <group delimiter=", " prefix=" ">
+                  <text variable="container-title" form="short"/>
+                  <text variable="volume"/>
+                  <text variable="page"/>
+                  <text macro="doi"/>
+                </group>
+              </else-if>
+              <else>
+                <text macro="editor"/>
+                <group prefix=", ">
+                  <text variable="container-title" form="short"/>
+                  <group delimiter=", ">
+                    <group>
+                      <text variable="volume"/>
+                      <text macro="published-date"/>
+                    </group>
+                    <text variable="archive"/>
+                    <text macro="pages"/>
+                    <text macro="doi"/>
+                  </group>
+                </group>
+              </else>
+            </choose>
+            <text macro="year-date" suffix="."/>
+          </if>
+          <else>
+            <choose>
+              <if type="webpage">
+                <group delimiter=", " prefix=" " suffix=".">
+                  <text macro="access"/>
+                  <date variable="issued">
+                    <date-part name="year"/>
+                  </date>
+                </group>
+              </if>
+              <else-if type="article">
+                <group delimiter=", " prefix=" " suffix=".">
+                  <text variable="archive" suffix=" [preprint]"/>
+                  <text macro="access"/>
+                  <date variable="issued">
+                    <date-part name="day" suffix=" "/>
+                    <date-part name="month" suffix=" "/>
+                    <date-part name="year"/>
+                  </date>
+                </group>
+              </else-if>
+            </choose>
+          </else>
+        </choose>
+      </group>
     </layout>
   </bibliography>
 </style>

--- a/copernicus-publications.csl
+++ b/copernicus-publications.csl
@@ -19,6 +19,9 @@
       <name>Johannes Wagner</name>
       <email>johannes.wagner@copernicus.org</email>
     </contributor>
+    <contributor>
+      <name>Christopher Holmes</name>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="science"/>
     <summary>The Copernicus generic style</summary>


### PR DESCRIPTION
### Description
The copernicus-publications style was previously unable to create bibliography entries for software items.

Software items are closely related to Dataset items,  so the Dataset type is modified to accommodate both. For both Software and Dataset, include URL in bibliography if DOI is empty


### Checklist
- [x] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [x] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [x] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [x] Check that you've not used `<text value="...` if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.
