### PR TITLE
Add Universitas Gadjah Mada - Farmasi DIF (Bahasa Indonesia)

### DIFF
--- a/universitas-gadjah-mada-doctor-of-pharmaceutical-sciences.csl
+++ b/universitas-gadjah-mada-doctor-of-pharmaceutical-sciences.csl
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="id-ID">
   <info>
-    <title>Universitas Gadjah Mada - Farmasi DIF (Bahasa Indonesia)</title>
-    <title-short>UGM Farmasi DIF</title-short>
-    <id>http://www.zotero.org/styles/universitas-gadjah-mada-farmasi-dif</id>
-    <link href="http://www.zotero.org/styles/universitas-gadjah-mada-farmasi-dif" rel="self"/>
+    <title>Universitas Gadjah Mada - Doctor of Pharmaceutical Sciences (DIF, Bahasa Indonesia)</title>
+    <title-short>UGM DIF</title-short>
+    <id>http://www.zotero.org/styles/universitas-gadjah-mada-doctor-of-pharmaceutical-sciences</id>
+    <link href="http://www.zotero.org/styles/universitas-gadjah-mada-doctor-of-pharmaceutical-sciences" rel="self"/>
     <link href="http://www.zotero.org/styles/ecology-letters" rel="template"/>
     <link href="https://programdoktor.farmasi.ugm.ac.id/academic-guideline/" rel="documentation"/>
     <author>
@@ -24,12 +24,9 @@
         <multiple>hal.</multiple>
       </term>
       <term name="retrieved">diakses</term>
-      <term name="from">dari</term>
       <term name="accessed">diakses tanggal</term>
       <term name="open-quote">‘</term>
       <term name="close-quote">’</term>
-      <term name="et-al">dkk.</term>
-      <term name="and">dan</term>
     </terms>
   </locale>
   <macro name="container">
@@ -91,7 +88,7 @@
             <text variable="title" form="short" font-style="italic"/>
           </if>
           <else-if type="webpage post post-weblog" match="any">
-            <text variable="title" form="long" quotes="false"/>
+            <text variable="title" form="long"/>
           </else-if>
           <else>
             <text variable="title" form="long" quotes="true"/>
@@ -105,8 +102,8 @@
       <if type="webpage post post-weblog">
         <group delimiter=" ">
           <text variable="URL" prefix="URL: "/>
-          <group prefix=" (" suffix=").">
-            <text term="accessed" suffix=" "/>
+          <group prefix=" (" suffix=")." delimiter=" ">
+            <text term="accessed"/>
             <date variable="accessed">
               <date-part name="day" suffix="/"/>
               <date-part name="month" form="numeric" suffix="/"/>
@@ -128,7 +125,7 @@
           <text macro="edition"/>
         </group>
       </else-if>
-      <else-if type="webpage">
+      <else-if type="webpage post post-weblog" match="any">
         <group delimiter=" ">
           <text variable="title"/>
           <text term="internet" font-style="italic" prefix="[" suffix="]"/>

--- a/universitas-gadjah-mada-doctor-of-pharmaceutical-sciences.csl
+++ b/universitas-gadjah-mada-doctor-of-pharmaceutical-sciences.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="id-ID">
   <info>
-    <title>Universitas Gadjah Mada - Doctor of Pharmaceutical Sciences (DIF, Bahasa Indonesia)</title>
+    <title>Universitas Gadjah Mada - Doctor of Pharmaceutical Sciences (Bahasa Indonesia)</title>
     <title-short>UGM DIF</title-short>
     <id>http://www.zotero.org/styles/universitas-gadjah-mada-doctor-of-pharmaceutical-sciences</id>
     <link href="http://www.zotero.org/styles/universitas-gadjah-mada-doctor-of-pharmaceutical-sciences" rel="self"/>
@@ -14,10 +14,10 @@
     <category citation-format="author-date"/>
     <category field="science"/>
     <category field="chemistry"/>
-    <updated>2026-08-04T00:00:00+00:00</updated>
+    <updated>2026-08-10T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <locale xml:lang="id-ID">
+  <locale xml:lang="id">
     <terms>
       <term name="page" form="short">
         <single>hal.</single>
