### PR TITLE
Use merge ref for pull_request_target checkout

### DIFF
--- a/.github/workflows/sheldon.yaml
+++ b/.github/workflows/sheldon.yaml
@@ -62,9 +62,9 @@ jobs:
       uses: actions/checkout@v6
       if: env.OWNER_TEST != 'true'
       with:
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        repository: ${{ github.repository }}
         path: pull-request
-        ref: ${{ github.event.pull_request.head.sha }}
+        ref: refs/pull/${{ github.event.pull_request.number }}/merge
         token: ${{ secrets.GITHUB_TOKEN }}
         # the PR is checked out into a subdirectory and only ever read as data
         # (spec/spec_helper.rb points STYLE_ROOT at it); the code that runs -- Gemfile,


### PR DESCRIPTION
### Summary

`actions/checkout@v6` refuses to check out the head of a fork from a `pull_request_target` workflow.

As a result, the workflow currently fails before the validation steps (`rake` and `sheldon`) are executed for pull requests opened from forks.

This updates the checkout step to use GitHub's pull request merge ref instead:

```
refs/pull/<PR-number>/merge
```

which is provided by the base repository and is permitted in `pull_request_target` workflows.