### PR TITLE
Schweizerische Zeitschrift für Geschichte: formatting fixes and bibliography

### DIFF
--- a/schweizerische-zeitschrift-fur-geschichte.csl
+++ b/schweizerische-zeitschrift-fur-geschichte.csl
@@ -17,11 +17,15 @@
       <email>moritz.maehr@gmail.com</email>
       <uri>https://moritzmaehr.ch/</uri>
     </contributor>
+    <contributor>
+      <name>Lucas Federer</name>
+      <email>lucas.federer@uzh.ch</email>
+    </contributor>
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
     <issn>0036-7834</issn>
-    <updated>2026-02-26T00:00:00+00:00</updated>
+    <updated>2026-08-12T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
@@ -218,7 +222,7 @@
   </macro>
   <macro name="alt-publisher">
     <choose>
-      <if type="book chapter paper-conference entry-dictionary entry-encyclopedia" match="none">
+      <if type="book chapter paper-conference entry-dictionary entry-encyclopedia article-journal" match="none">
         <text variable="publisher"/>
       </if>
     </choose>
@@ -252,7 +256,21 @@
               </else>
             </choose>
           </if>
-          <else-if type="article-newspaper article-magazine graphic entry-encyclopedia entry-dictionary report speech interview manuscript personal_communication" match="any">
+          <else-if type="article-newspaper broadcast motion_picture" match="any">
+            <choose>
+              <if variable="issued">
+                <date variable="issued">
+                  <date-part name="day" suffix="."/>
+                  <date-part name="month" form="numeric" suffix="."/>
+                  <date-part name="year"/>
+                </date>
+              </if>
+              <else>
+                <text term="no date" form="short"/>
+              </else>
+            </choose>
+          </else-if>
+          <else-if type="article-magazine graphic entry-encyclopedia entry-dictionary report speech interview manuscript personal_communication" match="any">
             <choose>
               <if variable="issued">
                 <date variable="issued" prefix="(" suffix=")">
@@ -266,8 +284,8 @@
           </else-if>
           <else-if type="webpage post-weblog" match="any">
             <date variable="issued">
-              <date-part name="day" suffix=".&#160;"/>
-              <date-part name="month" form="numeric" suffix=".&#160;"/>
+              <date-part name="day" suffix="."/>
+              <date-part name="month" form="numeric" suffix="."/>
               <date-part name="year"/>
             </date>
           </else-if>
@@ -336,7 +354,7 @@
   </macro>
   <macro name="url-web-documents-only">
     <choose>
-      <if type="webpage post post-weblog entry-encyclopedia" match="any">
+      <if type="webpage post post-weblog entry-encyclopedia article-newspaper broadcast motion_picture" match="any">
         <text macro="url"/>
       </if>
     </choose>
@@ -345,14 +363,14 @@
     <group delimiter=" ">
       <text variable="URL"/>
       <date variable="accessed" prefix="(" suffix=")">
-        <date-part name="day" suffix=".&#160;"/>
-        <date-part name="month" form="numeric" suffix=".&#160;"/>
+        <date-part name="day" suffix="."/>
+        <date-part name="month" form="numeric" suffix="."/>
         <date-part name="year"/>
       </date>
     </group>
   </macro>
   <macro name="edition">
-    <number vertical-align="sup" variable="edition" form="ordinal"/>
+    <number vertical-align="sup" variable="edition"/>
   </macro>
   <macro name="book-editor">
     <choose>
@@ -362,6 +380,38 @@
           <name/>
         </names>
       </if>
+    </choose>
+  </macro>
+  <macro name="full-reference">
+    <choose>
+      <if type="article" match="any">
+        <text macro="archive-location"/>
+      </if>
+      <else>
+        <group delimiter=", ">
+          <text macro="creator"/>
+          <text macro="title"/>
+          <group delimiter=" ">
+            <group delimiter=": ">
+              <text macro="in"/>
+              <text macro="container-information"/>
+            </group>
+            <text macro="journal-volume"/>
+          </group>
+          <text macro="type-description"/>
+          <text macro="alt-publisher"/>
+          <text macro="book-editor"/>
+          <group delimiter=" ">
+            <text macro="place"/>
+            <text macro="date"/>
+            <date variable="original-date" form="text" prefix="[" suffix="]"/>
+            <text macro="book-series"/>
+          </group>
+          <text macro="artwork-description"/>
+          <text macro="pages"/>
+          <text macro="url-web-documents-only"/>
+        </group>
+      </else>
     </choose>
   </macro>
   <citation et-al-min="4" et-al-use-first="1">
