### PR TITLE
Create academic-conferences-international-harvard.csl

### DIFF
--- a/academic-conferences-international-harvard.csl
+++ b/academic-conferences-international-harvard.csl
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
   <info>
-    <title>Harvard - ACPI (Academic Conferences International / ECGBL, ECRM et al.)</title>
+    <title>Academic Conferences International - Harvard (ECGBL, ECRM et al.)</title>
     <title-short>ACPI Harvard</title-short>
-    <id>http://www.zotero.org/styles/harvard-acpi</id>
-    <link href="http://www.zotero.org/styles/harvard-acpi" rel="self"/>
+    <id>http://www.zotero.org/styles/academic-conferences-international-harvard</id>
+    <link href="http://www.zotero.org/styles/academic-conferences-international-harvard" rel="self"/>
     <link href="http://www.zotero.org/styles/harvard-cite-them-right" rel="template"/>
     <link href="https://www.academic-conferences.org/conferences/ecgbl/ecgbl-submission-information/" rel="documentation"/>
     <author>
       <name>Sebastian Bernal-Garcia</name>
     </author>
     <category citation-format="author-date"/>
-    <category field="generic-base"/>
     <summary>Harvard-style referencing as specified in the Academic Conferences International (ACPI) model paper used for ECGBL, ECRM and related conferences. Author (Year) in-text citation, up to three authors then "et al", no square brackets, "Publisher, Place" order (no colon) for books, and "Vol X, No. Y, pp X-Y" for journal articles.</summary>
     <updated>2026-08-13T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+
   <locale xml:lang="en-GB">
     <terms>
       <term name="editor" form="short">
@@ -28,13 +28,15 @@
         <multiple>pp</multiple>
       </term>
       <term name="et-al">et al</term>
-      <term name="open-quote">“</term>
-      <term name="close-quote">”</term>
-      <term name="open-inner-quote">‘</term>
-      <term name="close-inner-quote">’</term>
+      <term name="open-quote">&#8220;</term>
+      <term name="close-quote">&#8221;</term>
+      <term name="open-inner-quote">&#8216;</term>
+      <term name="close-inner-quote">&#8217;</term>
     </terms>
   </locale>
+
   <!-- ===================== MACROS ===================== -->
+
   <macro name="author">
     <names variable="author">
       <name and="text" delimiter-precedes-last="never" initialize-with=". " name-as-sort-order="all" sort-separator=", "/>
@@ -47,6 +49,7 @@
       </substitute>
     </names>
   </macro>
+
   <!-- In-text: up to three authors spelled out, otherwise lead author + "et al" -->
   <macro name="author-short">
     <names variable="author">
@@ -59,6 +62,7 @@
       </substitute>
     </names>
   </macro>
+
   <macro name="year-date">
     <choose>
       <if variable="issued">
@@ -73,6 +77,7 @@
       </else>
     </choose>
   </macro>
+
   <!-- Book / report / thesis / webpage titles: italic. Journal / newspaper / magazine / conference-paper titles: quoted, roman -->
   <macro name="title">
     <choose>
@@ -87,6 +92,7 @@
       </else>
     </choose>
   </macro>
+
   <macro name="container-title">
     <choose>
       <if variable="container-title">
@@ -94,6 +100,7 @@
       </if>
     </choose>
   </macro>
+
   <macro name="edition">
     <choose>
       <if is-numeric="edition">
@@ -107,6 +114,7 @@
       </else>
     </choose>
   </macro>
+
   <!-- Books, reports, theses: "Publisher, Place" - comma-separated, no colon -->
   <macro name="publisher">
     <choose>
@@ -126,6 +134,7 @@
       </else-if>
     </choose>
   </macro>
+
   <!-- Journal articles: Vol X, No. Y, pp start-end (spelled out, not abbreviated volume(issue)) -->
   <macro name="locator">
     <choose>
@@ -143,6 +152,7 @@
       </if>
     </choose>
   </macro>
+
   <macro name="pages">
     <choose>
       <if type="chapter paper-conference article-journal article article-magazine article-newspaper review review-book" match="any">