@@ -50,12 +50,12 @@
         </group>
       </else-if>
       <else-if type="webpage post post-weblog" match="any">
-        <text variable="container-title" form="long" font-style="italic"/>
+        <text variable="container-title" font-style="italic"/>
       </else-if>
       <else-if type="thesis" match="any">
         <group delimiter=" ">
           <text variable="genre"/>
-          <text variable="container-title" form="long" font-style="italic"/>
+          <text variable="container-title" font-style="italic"/>
         </group>
       </else-if>
       <else>
@@ -88,10 +88,10 @@
             <text variable="title" form="short" font-style="italic"/>
           </if>
           <else-if type="webpage post post-weblog" match="any">
-            <text variable="title" form="long"/>
+            <text variable="title"/>
           </else-if>
           <else>
-            <text variable="title" form="long" quotes="true"/>
+            <text variable="title" quotes="true"/>
           </else>
         </choose>
       </substitute>
@@ -99,10 +99,10 @@
   </macro>
   <macro name="access">
     <choose>
-      <if type="webpage post post-weblog">
+      <if type="webpage post post-weblog" match="any">
         <group delimiter=" ">
           <text variable="URL" prefix="URL: "/>
-          <group prefix=" (" suffix=")." delimiter=" ">
+          <group prefix="(" suffix=")." delimiter=" ">
             <text term="accessed"/>
             <date variable="accessed">
               <date-part name="day" suffix="/"/>
@@ -190,8 +190,8 @@
   <macro name="locators">
     <choose>
       <if type="article-journal article-magazine article-newspaper" match="any">
-        <group>
-          <text variable="volume" font-weight="bold" suffix=":"/>
+        <group delimiter=":">
+          <text variable="volume" font-weight="bold"/>
           <text variable="page"/>
         </group>
       </if>

--- a/universitas-gadjah-mada-doctor-of-pharmaceutical-sciences.csl
+++ b/universitas-gadjah-mada-doctor-of-pharmaceutical-sciences.csl
@@ -9,7 +9,7 @@
     <link href="https://programdoktor.farmasi.ugm.ac.id/academic-guideline/" rel="documentation"/>
     <author>
       <name>Arifin Santoso</name>
-      <email>arifinsantoso@ugm.ac.id</email>
+      <email>arifinsantoso.apt@gmail.com</email>
     </author>
     <category citation-format="author-date"/>
     <category field="science"/>

