### PR TITLE
Update lancaster-university-harvard.csl

### DIFF
--- a/lancaster-university-harvard.csl
+++ b/lancaster-university-harvard.csl
@@ -340,7 +340,8 @@
       </else>
     </choose>
   </macro>
-
+<macro name="publisher-article">
+</macro>
   <macro name="publisher-monograph">
     <group delimiter=": ">
       <text variable="publisher-place"/>

--- a/lancaster-university-harvard.csl
+++ b/lancaster-university-harvard.csl
@@ -340,16 +340,7 @@
       </else>
     </choose>
   </macro>
-  <macro name="publisher-article">
-    <choose>
-      <if variable="publisher">
-        <text variable="publisher"/>
-      </if>
-      <else-if variable="archive">
-        <text variable="archive"/>
-      </else-if>
-    </choose>
-  </macro>
+
   <macro name="publisher-monograph">
     <group delimiter=": ">
       <text variable="publisher-place"/>

--- a/lancaster-university-harvard.csl
+++ b/lancaster-university-harvard.csl
@@ -12,7 +12,7 @@
     </author>
     <category citation-format="author-date"/>
     <summary>The Harvard author-date style - adapted for Lancaster University</summary>
-    <updated>2020-07-22T08:41:45+00:00</updated>
+    <updated>2026-01-25T22:16:24+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="accessed">
@@ -340,8 +340,19 @@
       </else>
     </choose>
   </macro>
-<macro name="publisher-article">
-</macro>
+  <macro name="publisher-article">
+  <!-- Journal articles do not display publisher per Lancaster guidelines -->
+  <!--
+  <choose>
+    <if variable="publisher">
+      <text variable="publisher"/>
+    </if>
+    <else-if variable="archive">
+      <text variable="archive"/>
+    </else-if>
+  </choose>
+  -->
+  </macro>
   <macro name="publisher-monograph">
     <group delimiter=": ">
       <text variable="publisher-place"/>


### PR DESCRIPTION
As per Lancaster guidelines (https://www.lancaster.ac.uk/media/lancaster-university/content-assets/documents/sociology/practice-learning/Harvard__Lancaster_University_Library__Referencing_Guide_21-22.pdf) journal articles shouldn't have the publisher field.

## CSL Styles Pull Request Template
You're about to create a pull request to the CSL **styles** repository.  
If you haven't done so already, see <https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md> for instructions on how to contribute, and <https://github.com/citation-style-language/styles/blob/master/STYLE_REQUIREMENTS.md> for the requirements a style must meet before acceptance.  
In addition, please fill out the pull request template below.


### Description
Removed the section that was adding publisher to journal articles for Lancaster Harvard style, as this is not part of the format (see https://www.lancaster.ac.uk/media/lancaster-university/content-assets/documents/sociology/practice-learning/Harvard__Lancaster_University_Library__Referencing_Guide_21-22.pdf)


### Checklist
- [ ] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [ ] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [ ] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [ ] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [ ] Check that you've not used `<text value="...` if not absolutely necessary.
- [ ] Check that you've not changed line 1 of the style.