@@ -153,6 +163,7 @@
       </if>
     </choose>
   </macro>
+
   <!-- Conference papers: "Paper read at Conference Name, Location, Month Year" -->
   <macro name="conference">
     <choose>
@@ -170,6 +181,7 @@
       </if>
     </choose>
   </macro>
+
   <!-- Online-only items: [online]/[medium], source, then URL -->
   <macro name="access">
     <choose>
@@ -189,7 +201,9 @@
       </if>
     </choose>
   </macro>
+
   <!-- ===================== IN-TEXT CITATION ===================== -->
+
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" collapse="year">
     <sort>
       <key macro="year-date"/>
@@ -201,7 +215,9 @@
       </group>
     </layout>
   </citation>
+
   <!-- ===================== BIBLIOGRAPHY ===================== -->
+
   <bibliography et-al-min="99" et-al-use-first="1">
     <sort>
       <key macro="author"/>

--- a/academic-conferences-international-harvard.csl
+++ b/academic-conferences-international-harvard.csl
@@ -15,7 +15,6 @@
     <updated>2026-08-13T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-
   <locale xml:lang="en-GB">
     <terms>
       <term name="editor" form="short">
@@ -28,15 +27,13 @@
         <multiple>pp</multiple>
       </term>
       <term name="et-al">et al</term>
-      <term name="open-quote">&#8220;</term>
-      <term name="close-quote">&#8221;</term>
-      <term name="open-inner-quote">&#8216;</term>
-      <term name="close-inner-quote">&#8217;</term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
     </terms>
   </locale>
-
   <!-- ===================== MACROS ===================== -->
-
   <macro name="author">
     <names variable="author">
       <name and="text" delimiter-precedes-last="never" initialize-with=". " name-as-sort-order="all" sort-separator=", "/>
@@ -49,7 +46,6 @@
       </substitute>
     </names>
   </macro>
-
   <!-- In-text: up to three authors spelled out, otherwise lead author + "et al" -->
   <macro name="author-short">
     <names variable="author">
@@ -62,7 +58,6 @@
       </substitute>
     </names>
   </macro>
-
   <macro name="year-date">
     <choose>
       <if variable="issued">
@@ -77,7 +72,6 @@
       </else>
     </choose>
   </macro>
-
   <!-- Book / report / thesis / webpage titles: italic. Journal / newspaper / magazine / conference-paper titles: quoted, roman -->
   <macro name="title">
     <choose>
@@ -92,7 +86,6 @@
       </else>
     </choose>
   </macro>
-
   <macro name="container-title">
     <choose>
       <if variable="container-title">
@@ -100,7 +93,6 @@
       </if>
     </choose>
   </macro>
-
   <macro name="edition">
     <choose>
       <if is-numeric="edition">
@@ -114,7 +106,6 @@
       </else>
     </choose>
   </macro>
-
   <!-- Books, reports, theses: "Publisher, Place" - comma-separated, no colon -->
   <macro name="publisher">
     <choose>
@@ -134,7 +125,6 @@
       </else-if>
     </choose>
   </macro>
-
   <!-- Journal articles: Vol X, No. Y, pp start-end (spelled out, not abbreviated volume(issue)) -->
   <macro name="locator">
     <choose>
@@ -152,7 +142,6 @@
       </if>
     </choose>
   </macro>
-
   <macro name="pages">
     <choose>
       <if type="chapter paper-conference article-journal article article-magazine article-newspaper review review-book" match="any">
@@ -163,7 +152,6 @@
       </if>
     </choose>
   </macro>
-
   <!-- Conference papers: "Paper read at Conference Name, Location, Month Year" -->
   <macro name="conference">
     <choose>
@@ -181,7 +169,6 @@
       </if>
     </choose>
   </macro>
-
   <!-- Online-only items: [online]/[medium], source, then URL -->
   <macro name="access">
     <choose>
@@ -201,9 +188,7 @@
       </if>
     </choose>
   </macro>
-
   <!-- ===================== IN-TEXT CITATION ===================== -->
-
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" collapse="year">
     <sort>
       <key macro="year-date"/>