--- a/universitas-gadjah-mada-farmasi-dif.csl
+++ b/universitas-gadjah-mada-farmasi-dif.csl
@@ -1,0 +1,258 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="id">
+  <info>
+    <title>Universitas Gadjah Mada - Farmasi DIF (Bahasa Indonesia)</title>
+    <title-short>UGM Farmasi DIF</title-short>
+    <id>http://www.zotero.org/styles/universitas-gadjah-mada-farmasi-dif</id>
+    <link href="http://www.zotero.org/styles/universitas-gadjah-mada-farmasi-dif" rel="self"/>
+    <link href="http://www.zotero.org/styles/ecology-letters" rel="template"/>
+    <link href="https://programdoktor.farmasi.ugm.ac.id/academic-guideline/" rel="documentation"/>
+    <author>
+      <name>Arifin Santoso</name>
+      <email>arifinsantoso@ugm.ac.id</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="science"/>
+    <category field="chemistry"/>
+    <updated>2026-08-04T00:00:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="id">
+    <terms>
+      <term name="page" form="short">
+        <single>hal.</single>
+        <multiple>hal.</multiple>
+      </term>
+      <term name="retrieved">diakses</term>
+      <term name="from">dari</term>
+      <term name="accessed">diakses tanggal</term>
+      <term name="open-quote">‘</term>
+      <term name="close-quote">’</term>
+      <term name="et-al">dkk.</term>
+      <term name="and">dan</term>
+    </terms>
+  </locale>
+  <macro name="container">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <group delimiter=", ">
+          <group delimiter=": ">
+            <text term="in"/>
+            <names variable="editor translator" delimiter=", ">
+              <name name-as-sort-order="all" sort-separator=", " initialize-with="." and="text" delimiter=", " delimiter-precedes-last="contextual"/>
+              <label plural="never" text-case="capitalize-first" prefix=" (" suffix=")"/>
+            </names>
+          </group>
+          <text variable="container-title" text-case="title" font-style="italic"/>
+          <text variable="collection-title" text-case="title" font-style="italic"/>
+        </group>
+      </if>
+      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <group delimiter=", ">
+          <text variable="container-title"/>
+          <text variable="collection-title"/>
+        </group>
+      </else-if>
+      <else-if type="webpage post post-weblog" match="any">
+        <text variable="container-title" form="long" font-style="italic"/>
+      </else-if>
+      <else-if type="thesis" match="any">
+        <group delimiter=" ">
+          <text variable="genre"/>
+          <text variable="container-title" form="long" font-style="italic"/>
+        </group>
+      </else-if>
+      <else>
+        <group delimiter=", ">
+          <text variable="container-title" font-style="italic"/>
+          <text variable="collection-title"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name name-as-sort-order="all" sort-separator=", " initialize-with="." and="text" delimiter=", " delimiter-precedes-last="contextual"/>
+      <label plural="never" text-case="capitalize-first" prefix=" (" suffix=")"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="text" delimiter=", " initialize-with=". "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+            <text variable="title" form="short" font-style="italic"/>
+          </if>
+          <else-if type="webpage post post-weblog" match="any">
+            <text variable="title" form="long" quotes="false"/>
+          </else-if>
+          <else>
+            <text variable="title" form="long" quotes="true"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if type="webpage post post-weblog">
+        <group delimiter=" ">
+          <text variable="URL" prefix="URL: "/>
+          <group prefix=" (" suffix=").">
+            <text term="accessed" suffix=" "/>
+            <date variable="accessed">
+              <date-part name="day" suffix="/"/>
+              <date-part name="month" form="numeric" suffix="/"/>
+              <date-part name="year" form="long"/>
+            </date>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="thesis paper-conference chapter" match="any">
+        <text variable="title" quotes="true"/>
+      </if>
+      <else-if type="bill book graphic legal_case legislation motion_picture song speech" match="any">
+        <group delimiter=", ">
+          <text variable="title" text-case="title" font-style="italic"/>
+          <text macro="edition"/>
+        </group>
+      </else-if>
+      <else-if type="webpage">
+        <group delimiter=" ">
+          <text variable="title"/>
+          <text term="internet" font-style="italic" prefix="[" suffix="]"/>
+        </group>
+      </else-if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="report" match="any">
+        <group delimiter=", ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=", ">
+          <text variable="publisher"/>
+          <text variable="publisher-place"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if variable="event">
+        <group delimiter=" ">
+          <text term="presented at" text-case="capitalize-first"/>
+          <text variable="event"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <label variable="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper" match="any">
+        <group>
+          <text variable="volume" font-weight="bold" suffix=":"/>
+          <text variable="page"/>
+        </group>
+      </if>
+      <else-if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
+        <group delimiter=", ">
+          <text macro="event"/>
+          <text macro="publisher"/>
+        </group>
+      </else-if>
+      <else-if type="chapter paper-conference" match="any">
+        <group delimiter=", ">
+          <text macro="event"/>
+          <text macro="publisher"/>
+          <group delimiter=" ">
+            <label variable="page" form="short"/>
+            <text variable="page"/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="patent">
+        <group delimiter=" ">
+          <text term="patent" font-style="italic" prefix="[" suffix="]"/>
+          <text variable="number"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year" cite-group-delimiter=", ">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued" sort="descending"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="author-short"/>
+        <text macro="issued"/>
+        <group delimiter=" ">
+          <label variable="locator" form="short"/>
+          <text variable="locator"/>
+        </group>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" et-al-min="7" et-al-use-first="6" entry-spacing="0" line-spacing="1">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued" sort="ascending"/>
+    </sort>
+    <layout suffix=".">
+      <text macro="author" suffix=" "/>
+      <group delimiter=", ">
+        <text macro="issued"/>
+        <text macro="title"/>
+        <text macro="container"/>
+        <text macro="locators"/>
+      </group>
+      <text macro="access" prefix=". "/>
+    </layout>
+  </bibliography>
+</style>

