### PR TITLE
Create dependent/jurnal-pharmascience.csl

### DIFF
--- a/dependent/jurnal-pharmascience.csl
+++ b/dependent/jurnal-pharmascience.csl
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="en-US">
+  <info>
+    <title>Jurnal Pharmascience</title>
+    <title-short>JPS</title-short>
+    <id>http://www.zotero.org/styles/jurnal-pharmascience</id>
+    <link href="http://www.zotero.org/styles/jurnal-pharmascience" rel="self"/>
+    <link href="http://www.zotero.org/styles/apa" rel="independent-parent"/>
+    <link href="https://pharmascience.ulm.ac.id/index.php/pharmascience/about/submissions" rel="documentation"/>
+    <author>
+      <name>Arifin Santoso</name>
+      <email>arifinsantoso.apt@gmail.com</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="science"/>
+    <category field="medicine"/>
+    <category field="chemistry"/>
+    <issn>2355-5386</issn>
+    <eissn>2460-9560</eissn>
+    <updated>2026-08-11T00:00:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+</style>


### PR DESCRIPTION
## New dependent style: Jurnal Pharmascience

Jurnal Pharmascience (p-ISSN 2355-5386, e-ISSN 2460-9560, SINTA 2 accredited)
explicitly requires "American Psychological Association (APA) Edition 7" in
its author template, so this is a dependent style pointing to the existing
`apa` (APA Style 7th edition) independent style.

Author guidelines: https://pharmascience.ulm.ac.id/index.php/pharmascience/about/submissions