@@ -215,9 +200,7 @@
       </group>
     </layout>
   </citation>
-
   <!-- ===================== BIBLIOGRAPHY ===================== -->
-
   <bibliography et-al-min="99" et-al-use-first="1">
     <sort>
       <key macro="author"/>

--- a/harvard-acpi.csl
+++ b/harvard-acpi.csl
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
+  <info>
+    <title>Harvard - ACPI (Academic Conferences International / ECGBL, ECRM et al.)</title>
+    <title-short>ACPI Harvard</title-short>
+    <id>http://www.zotero.org/styles/harvard-acpi</id>
+    <link href="http://www.zotero.org/styles/harvard-acpi" rel="self"/>
+    <link href="http://www.zotero.org/styles/harvard-cite-them-right" rel="template"/>
+    <link href="https://www.academic-conferences.org/conferences/ecgbl/ecgbl-submission-information/" rel="documentation"/>
+    <author>
+      <name>Sebastian Bernal-Garcia</name>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="generic-base"/>
+    <summary>Harvard-style referencing as specified in the Academic Conferences International (ACPI) model paper used for ECGBL, ECRM and related conferences. Author (Year) in-text citation, up to three authors then "et al", no square brackets, "Publisher, Place" order (no colon) for books, and "Vol X, No. Y, pp X-Y" for journal articles.</summary>
+    <updated>2026-08-13T00:00:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+
+  <locale xml:lang="en-GB">
+    <terms>
+      <term name="editor" form="short">
+        <single>ed.</single>
+        <multiple>eds</multiple>
+      </term>
+      <term name="edition" form="short">edn.</term>
+      <term name="page" form="short">
+        <single>p</single>
+        <multiple>pp</multiple>
+      </term>
+      <term name="et-al">et al</term>
+      <term name="open-quote">&#8220;</term>
+      <term name="close-quote">&#8221;</term>
+      <term name="open-inner-quote">&#8216;</term>
+      <term name="close-inner-quote">&#8217;</term>
+    </terms>
+  </locale>
+
+  <!-- ===================== MACROS ===================== -->
+
+  <macro name="author">
+    <names variable="author">
+      <name and="text" delimiter-precedes-last="never" initialize-with=". " name-as-sort-order="all" sort-separator=", "/>
+      <label form="short" prefix=" (" suffix=")"/>
+      <et-al font-style="normal"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="title"/>
+      </substitute>
+    </names>
+  </macro>
+
+  <!-- In-text: up to three authors spelled out, otherwise lead author + "et al" -->
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="text" delimiter=", " delimiter-precedes-last="never" et-al-min="4" et-al-use-first="1"/>
+      <et-al font-style="normal"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="title"/>
+      </substitute>
+    </names>
+  </macro>
+
+  <macro name="year-date">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+        <text variable="year-suffix"/>
+      </if>
+      <else>
+        <text term="no date"/>
+        <text variable="year-suffix" prefix=" "/>
+      </else>
+    </choose>
+  </macro>
+
+  <!-- Book / report / thesis / webpage titles: italic. Journal / newspaper / magazine / conference-paper titles: quoted, roman -->
+  <macro name="title">
+    <choose>
+      <if type="book report thesis motion_picture graphic legal_case legislation" match="any">
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else-if type="chapter" match="any">
+        <text variable="title" quotes="true"/>
+      </else-if>
+      <else>
+        <text variable="title" quotes="true"/>
+      </else>
+    </choose>
+  </macro>
+
+  <macro name="container-title">
+    <choose>
+      <if variable="container-title">
+        <text variable="container-title" font-style="italic"/>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short" strip-periods="true"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+
+  <!-- Books, reports, theses: "Publisher, Place" - comma-separated, no colon -->
+  <macro name="publisher">
+    <choose>
+      <if type="thesis">
+        <group delimiter=", ">
+          <text variable="genre"/>
+          <text variable="publisher"/>
+          <text variable="publisher-place"/>
+        </group>
+      </if>
+      <else-if type="paper-conference speech" match="any"/>
+      <else-if type="webpage post-weblog article article-newspaper article-magazine" match="none">
+        <group delimiter=", ">
+          <text variable="publisher"/>
+          <text variable="publisher-place"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+
+  <!-- Journal articles: Vol X, No. Y, pp start-end (spelled out, not abbreviated volume(issue)) -->
+  <macro name="locator">
+    <choose>
+      <if type="article-journal">
+        <group delimiter=", ">
+          <group delimiter=" ">
+            <text value="Vol"/>
+            <text variable="volume"/>
+          </group>
+          <group delimiter=" ">
+            <text value="No."/>
+            <text variable="issue"/>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="pages">
+    <choose>
+      <if type="chapter paper-conference article-journal article article-magazine article-newspaper review review-book" match="any">
+        <group delimiter=" ">
+          <label variable="page" form="short" strip-periods="true"/>
+          <text variable="page"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+
+  <!-- Conference papers: "Paper read at Conference Name, Location, Month Year" -->
+  <macro name="conference">
+    <choose>
+      <if type="paper-conference speech" match="any">
+        <group delimiter=", ">
+          <group delimiter=" ">
+            <text term="presented at" text-case="capitalize-first"/>
+            <text variable="event-title" font-style="italic"/>
+          </group>
+          <text variable="event-place"/>
+          <date variable="issued" form="text">
+            <date-part name="month"/>
+          </date>
+        </group>
+      </if>
+    </choose>
+  </macro>
+
+  <!-- Online-only items: [online], source, then URL -->
+  <macro name="access">
+    <choose>
+      <if variable="URL">
+        <group delimiter=", ">
+          <text value="[online]"/>
+          <text variable="publisher"/>
+          <text variable="URL"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+
+  <!-- ===================== IN-TEXT CITATION ===================== -->
+
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" collapse="year">
+    <sort>
+      <key macro="year-date"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="author-short"/>
+        <text macro="year-date"/>
+      </group>
+    </layout>
+  </citation>
+
+  <!-- ===================== BIBLIOGRAPHY ===================== -->
+
+  <bibliography et-al-min="99" et-al-use-first="1">
+    <sort>
+      <key macro="author"/>
+      <key macro="year-date"/>
+      <key variable="title"/>
+    </sort>
+    <layout suffix=".">
+      <group delimiter=" ">
+        <text macro="author"/>
+        <text macro="year-date" prefix="(" suffix=")"/>
+        <group delimiter=", ">
+          <text macro="title"/>
+          <text macro="container-title"/>
+          <text macro="edition"/>
+          <text macro="conference"/>
+          <text macro="publisher"/>
+          <text macro="locator"/>
+          <text macro="pages"/>
+          <text macro="access"/>
+        </group>
+      </group>
+    </layout>
+  </bibliography>
+</style>