--- a/universitas-gadjah-mada-farmasi-dif.csl
+++ b/universitas-gadjah-mada-farmasi-dif.csl
@@ -36,11 +36,10 @@
     <choose>
       <if type="chapter paper-conference" match="any">
         <group delimiter=", ">
-          <group delimiter=": ">
+          <group delimiter=" ">
             <text term="in"/>
             <names variable="editor translator" delimiter=", ">
               <name name-as-sort-order="all" sort-separator=", " initialize-with="." and="text" delimiter=", " delimiter-precedes-last="contextual"/>
-              <label plural="never" text-case="capitalize-first" prefix=" (" suffix=")"/>
             </names>
           </group>
           <text variable="container-title" text-case="title" font-style="italic"/>
@@ -73,7 +72,7 @@
   <macro name="author">
     <names variable="author">
       <name name-as-sort-order="all" sort-separator=", " initialize-with="." and="text" delimiter=", " delimiter-precedes-last="contextual"/>
-      <label plural="never" text-case="capitalize-first" prefix=" (" suffix=")"/>
+      <label form="short" plural="contextual" prefix=" (" suffix=")"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -123,7 +122,7 @@
       <if type="thesis paper-conference chapter" match="any">
         <text variable="title" quotes="true"/>
       </if>
-      <else-if type="bill book graphic legal_case legislation motion_picture song speech" match="any">
+      <else-if type="bill book graphic legal_case legislation motion_picture report song speech" match="any">
         <group delimiter=", ">
           <text variable="title" text-case="title" font-style="italic"/>
           <text macro="edition"/>
@@ -245,7 +244,14 @@
       <key macro="issued" sort="ascending"/>
     </sort>
     <layout suffix=".">
-      <text macro="author" suffix=" "/>
+      <choose>
+        <if type="report" match="any">
+          <text macro="author" suffix=". "/>
+        </if>
+        <else>
+          <text macro="author" suffix=" "/>
+        </else>
+      </choose>
       <group delimiter=", ">
         <text macro="issued"/>
         <text macro="title"/>

--- a/universitas-gadjah-mada-farmasi-dif.csl
+++ b/universitas-gadjah-mada-farmasi-dif.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="id">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="id-ID">
   <info>
     <title>Universitas Gadjah Mada - Farmasi DIF (Bahasa Indonesia)</title>
     <title-short>UGM Farmasi DIF</title-short>
@@ -17,7 +17,7 @@
     <updated>2026-08-04T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <locale xml:lang="id">
+  <locale xml:lang="id-ID">
     <terms>
       <term name="page" form="short">
         <single>hal.</single>


### PR DESCRIPTION
## Style baru: Universitas Gadjah Mada - Farmasi DIF (Bahasa Indonesia)

Style sitasi author-date untuk Program Doktor Ilmu Farmasi (DIF), 
Fakultas Farmasi, Universitas Gadjah Mada, berdasarkan panduan resmi 
akademik program studi:
https://programdoktor.farmasi.ugm.ac.id/academic-guideline/

### Konvensi khusus Bahasa Indonesia yang diterapkan:
- Istilah "et al." diset ke "dkk." dan konjungsi "and" ke "dan", 
  sesuai konvensi akademik Indonesia
- Bibliografi: 3-6 penulis dicantumkan lengkap, 7+ penulis dipotong 
  6 nama pertama + "dkk." — sesuai panduan resmi program

### Relasi dengan style existing
Ada style lain untuk institusi yang sama ("Universitas Gadjah Mada - 
Doctoral Program in Pharmaceutical Sciences") yang sudah published 
sebelumnya. Style ini dibuat terpisah dengan penyesuaian format 
(pemisah tanda baca, urutan nama-tahun-judul) agar lebih presisi 
mengikuti contoh konkret di panduan resmi program.