@@ -380,38 +430,19 @@
           <text macro="subsequent-reference"/>
         </else-if>
         <else>
-          <choose>
-            <if type="article" match="any">
-              <text macro="archive-location"/>
-            </if>
-            <else>
-              <group delimiter=", ">
-                <text macro="creator"/>
-                <text macro="title"/>
-                <group delimiter=" ">
-                  <group delimiter=": ">
-                    <text macro="in"/>
-                    <text macro="container-information"/>
-                  </group>
-                  <text macro="journal-volume"/>
-                </group>
-                <text macro="type-description"/>
-                <text macro="alt-publisher"/>
-                <text macro="book-editor"/>
-                <group delimiter=" ">
-                  <text macro="place"/>
-                  <text macro="date"/>
-                  <date variable="original-date" form="text" prefix="[" suffix="]"/>
-                  <text macro="book-series"/>
-                </group>
-                <text macro="artwork-description"/>
-                <text macro="pages"/>
-                <text macro="url-web-documents-only"/>
-              </group>
-            </else>
-          </choose>
+          <text macro="full-reference"/>
         </else>
       </choose>
     </layout>
   </citation>
+  <bibliography et-al-min="4" et-al-use-first="1">
+    <sort>
+      <key macro="creator"/>
+      <key variable="title"/>
+      <key variable="issued"/>
+    </sort>
+    <layout suffix=".">
+      <text macro="full-reference"/>
+    </layout>
+  </bibliography>
 </style>


### PR DESCRIPTION
### Description

Update of the existing `schweizerische-zeitschrift-fur-geschichte.csl`. The changes were written by **Lucas Federer** (Universität Zürich), who has been using the style for editorial work at the *Schweizerische Zeitschrift für Geschichte*; he is added as a `<contributor>`. Each change follows the journal's author guidelines ([szg-itinera_autorenrichtlinien_de_2024_0.pdf](https://www.sgg-ssh.ch/sites/default/files/szg-itinera_autorenrichtlinien_de_2024_0.pdf), the style's `documentation` link):

1. **No publisher for journal articles.** The guidelines give the pattern "Vorname Nachname, Haupttitel. Untertitel, in: Zeitschriftentitel Bd./Heftnr. (Erscheinungsjahr), S. Seitenzahlen" — no publisher. `article-journal` is now excluded in the `alt-publisher` macro.
   `… Schweizerische Zeitschrift für Geschichte 59/1 (2009), Schwabe Verlag, S. 101–118` → `… 59/1 (2009), S. 101–118`
2. **Superscript edition without ordinal suffix.** "Neuauflagen werden mit einer hochgestellten Ziffer **ohne Leerschlag** vor dem Erscheinungsjahr gekennzeichnet", example `London 31986`. Dropping `form="ordinal"` from the `edition` macro yields exactly that.
   `London ³·1986` (superscript "3.") → `London ³1986`
3. **Full date for newspaper articles, broadcasts and motion pictures** instead of the year alone; the guidelines' footnote example is "… in: Neue Zürcher Zeitung, 4.7.2013."
   `… in: Neue Zürcher Zeitung, (2013)` → `… in: Neue Zürcher Zeitung, 4.7.2013`
4. **URL for newspaper articles, broadcasts and motion pictures** when the item has one, in line with "Bei Verweisen auf Internetadressen immer Datum des letzten Besuchs angeben".
5. **No non-breaking spaces in numeric dates.** The guidelines write dates without spaces: `www.sgg-ssh.ch/ (30.4.2021)`.
   `(20. 7. 2026)` → `(20.7.2026)`
6. **Bibliography added.** The style previously had no `<bibliography>`. It reuses the first-citation reference format via a new `full-reference` macro (the citation output is unchanged — the macro is just the former `<else>` branch of the citation layout), sorted by author, title, year.

Verified with pandoc/citeproc against test items covering all affected types, and validated against the CSL 1.0.2 schema (jing/RELAX NG).

### Checklist
- [x] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.
- [x] Check that you've added a link to the style guidelines with `rel="documentation"`.
- [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update.
- [x] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [x] Check that you've not used `<text value="...` if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.