--- a/harvard-acpi.csl
+++ b/harvard-acpi.csl
@@ -142,11 +142,11 @@
       <if type="article-journal">
         <group delimiter=", ">
           <group delimiter=" ">
-            <text value="Vol"/>
+            <text term="volume" form="short" text-case="capitalize-first" strip-periods="true"/>
             <text variable="volume"/>
           </group>
           <group delimiter=" ">
-            <text value="No."/>
+            <text term="issue" form="short" text-case="capitalize-first"/>
             <text variable="issue"/>
           </group>
         </group>
@@ -183,12 +183,19 @@
     </choose>
   </macro>
 
-  <!-- Online-only items: [online], source, then URL -->
+  <!-- Online-only items: [online]/[medium], source, then URL -->
   <macro name="access">
     <choose>
       <if variable="URL">
         <group delimiter=", ">
-          <text value="[online]"/>
+          <choose>
+            <if variable="medium">
+              <text variable="medium" prefix="[" suffix="]"/>
+            </if>
+            <else>
+              <text term="online" prefix="[" suffix="]"/>
+            </else>
+          </choose>
           <text variable="publisher"/>
           <text variable="URL"/>
         </group>

--- a/harvard-acpi.csl
+++ b/harvard-acpi.csl
@@ -16,7 +16,6 @@
     <updated>2026-08-13T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-
   <locale xml:lang="en-GB">
     <terms>
       <term name="editor" form="short">
@@ -29,15 +28,13 @@
         <multiple>pp</multiple>
       </term>
       <term name="et-al">et al</term>
-      <term name="open-quote">&#8220;</term>
-      <term name="close-quote">&#8221;</term>
-      <term name="open-inner-quote">&#8216;</term>
-      <term name="close-inner-quote">&#8217;</term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
     </terms>
   </locale>
-
   <!-- ===================== MACROS ===================== -->
-
   <macro name="author">
     <names variable="author">
       <name and="text" delimiter-precedes-last="never" initialize-with=". " name-as-sort-order="all" sort-separator=", "/>
@@ -50,7 +47,6 @@
       </substitute>
     </names>
   </macro>
-
   <!-- In-text: up to three authors spelled out, otherwise lead author + "et al" -->
   <macro name="author-short">
     <names variable="author">
@@ -63,7 +59,6 @@
       </substitute>
     </names>
   </macro>
-
   <macro name="year-date">
     <choose>
       <if variable="issued">
@@ -78,7 +73,6 @@
       </else>
     </choose>
   </macro>
-
   <!-- Book / report / thesis / webpage titles: italic. Journal / newspaper / magazine / conference-paper titles: quoted, roman -->
   <macro name="title">
     <choose>
@@ -93,7 +87,6 @@
       </else>
     </choose>
   </macro>
-
   <macro name="container-title">
     <choose>
       <if variable="container-title">
@@ -101,7 +94,6 @@
       </if>
     </choose>
   </macro>
-
   <macro name="edition">
     <choose>
       <if is-numeric="edition">
@@ -115,7 +107,6 @@
       </else>
     </choose>
   </macro>
-
   <!-- Books, reports, theses: "Publisher, Place" - comma-separated, no colon -->
   <macro name="publisher">
     <choose>
@@ -135,7 +126,6 @@
       </else-if>
     </choose>
   </macro>
-
   <!-- Journal articles: Vol X, No. Y, pp start-end (spelled out, not abbreviated volume(issue)) -->
   <macro name="locator">
     <choose>
@@ -153,7 +143,6 @@
       </if>
     </choose>
   </macro>
-
   <macro name="pages">
     <choose>
       <if type="chapter paper-conference article-journal article article-magazine article-newspaper review review-book" match="any">
@@ -164,7 +153,6 @@
       </if>
     </choose>
   </macro>
-
   <!-- Conference papers: "Paper read at Conference Name, Location, Month Year" -->
   <macro name="conference">
     <choose>
@@ -182,7 +170,6 @@
       </if>
     </choose>
   </macro>
-
   <!-- Online-only items: [online]/[medium], source, then URL -->
   <macro name="access">
     <choose>
@@ -202,9 +189,7 @@
       </if>
     </choose>
   </macro>
-
   <!-- ===================== IN-TEXT CITATION ===================== -->
-
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" collapse="year">
     <sort>
       <key macro="year-date"/>
@@ -216,9 +201,7 @@
       </group>
     </layout>
   </citation>
-
   <!-- ===================== BIBLIOGRAPHY ===================== -->
-
   <bibliography et-al-min="99" et-al-use-first="1">
     <sort>
       <key macro="author"/>


### PR DESCRIPTION
### Description
Adds a Harvard-style CSL matching the referencing guidelines specified by
Academic Conferences International (ACPI) for ECGBL, ECRM, ECIS and related
conferences and journals. Key differences from existing Harvard styles in
the repo: "Publisher, Place" order (no colon) for books, "Vol X, No. Y, pp
X-Y" for journal articles, and "et al" (no trailing period) with a comma
before the year in in-text citations, e.g. (Nugus et al, 2003).

Source guidelines: https://www.academic-conferences.org/conferences/ecgbl/ecgbl-submission-information/

Validated against the CSL 1.0.2 schema and tested with citeproc-js against
the source paper's own worked examples (books, journal articles, and an
online source) — output matches exactly.

### Checklist
- [x] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.
- [x] Check that you've added a link to the style guidelines with `rel="documentation"`.
- [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update.
- [x] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [x] Check that you've not used `<text value="...` if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.
