### PR TITLE
Add BIONORTE author-date style

### DIFF
--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -20,8 +20,10 @@
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
 
-  <macro name="authorinitials">
-    <text variable="title"/>
+  <macro name="author-initials">
+    <names variable="author" delimiter="; ">
+      <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; "/>
+    </names>
   </macro>
   
     <macro name="author-full">
@@ -131,7 +133,7 @@
   
     <bibliography hanging-indent="true" entry-spacing="1">
       <sort>
-        <key macro="authorinitials"/>
+        <key macro="author-initials"/>
         <key macro="issued-year"/>
         <key variable="title"/>
       </sort>
@@ -153,7 +155,7 @@
           </if>
   
           <else-if type="article-journal">
-            <text macro="authorinitials" suffix=". "/>
+            <text macro="author-initials" suffix=". "/>
             <text variable="title" suffix=". "/>
             <group delimiter=", ">
               <text variable="container-title" font-style="italic"/>
@@ -167,7 +169,7 @@
           </else-if>
   
           <else-if type="book">
-            <text macro="authorinitials" suffix=". "/>
+            <text macro="author-initials" suffix=". "/>
             <text variable="title" font-style="italic" suffix=". "/>
             <text macro="edition" suffix=". "/>
             <group delimiter=", ">
@@ -179,7 +181,7 @@
           </else-if>
   
           <else-if type="chapter">
-            <text macro="authorinitials" suffix=". "/>
+            <text macro="author-initials" suffix=". "/>
             <text variable="title" suffix=". "/>
             <text term="in" text-case="capitalize-first" suffix=": "/>
             <text macro="editor"/>
@@ -194,7 +196,7 @@
           </else-if>
   
           <else-if type="paper-conference">
-            <text macro="authorinitials" suffix=". "/>
+            <text macro="author-initials" suffix=". "/>
             <text variable="title" suffix=". "/>
             <text term="in" text-case="capitalize-first" suffix=": "/>
             <group delimiter=", ">
@@ -212,7 +214,7 @@
           </else-if>
   
           <else-if type="report webpage post-weblog" match="any">
-            <text macro="authorinitials" suffix=". "/>
+            <text macro="author-initials" suffix=". "/>
             <text variable="title" font-style="italic" suffix=". "/>
             <group delimiter=", ">
               <text macro="publisher-block"/>
@@ -222,7 +224,7 @@
           </else-if>
   
           <else>
-            <text macro="authorinitials" suffix=". "/>
+            <text macro="author-initials" suffix=". "/>
             <text variable="title" suffix=". "/>
             <group delimiter=", ">
               <text variable="container-title" font-style="italic"/>

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -4,7 +4,7 @@
     <title>Rede de Biodiversidade e Biotecnologia da Amazônia Legal (BIONORTE) - ABNT 2026</title>
     <id>http://www.zotero.org/styles/bionorte-abnt-2026</id>
     <link href="http://www.zotero.org/styles/bionorte-abnt-2026" rel="self"/>
-    <link href="http://www.zotero.org/styles/associacao-brasileira-de-normas-tecnicas" rel="template"/>
+    <!-- Based on http://www.zotero.org/styles/associacao-brasileira-de-normas-tecnicas -->
     <link href="https://bionorte.org.br/uploads/2025/p12/F334818251668.pdf" rel="documentation"/>
     <author>
       <name>José Carlos Ipuchima da Silva</name>
@@ -272,6 +272,9 @@
     </layout>
   </bibliography>
 </style>
+
+
+
 
 
 

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -4,7 +4,7 @@
     <title>Rede de Biodiversidade e Biotecnologia da Amazônia Legal (BIONORTE) - ABNT 2026 (Português - Brasil)</title>
     <id>http://www.zotero.org/styles/bionorte-abnt-2026</id>
     <link href="http://www.zotero.org/styles/bionorte-abnt-2026" rel="self"/>
-    <link href="http://www.zotero.org/styles/brazilian-journal-of-microbiology-2026" rel="template"/>
+    <link href="http://www.zotero.org/styles/associacao-brasileira-de-normas-tecnicas" rel="template"/>
     <link href="https://bionorte.org.br/uploads/2025/p12/F334818251668.pdf" rel="documentation"/>
     <author>
       <name>José Carlos Ipuchima da Silva</name>

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -1,9 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" default-locale="pt-BR">
   <info>
-    <title>Rede de Biodiversidade e Biotecnologia da Amazônia Legal (BIONORTE) - ABNT 2026</title>
+    <title>Rede de Biodiversidade e Biotecnologia da Amazônia Legal (BIONORTE) - ABNT 2026 (Português - Brasil)</title>
     <id>http://www.zotero.org/styles/bionorte-abnt-2026</id>
     <link href="http://www.zotero.org/styles/bionorte-abnt-2026" rel="self"/>
+    <link href="http://www.zotero.org/styles/associacao-brasileira-de-normas-tecnicas" rel="template"/>
     <link rel="documentation" href="https://bionorte.org.br/uploads/2025/p12/F334818251668.pdf"/>
     <author>
       <name>José Carlos Ipuchima da Silva</name>

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -4,7 +4,6 @@
     <title>Rede de Biodiversidade e Biotecnologia da Amazônia Legal (BIONORTE) - ABNT 2026 (Português - Brasil)</title>
     <id>http://www.zotero.org/styles/bionorte-abnt-2026</id>
     <link href="http://www.zotero.org/styles/bionorte-abnt-2026" rel="self"/>
-    <link href="http://www.zotero.org/styles/apa" rel="template"/>
     <link href="https://bionorte.org.br/uploads/2025/p12/F334818251668.pdf" rel="documentation"/>
     <author>
       <name>José Carlos Ipuchima da Silva</name>

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -4,7 +4,6 @@
     <title>Rede de Biodiversidade e Biotecnologia da Amazônia Legal (BIONORTE) - ABNT 2026</title>
     <id>http://www.zotero.org/styles/bionorte-abnt-2026</id>
     <link href="http://www.zotero.org/styles/bionorte-abnt-2026" rel="self"/>
-    <!-- Based on http://www.zotero.org/styles/associacao-brasileira-de-normas-tecnicas -->
     <link href="https://bionorte.org.br/uploads/2025/p12/F334818251668.pdf" rel="documentation"/>
     <author>
       <name>José Carlos Ipuchima da Silva</name>
@@ -16,7 +15,7 @@
     </contributor>
     <category citation-format="author-date"/>
     <category field="biology"/>
-    <summary>Estilo autor-data BIONORTE ABNT 2026 para Mendeley e Zotero.</summary>
+    <summary>Estilo autor-data BIONORTE ABNT 2026 para Mendeley e Zotero, baseado no estilo Associacao Brasileira de Normas Tecnicas.</summary>
     <updated>2026-08-13T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
@@ -272,6 +271,7 @@
     </layout>
   </bibliography>
 </style>
+
 
 
 

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -4,7 +4,7 @@
     <title>Rede de Biodiversidade e Biotecnologia da Amazônia Legal (BIONORTE) - ABNT 2026</title>
     <id>http://www.zotero.org/styles/bionorte-abnt-2026</id>
     <link href="http://www.zotero.org/styles/bionorte-abnt-2026" rel="self"/>
-    <link href="http://www.zotero.org/styles/associacao-brasileira-de-normas-tecnicas-ufmg-face-full" rel="template"/>
+    <link href="http://www.zotero.org/styles/associacao-brasileira-de-normas-tecnicas" rel="template"/>
     <link href="https://bionorte.org.br/uploads/2025/p12/F334818251668.pdf" rel="documentation"/>
     <author>
       <name>José Carlos Ipuchima da Silva</name>
@@ -272,5 +272,6 @@
     </layout>
   </bibliography>
 </style>
+
 
 

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -74,9 +74,9 @@
   </macro>
 
   <macro name="accessed-date">
-    <date variable="accessed">
-      <date-part name="day" form="numeric-leading-zeros" suffix="/"/>
-      <date-part name="month" form="numeric-leading-zeros" suffix="/"/>
+    <date variable="accessed" delimiter="/">
+      <date-part name="day" form="numeric-leading-zeros"/>
+      <date-part name="month" form="numeric-leading-zeros"/>
       <date-part name="year"/>
     </date>
   </macro>
@@ -272,6 +272,9 @@
     </layout>
   </bibliography>
 </style>
+
+
+
 
 
 

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -4,7 +4,6 @@
     <title>Rede de Biodiversidade e Biotecnologia da Amazônia Legal (BIONORTE) - ABNT 2026 (Português - Brasil)</title>
     <id>http://www.zotero.org/styles/bionorte-abnt-2026</id>
     <link href="http://www.zotero.org/styles/bionorte-abnt-2026" rel="self"/>
-    <link href="http://www.zotero.org/styles/associacao-brasileira-de-normas-tecnicas" rel="template"/>
     <link rel="documentation" href="https://bionorte.org.br/uploads/2025/p12/F334818251668.pdf"/>
     <author>
       <name>José Carlos Ipuchima da Silva</name>

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -13,10 +13,8 @@
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author-initials">
-      <names variable="author" delimiter="; ">
-        <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; "/>
-      </names>
-    </macro>
+    <text variable="title"/>
+  </macro>
   
     <macro name="author-full">
       <names variable="author" delimiter="; ">

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -4,7 +4,6 @@
     <title>Rede de Biodiversidade e Biotecnologia da Amazônia Legal (BIONORTE) - ABNT 2026 (Português - Brasil)</title>
     <id>http://www.zotero.org/styles/bionorte-abnt-2026</id>
     <link href="http://www.zotero.org/styles/bionorte-abnt-2026" rel="self"/>
-    <link href="https://bionorte.org.br/uploads/2025/p12/F334818251668.pdf" rel="documentation"/>
     <author>
       <name>José Carlos Ipuchima da Silva</name>
       <email>carlos.silva.jcids@gmail.com</email>

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -211,7 +211,7 @@
             <text macro="doi-url-access" prefix=". "/>
           </else-if>
   
-          <else-if type="report software webpage post-weblog" match="any">
+          <else-if type="report webpage post-weblog" match="any">
             <text macro="authorinitials" suffix=". "/>
             <text variable="title" font-style="italic" suffix=". "/>
             <group delimiter=", ">

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -2,6 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" default-locale="pt-BR">
   <info>
     <title>Rede de Biodiversidade e Biotecnologia da Amazônia Legal (BIONORTE) - ABNT 2026 (Português - Brasil)</title>
+    <title-short>BIONORTE</title-short>
     <id>http://www.zotero.org/styles/bionorte-abnt-2026</id>
     <link href="http://www.zotero.org/styles/bionorte-abnt-2026" rel="self"/>
     <link href="https://bionorte.org.br/uploads/2025/p12/F334818251668.pdf" rel="documentation"/>
@@ -9,13 +10,7 @@
       <name>José Carlos Ipuchima da Silva</name>
       <email>carlos.silva.jcids@gmail.com</email>
     </author>
-    <contributor>
-      <name>Hector Henrique Ferreira Koolen</name>
-      <email>hkoolen@uea.edu.br</email>
-    </contributor>
     <category citation-format="author-date"/>
-    <category field="biology"/>
-    <summary>Estilo autor-data BIONORTE ABNT 2026 para Mendeley e Zotero.</summary>
     <updated>2026-08-13T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -4,7 +4,7 @@
     <title>Rede de Biodiversidade e Biotecnologia da Amazônia Legal (BIONORTE) - ABNT 2026 (Português - Brasil)</title>
     <id>http://www.zotero.org/styles/bionorte-abnt-2026</id>
     <link href="http://www.zotero.org/styles/bionorte-abnt-2026" rel="self"/>
-    <link href="http://www.zotero.org/styles/associacao-brasileira-de-normas-tecnicas" rel="template"/>
+    <link href="http://www.zotero.org/styles/apa" rel="template"/>
     <link href="https://bionorte.org.br/uploads/2025/p12/F334818251668.pdf" rel="documentation"/>
     <author>
       <name>José Carlos Ipuchima da Silva</name>

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" default-locale="pt-BR">
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" demote-non-dropping-particle="never" default-locale="pt-BR">
   <info>
     <title>Rede de Biodiversidade e Biotecnologia da Amazônia Legal (BIONORTE) - ABNT 2026 (Português - Brasil)</title>
-    <title-short>BIONORTE</title-short>
     <id>http://www.zotero.org/styles/bionorte-abnt-2026</id>
     <link href="http://www.zotero.org/styles/bionorte-abnt-2026" rel="self"/>
     <link href="https://bionorte.org.br/uploads/2025/p12/F334818251668.pdf" rel="documentation"/>

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -4,10 +4,19 @@
     <title>Rede de Biodiversidade e Biotecnologia da Amazônia Legal (BIONORTE) - ABNT 2026 (Português - Brasil)</title>
     <id>http://www.zotero.org/styles/bionorte-abnt-2026</id>
     <link href="http://www.zotero.org/styles/bionorte-abnt-2026" rel="self"/>
+    <link href="http://www.zotero.org/styles/brazilian-journal-of-microbiology-2026" rel="template"/>
+    <link href="https://bionorte.org.br/uploads/2025/p12/F334818251668.pdf" rel="documentation"/>
     <author>
       <name>José Carlos Ipuchima da Silva</name>
+      <email>carlos.silva.jcids@gmail.com</email>
     </author>
+    <contributor>
+      <name>Hector Henrique Ferreira Koolen</name>
+      <email>hkoolen@uea.edu.br</email>
+    </contributor>
     <category citation-format="author-date"/>
+    <category field="biology"/>
+    <summary>Estilo autor-data BIONORTE ABNT 2026 para Mendeley e Zotero.</summary>
     <updated>2026-08-13T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -19,220 +19,220 @@
     <updated>2026-08-13T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-<citation et-al-min="3" et-al-use-first="1" collapse="year">
-    <sort>
-      <key macro="issued-year" sort="ascending"/>
-      <key macro="citation-author" sort="ascending"/>
-    </sort>
-    <layout prefix="(" suffix=")" delimiter="; ">
-      <group delimiter=", ">
-        <text macro="citation-author"/>
-        <text macro="issued-year"/>
-      </group>
-    </layout>
-  </citation>
-
-  <bibliography hanging-indent="true" entry-spacing="1">
-    <sort>
-      <key macro="author-initials"/>
-      <key macro="issued-year"/>
-      <key variable="title"/>
-    </sort>
-    <layout suffix=".">
+  <macro name="author-initials">
+      <names variable="author" delimiter="; ">
+        <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; "/>
+      </names>
+    </macro>
+  
+    <macro name="author-full">
+      <names variable="author" delimiter="; ">
+        <name name-as-sort-order="all" sort-separator=", " initialize="false" delimiter="; "/>
+      </names>
+    </macro>
+  
+    <macro name="editor">
+      <names variable="editor" delimiter="; " suffix=" ">
+        <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; "/>
+        <label form="short" prefix="(" suffix=")."/>
+      </names>
+    </macro>
+  
+    <macro name="issued-year">
+      <date variable="issued">
+        <date-part name="year"/>
+      </date>
+    </macro>
+  
+    <macro name="accessed-date">
+      <date variable="accessed" delimiter="/">
+        <date-part name="day" form="numeric-leading-zeros"/>
+        <date-part name="month" form="numeric-leading-zeros"/>
+        <date-part name="year"/>
+      </date>
+    </macro>
+  
+    <macro name="edition">
       <choose>
-        <if type="thesis">
-          <text macro="author-full" suffix=". "/>
-          <text variable="title" font-style="italic" suffix=". "/>
-          <text macro="issued-year" suffix=". "/>
-          <group delimiter=" – ">
-            <text variable="genre"/>
-            <group delimiter=", ">
-              <text variable="publisher"/>
-              <text variable="publisher-place"/>
-              <text macro="issued-year"/>
-            </group>
+        <if is-numeric="edition">
+          <group delimiter=" ">
+            <number variable="edition" form="numeric"/>
+            <label variable="edition" form="short"/>
           </group>
-          <text macro="doi-url-access" prefix=". "/>
         </if>
-
-        <else-if type="article-journal">
-          <text macro="author-initials" suffix=". "/>
-          <text variable="title" suffix=". "/>
-          <group delimiter=", ">
-            <text variable="container-title" font-style="italic"/>
-            <group delimiter=" "><label variable="volume" form="short"/><text variable="volume"/></group>
-            <group delimiter=" "><label variable="issue" form="short"/><text variable="issue"/></group>
-            <text macro="article-number"/>
-            <text macro="pages"/>
-            <text macro="issued-year"/>
-          </group>
-          <text macro="doi-url-access" prefix=". "/>
-        </else-if>
-
-        <else-if type="book">
-          <text macro="author-initials" suffix=". "/>
-          <text variable="title" font-style="italic" suffix=". "/>
-          <text macro="edition" suffix=". "/>
-          <group delimiter=", ">
-            <text macro="publisher-block"/>
-            <text macro="issued-year"/>
-          </group>
-          <text macro="pages" prefix=". "/>
-          <text macro="doi-url-access" prefix=". "/>
-        </else-if>
-
-        <else-if type="chapter">
-          <text macro="author-initials" suffix=". "/>
-          <text variable="title" suffix=". "/>
-          <text term="in" text-case="capitalize-first" suffix=": "/>
-          <text macro="editor"/>
-          <text variable="container-title" font-style="italic" suffix=". "/>
-          <text macro="edition" suffix=". "/>
-          <group delimiter=", ">
-            <text macro="publisher-block"/>
-            <text macro="issued-year"/>
-          </group>
-          <text macro="pages" prefix=". "/>
-          <text macro="doi-url-access" prefix=". "/>
-        </else-if>
-
-        <else-if type="paper-conference">
-          <text macro="author-initials" suffix=". "/>
-          <text variable="title" suffix=". "/>
-          <text term="in" text-case="capitalize-first" suffix=": "/>
-          <group delimiter=", ">
-            <text variable="event"/>
-            <text macro="issued-year"/>
-            <text variable="event-place"/>
-          </group>
-          <text variable="container-title" font-style="italic" prefix=". " suffix=". "/>
-          <group delimiter=", ">
-            <text macro="publisher-block"/>
-            <text macro="issued-year"/>
-          </group>
-          <text macro="pages" prefix=". "/>
-          <text macro="doi-url-access" prefix=". "/>
-        </else-if>
-
-        <else-if type="report software webpage post-weblog" match="any">
-          <text macro="author-initials" suffix=". "/>
-          <text variable="title" font-style="italic" suffix=". "/>
-          <group delimiter=", ">
-            <text macro="publisher-block"/>
-            <text macro="issued-year"/>
-          </group>
-          <text macro="doi-url-access" prefix=". "/>
-        </else-if>
-
         <else>
-          <text macro="author-initials" suffix=". "/>
-          <text variable="title" suffix=". "/>
-          <group delimiter=", ">
-            <text variable="container-title" font-style="italic"/>
-            <text macro="publisher-block"/>
-            <text macro="issued-year"/>
-          </group>
-          <text macro="doi-url-access" prefix=". "/>
+          <text variable="edition"/>
         </else>
       </choose>
-    </layout>
-  </bibliography>
+    </macro>
+  
+    <macro name="publisher-block">
+      <group delimiter=": ">
+        <text variable="publisher-place"/>
+        <text variable="publisher"/>
+      </group>
+    </macro>
+  
+    <macro name="pages">
+      <choose>
+        <if variable="page">
+          <group delimiter=" "><label variable="page" form="short"/><text variable="page"/></group>
+        </if>
+        <else-if variable="number-of-pages">
+          <group delimiter=" "><label variable="page" form="short"/><text variable="number-of-pages"/></group>
+        </else-if>
+      </choose>
+    </macro>
+  
+    <macro name="article-number">
+      <choose>
+        <if variable="number">
+          <text variable="number" prefix="Article ID "/>
+        </if>
+      </choose>
+    </macro>
+  
+    <macro name="doi-url-access">
+      <choose>
+        <if variable="DOI">
+          <text variable="DOI" prefix="https://doi.org/"/>
+        </if>
+        <else-if variable="URL">
+          <group delimiter=". ">
+            <group delimiter=": "><text term="available at"/><text variable="URL"/></group>
+            <choose>
+              <if variable="accessed">
+                <group delimiter=": "><text term="accessed"/><text macro="accessed-date"/></group>
+              </if>
+            </choose>
+          </group>
+        </else-if>
+      </choose>
+    </macro>
+  
+    <macro name="citation-author">
+      <names variable="author" et-al-min="3" et-al-use-first="1">
+        <name form="short" and="text" delimiter=" e "/>
+        <et-al term="et-al"/>
+      </names>
+    </macro>
 
-<macro name="author-initials">
-    <names variable="author" delimiter="; ">
-      <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; "/>
-    </names>
-  </macro>
-
-  <macro name="author-full">
-    <names variable="author" delimiter="; ">
-      <name name-as-sort-order="all" sort-separator=", " initialize="false" delimiter="; "/>
-    </names>
-  </macro>
-
-  <macro name="editor">
-    <names variable="editor" delimiter="; " suffix=" ">
-      <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; "/>
-      <label form="short" prefix="(" suffix=")."/>
-    </names>
-  </macro>
-
-  <macro name="issued-year">
-    <date variable="issued">
-      <date-part name="year"/>
-    </date>
-  </macro>
-
-  <macro name="accessed-date">
-    <date variable="accessed" delimiter="/">
-      <date-part name="day" form="numeric-leading-zeros"/>
-      <date-part name="month" form="numeric-leading-zeros"/>
-      <date-part name="year"/>
-    </date>
-  </macro>
-
-  <macro name="edition">
-    <choose>
-      <if is-numeric="edition">
-        <group delimiter=" ">
-          <number variable="edition" form="numeric"/>
-          <label variable="edition" form="short"/>
+  <citation et-al-min="3" et-al-use-first="1" collapse="year">
+      <sort>
+        <key macro="issued-year" sort="ascending"/>
+        <key macro="citation-author" sort="ascending"/>
+      </sort>
+      <layout prefix="(" suffix=")" delimiter="; ">
+        <group delimiter=", ">
+          <text macro="citation-author"/>
+          <text macro="issued-year"/>
         </group>
-      </if>
-      <else>
-        <text variable="edition"/>
-      </else>
-    </choose>
-  </macro>
-
-  <macro name="publisher-block">
-    <group delimiter=": ">
-      <text variable="publisher-place"/>
-      <text variable="publisher"/>
-    </group>
-  </macro>
-
-  <macro name="pages">
-    <choose>
-      <if variable="page">
-        <group delimiter=" "><label variable="page" form="short"/><text variable="page"/></group>
-      </if>
-      <else-if variable="number-of-pages">
-        <group delimiter=" "><label variable="page" form="short"/><text variable="number-of-pages"/></group>
-      </else-if>
-    </choose>
-  </macro>
-
-  <macro name="article-number">
-    <choose>
-      <if variable="number">
-        <text variable="number" prefix="Article ID "/>
-      </if>
-    </choose>
-  </macro>
-
-  <macro name="doi-url-access">
-    <choose>
-      <if variable="DOI">
-        <text variable="DOI" prefix="https://doi.org/"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=". ">
-          <group delimiter=": "><text term="available at"/><text variable="URL"/></group>
-          <choose>
-            <if variable="accessed">
-              <group delimiter=": "><text term="accessed"/><text macro="accessed-date"/></group>
-            </if>
-          </choose>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
-
-  <macro name="citation-author">
-    <names variable="author" et-al-min="3" et-al-use-first="1">
-      <name form="short" and="text" delimiter=" e "/>
-      <et-al term="et-al"/>
-    </names>
-  </macro>
+      </layout>
+    </citation>
+  
+    <bibliography hanging-indent="true" entry-spacing="1">
+      <sort>
+        <key macro="author-initials"/>
+        <key macro="issued-year"/>
+        <key variable="title"/>
+      </sort>
+      <layout suffix=".">
+        <choose>
+          <if type="thesis">
+            <text macro="author-full" suffix=". "/>
+            <text variable="title" font-style="italic" suffix=". "/>
+            <text macro="issued-year" suffix=". "/>
+            <group delimiter=" – ">
+              <text variable="genre"/>
+              <group delimiter=", ">
+                <text variable="publisher"/>
+                <text variable="publisher-place"/>
+                <text macro="issued-year"/>
+              </group>
+            </group>
+            <text macro="doi-url-access" prefix=". "/>
+          </if>
+  
+          <else-if type="article-journal">
+            <text macro="author-initials" suffix=". "/>
+            <text variable="title" suffix=". "/>
+            <group delimiter=", ">
+              <text variable="container-title" font-style="italic"/>
+              <group delimiter=" "><label variable="volume" form="short"/><text variable="volume"/></group>
+              <group delimiter=" "><label variable="issue" form="short"/><text variable="issue"/></group>
+              <text macro="article-number"/>
+              <text macro="pages"/>
+              <text macro="issued-year"/>
+            </group>
+            <text macro="doi-url-access" prefix=". "/>
+          </else-if>
+  
+          <else-if type="book">
+            <text macro="author-initials" suffix=". "/>
+            <text variable="title" font-style="italic" suffix=". "/>
+            <text macro="edition" suffix=". "/>
+            <group delimiter=", ">
+              <text macro="publisher-block"/>
+              <text macro="issued-year"/>
+            </group>
+            <text macro="pages" prefix=". "/>
+            <text macro="doi-url-access" prefix=". "/>
+          </else-if>
+  
+          <else-if type="chapter">
+            <text macro="author-initials" suffix=". "/>
+            <text variable="title" suffix=". "/>
+            <text term="in" text-case="capitalize-first" suffix=": "/>
+            <text macro="editor"/>
+            <text variable="container-title" font-style="italic" suffix=". "/>
+            <text macro="edition" suffix=". "/>
+            <group delimiter=", ">
+              <text macro="publisher-block"/>
+              <text macro="issued-year"/>
+            </group>
+            <text macro="pages" prefix=". "/>
+            <text macro="doi-url-access" prefix=". "/>
+          </else-if>
+  
+          <else-if type="paper-conference">
+            <text macro="author-initials" suffix=". "/>
+            <text variable="title" suffix=". "/>
+            <text term="in" text-case="capitalize-first" suffix=": "/>
+            <group delimiter=", ">
+              <text variable="event"/>
+              <text macro="issued-year"/>
+              <text variable="event-place"/>
+            </group>
+            <text variable="container-title" font-style="italic" prefix=". " suffix=". "/>
+            <group delimiter=", ">
+              <text macro="publisher-block"/>
+              <text macro="issued-year"/>
+            </group>
+            <text macro="pages" prefix=". "/>
+            <text macro="doi-url-access" prefix=". "/>
+          </else-if>
+  
+          <else-if type="report software webpage post-weblog" match="any">
+            <text macro="author-initials" suffix=". "/>
+            <text variable="title" font-style="italic" suffix=". "/>
+            <group delimiter=", ">
+              <text macro="publisher-block"/>
+              <text macro="issued-year"/>
+            </group>
+            <text macro="doi-url-access" prefix=". "/>
+          </else-if>
+  
+          <else>
+            <text macro="author-initials" suffix=". "/>
+            <text variable="title" suffix=". "/>
+            <group delimiter=", ">
+              <text variable="container-title" font-style="italic"/>
+              <text macro="publisher-block"/>
+              <text macro="issued-year"/>
+            </group>
+            <text macro="doi-url-access" prefix=". "/>
+          </else>
+        </choose>
+      </layout>
+    </bibliography>
 </style>

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -19,19 +19,6 @@
     <updated>2026-08-13T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-
-  <locale xml:lang="pt-BR">
-    <terms>
-      <term name="et-al">et al.</term>
-      <term name="editor" form="short">
-        <single>Org.</single>
-        <multiple>Orgs.</multiple>
-      </term>
-      <term name="available at">Disponível em</term>
-      <term name="accessed">Acesso em</term>
-    </terms>
-  </locale>
-
   <macro name="author-initials">
     <names variable="author" delimiter="; ">
       <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; "/>
@@ -271,6 +258,7 @@
     </layout>
   </bibliography>
 </style>
+
 
 
 

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -4,13 +4,8 @@
     <title>Rede de Biodiversidade e Biotecnologia da Amazônia Legal (BIONORTE) - ABNT 2026 (Português - Brasil)</title>
     <id>http://www.zotero.org/styles/bionorte-abnt-2026</id>
     <link href="http://www.zotero.org/styles/bionorte-abnt-2026" rel="self"/>
-    <author>
-      <name>José Carlos Ipuchima da Silva</name>
-      <email>carlos.silva.jcids@gmail.com</email>
-    </author>
     <category citation-format="author-date"/>
     <updated>2026-08-13T00:00:00+00:00</updated>
-    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
 
   <macro name="authorinitials">

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -12,17 +12,6 @@
     <updated>2026-08-13T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <locale xml:lang="pt-BR">
-    <terms>
-      <term name="et-al">et al.</term>
-      <term name="editor" form="short">
-        <single>Org.</single>
-        <multiple>Orgs.</multiple>
-      </term>
-      <term name="available at">Disponível em</term>
-      <term name="accessed">Acesso em</term>
-    </terms>
-  </locale>
 
   <macro name="authorinitials">
     <text variable="title"/>
@@ -120,7 +109,7 @@
       </names>
     </macro>
 
-  <citation et-al-min="3" et-al-use-first="1" collapse="year">
+  <citation collapse="year">
       <sort>
         <key macro="issued-year" sort="ascending"/>
         <key macro="citation-author" sort="ascending"/>

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -6,14 +6,8 @@
     <link href="http://www.zotero.org/styles/bionorte-abnt-2026" rel="self"/>
     <author>
       <name>José Carlos Ipuchima da Silva</name>
-      <email>carlos.silva.jcids@gmail.com</email>
     </author>
-    <contributor>
-      <name>Hector Henrique Ferreira Koolen</name>
-      <email>hkoolen@uea.edu.br</email>
-    </contributor>
     <category citation-format="author-date"/>
-    <category field="biology"/>
     <updated>2026-08-13T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -20,14 +20,6 @@
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
 
-  <locale xml:lang="pt-BR">
-    <terms>
-      <term name="and">e</term>
-      <term name="et-al">et al.</term>
-      <term name="in">In</term>
-    </terms>
-  </locale>
-
   <macro name="authorinitials">
     <text variable="title"/>
   </macro>

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -9,6 +9,14 @@
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
 
+  <locale xml:lang="pt-BR">
+    <terms>
+      <term name="and">e</term>
+      <term name="et-al">et al.</term>
+      <term name="in">In</term>
+    </terms>
+  </locale>
+
   <macro name="authorinitials">
     <text variable="title"/>
   </macro>

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -15,12 +15,8 @@
     <names variable="author" delimiter="; ">
       <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; "/>
       <substitute>
-        <names variable="editor" delimiter="; ">
-          <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; "/>
-        </names>
-        <names variable="translator" delimiter="; ">
-          <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; "/>
-        </names>
+        <names variable="editor" delimiter="; "/>
+        <names variable="translator" delimiter="; "/>
         <text variable="title"/>
       </substitute>
     </names>
@@ -30,9 +26,7 @@
     <names variable="author" delimiter="; ">
       <name name-as-sort-order="all" sort-separator=", " initialize="false" delimiter="; "/>
       <substitute>
-        <names variable="editor" delimiter="; ">
-          <name name-as-sort-order="all" sort-separator=", " initialize="false" delimiter="; "/>
-        </names>
+        <names variable="editor" delimiter="; "/>
         <text variable="title"/>
       </substitute>
     </names>
@@ -122,10 +116,7 @@
       <name form="short" and="text" delimiter=" e "/>
       <et-al term="et-al"/>
       <substitute>
-        <names variable="editor" et-al-min="3" et-al-use-first="1">
-          <name form="short" and="text" delimiter=" e "/>
-          <et-al term="et-al"/>
-        </names>
+        <names variable="editor"/>
         <text variable="title" form="short"/>
       </substitute>
     </names>

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -2,9 +2,20 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" demote-non-dropping-particle="never" default-locale="pt-BR">
   <info>
     <title>Rede de Biodiversidade e Biotecnologia da Amazônia Legal (BIONORTE) - ABNT 2026 (Português - Brasil)</title>
+    <title-short>BIONORTE-ABNT-2026</title-short>
     <id>http://www.zotero.org/styles/bionorte-abnt-2026</id>
     <link href="http://www.zotero.org/styles/bionorte-abnt-2026" rel="self"/>
+    <link href="https://bionorte.org.br/uploads/2025/p12/F334818251668.pdf" rel="documentation"/>
+    <author>
+      <name>José Carlos Ipuchima da Silva</name>
+      <email>carlos.silva.jcids@gmail.com</email>
+    </author>
+    <contributor>
+      <name>Hector Henrique Ferreira Koolen</name>
+      <email>hkoolen@uea.edu.br</email>
+    </contributor>
     <category citation-format="author-date"/>
+    <summary>Author-date style for Rede de Biodiversidade e Biotecnologia da Amazônia Legal (BIONORTE), based on ABNT conventions.</summary>
     <updated>2026-08-13T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -19,221 +19,220 @@
     <updated>2026-08-13T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-
   <macro name="author-initials">
     <names variable="author" delimiter="; ">
       <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; "/>
     </names>
   </macro>
-  
-    <macro name="author-full">
-      <names variable="author" delimiter="; ">
-        <name name-as-sort-order="all" sort-separator=", " initialize="false" delimiter="; "/>
-      </names>
-    </macro>
-  
-    <macro name="editor">
-      <names variable="editor" delimiter="; " suffix=" ">
-        <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; "/>
-        <label form="short" prefix="(" suffix=")."/>
-      </names>
-    </macro>
-  
-    <macro name="issued-year">
-      <date variable="issued">
-        <date-part name="year"/>
-      </date>
-    </macro>
-  
-    <macro name="accessed-date">
-      <date variable="accessed" delimiter="/">
-        <date-part name="day" form="numeric-leading-zeros"/>
-        <date-part name="month" form="numeric-leading-zeros"/>
-        <date-part name="year"/>
-      </date>
-    </macro>
-  
-    <macro name="edition">
-      <choose>
-        <if is-numeric="edition">
-          <group delimiter=" ">
-            <number variable="edition" form="numeric"/>
-            <label variable="edition" form="short"/>
+  <macro name="author-full">
+    <names variable="author" delimiter="; ">
+      <name name-as-sort-order="all" sort-separator=", " initialize="false" delimiter="; "/>
+    </names>
+  </macro>
+  <macro name="editor">
+    <names variable="editor" delimiter="; " suffix=" ">
+      <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; "/>
+      <label form="short" prefix="(" suffix=")."/>
+    </names>
+  </macro>
+  <macro name="issued-year">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
+  <macro name="accessed-date">
+    <date variable="accessed" delimiter="/">
+      <date-part name="day" form="numeric-leading-zeros"/>
+      <date-part name="month" form="numeric-leading-zeros"/>
+      <date-part name="year"/>
+    </date>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="numeric"/>
+          <label variable="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher-block">
+    <group delimiter=": ">
+      <text variable="publisher-place"/>
+      <text variable="publisher"/>
+    </group>
+  </macro>
+  <macro name="pages">
+    <choose>
+      <if variable="page">
+        <group delimiter=" ">
+          <label variable="page" form="short"/>
+          <text variable="page"/>
+        </group>
+      </if>
+      <else-if variable="number-of-pages">
+        <group delimiter=" ">
+          <label variable="page" form="short"/>
+          <text variable="number-of-pages"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="article-number">
+    <choose>
+      <if variable="number">
+        <text variable="number" prefix="Article ID "/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="doi-url-access">
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix="https://doi.org/"/>
+      </if>
+      <else-if variable="URL">
+        <group delimiter=". ">
+          <group delimiter=": ">
+            <text term="available at"/>
+            <text variable="URL"/>
           </group>
+          <choose>
+            <if variable="accessed">
+              <group delimiter=": ">
+                <text term="accessed"/>
+                <text macro="accessed-date"/>
+              </group>
+            </if>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="citation-author">
+    <names variable="author">
+      <name form="short" and="text" delimiter=" e " et-al-min="3" et-al-use-first="1"/>
+      <et-al term="et-al"/>
+    </names>
+  </macro>
+  <citation collapse="year">
+    <sort>
+      <key macro="issued-year" sort="ascending"/>
+      <key macro="citation-author" sort="ascending"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="citation-author"/>
+        <text macro="issued-year"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" entry-spacing="1">
+    <sort>
+      <key macro="author-initials"/>
+      <key macro="issued-year"/>
+      <key variable="title"/>
+    </sort>
+    <layout suffix=".">
+      <choose>
+        <if type="thesis">
+          <text macro="author-full" suffix=". "/>
+          <text variable="title" font-style="italic" suffix=". "/>
+          <text macro="issued-year" suffix=". "/>
+          <group delimiter=" &#8211; ">
+            <text variable="genre"/>
+            <group delimiter=", ">
+              <text variable="publisher"/>
+              <text variable="publisher-place"/>
+              <text macro="issued-year"/>
+            </group>
+          </group>
+          <text macro="doi-url-access" prefix=". "/>
         </if>
+        <else-if type="article-journal">
+          <text macro="author-initials" suffix=". "/>
+          <text variable="title" suffix=". "/>
+          <group delimiter=", ">
+            <text variable="container-title" font-style="italic"/>
+            <group delimiter=" ">
+              <label variable="volume" form="short"/>
+              <text variable="volume"/>
+            </group>
+            <group delimiter=" ">
+              <label variable="issue" form="short"/>
+              <text variable="issue"/>
+            </group>
+            <text macro="article-number"/>
+            <text macro="pages"/>
+            <text macro="issued-year"/>
+          </group>
+          <text macro="doi-url-access" prefix=". "/>
+        </else-if>
+        <else-if type="book">
+          <text macro="author-initials" suffix=". "/>
+          <text variable="title" font-style="italic" suffix=". "/>
+          <text macro="edition" suffix=". "/>
+          <group delimiter=", ">
+            <text macro="publisher-block"/>
+            <text macro="issued-year"/>
+          </group>
+          <text macro="pages" prefix=". "/>
+          <text macro="doi-url-access" prefix=". "/>
+        </else-if>
+        <else-if type="chapter">
+          <text macro="author-initials" suffix=". "/>
+          <text variable="title" suffix=". "/>
+          <text term="in" text-case="capitalize-first" suffix=": "/>
+          <text macro="editor"/>
+          <text variable="container-title" font-style="italic" suffix=". "/>
+          <text macro="edition" suffix=". "/>
+          <group delimiter=", ">
+            <text macro="publisher-block"/>
+            <text macro="issued-year"/>
+          </group>
+          <text macro="pages" prefix=". "/>
+          <text macro="doi-url-access" prefix=". "/>
+        </else-if>
+        <else-if type="paper-conference">
+          <text macro="author-initials" suffix=". "/>
+          <text variable="title" suffix=". "/>
+          <text term="in" text-case="capitalize-first" suffix=": "/>
+          <group delimiter=", ">
+            <text variable="event"/>
+            <text macro="issued-year"/>
+            <text variable="event-place"/>
+          </group>
+          <text variable="container-title" font-style="italic" prefix=". " suffix=". "/>
+          <group delimiter=", ">
+            <text macro="publisher-block"/>
+            <text macro="issued-year"/>
+          </group>
+          <text macro="pages" prefix=". "/>
+          <text macro="doi-url-access" prefix=". "/>
+        </else-if>
+        <else-if type="report webpage post-weblog" match="any">
+          <text macro="author-initials" suffix=". "/>
+          <text variable="title" font-style="italic" suffix=". "/>
+          <group delimiter=", ">
+            <text macro="publisher-block"/>
+            <text macro="issued-year"/>
+          </group>
+          <text macro="doi-url-access" prefix=". "/>
+        </else-if>
         <else>
-          <text variable="edition"/>
+          <text macro="author-initials" suffix=". "/>
+          <text variable="title" suffix=". "/>
+          <group delimiter=", ">
+            <text variable="container-title" font-style="italic"/>
+            <text macro="publisher-block"/>
+            <text macro="issued-year"/>
+          </group>
+          <text macro="doi-url-access" prefix=". "/>
         </else>
       </choose>
-    </macro>
-  
-    <macro name="publisher-block">
-      <group delimiter=": ">
-        <text variable="publisher-place"/>
-        <text variable="publisher"/>
-      </group>
-    </macro>
-  
-    <macro name="pages">
-      <choose>
-        <if variable="page">
-          <group delimiter=" "><label variable="page" form="short"/><text variable="page"/></group>
-        </if>
-        <else-if variable="number-of-pages">
-          <group delimiter=" "><label variable="page" form="short"/><text variable="number-of-pages"/></group>
-        </else-if>
-      </choose>
-    </macro>
-  
-    <macro name="article-number">
-      <choose>
-        <if variable="number">
-          <text variable="number" prefix="Article ID "/>
-        </if>
-      </choose>
-    </macro>
-  
-    <macro name="doi-url-access">
-      <choose>
-        <if variable="DOI">
-          <text variable="DOI" prefix="https://doi.org/"/>
-        </if>
-        <else-if variable="URL">
-          <group delimiter=". ">
-            <group delimiter=": "><text term="available at"/><text variable="URL"/></group>
-            <choose>
-              <if variable="accessed">
-                <group delimiter=": "><text term="accessed"/><text macro="accessed-date"/></group>
-              </if>
-            </choose>
-          </group>
-        </else-if>
-      </choose>
-    </macro>
-  
-  <macro name="citation-author">
-      <names variable="author">
-        <name form="short" and="text" delimiter=" e " et-al-min="3" et-al-use-first="1"/>
-        <et-al term="et-al"/>
-      </names>
-    </macro>
-
-  <citation collapse="year">
-      <sort>
-        <key macro="issued-year" sort="ascending"/>
-        <key macro="citation-author" sort="ascending"/>
-      </sort>
-      <layout prefix="(" suffix=")" delimiter="; ">
-        <group delimiter=", ">
-          <text macro="citation-author"/>
-          <text macro="issued-year"/>
-        </group>
-      </layout>
-    </citation>
-  
-    <bibliography hanging-indent="true" entry-spacing="1">
-      <sort>
-        <key macro="author-initials"/>
-        <key macro="issued-year"/>
-        <key variable="title"/>
-      </sort>
-      <layout suffix=".">
-        <choose>
-          <if type="thesis">
-            <text macro="author-full" suffix=". "/>
-            <text variable="title" font-style="italic" suffix=". "/>
-            <text macro="issued-year" suffix=". "/>
-            <group delimiter=" – ">
-              <text variable="genre"/>
-              <group delimiter=", ">
-                <text variable="publisher"/>
-                <text variable="publisher-place"/>
-                <text macro="issued-year"/>
-              </group>
-            </group>
-            <text macro="doi-url-access" prefix=". "/>
-          </if>
-  
-          <else-if type="article-journal">
-            <text macro="author-initials" suffix=". "/>
-            <text variable="title" suffix=". "/>
-            <group delimiter=", ">
-              <text variable="container-title" font-style="italic"/>
-              <group delimiter=" "><label variable="volume" form="short"/><text variable="volume"/></group>
-              <group delimiter=" "><label variable="issue" form="short"/><text variable="issue"/></group>
-              <text macro="article-number"/>
-              <text macro="pages"/>
-              <text macro="issued-year"/>
-            </group>
-            <text macro="doi-url-access" prefix=". "/>
-          </else-if>
-  
-          <else-if type="book">
-            <text macro="author-initials" suffix=". "/>
-            <text variable="title" font-style="italic" suffix=". "/>
-            <text macro="edition" suffix=". "/>
-            <group delimiter=", ">
-              <text macro="publisher-block"/>
-              <text macro="issued-year"/>
-            </group>
-            <text macro="pages" prefix=". "/>
-            <text macro="doi-url-access" prefix=". "/>
-          </else-if>
-  
-          <else-if type="chapter">
-            <text macro="author-initials" suffix=". "/>
-            <text variable="title" suffix=". "/>
-            <text term="in" text-case="capitalize-first" suffix=": "/>
-            <text macro="editor"/>
-            <text variable="container-title" font-style="italic" suffix=". "/>
-            <text macro="edition" suffix=". "/>
-            <group delimiter=", ">
-              <text macro="publisher-block"/>
-              <text macro="issued-year"/>
-            </group>
-            <text macro="pages" prefix=". "/>
-            <text macro="doi-url-access" prefix=". "/>
-          </else-if>
-  
-          <else-if type="paper-conference">
-            <text macro="author-initials" suffix=". "/>
-            <text variable="title" suffix=". "/>
-            <text term="in" text-case="capitalize-first" suffix=": "/>
-            <group delimiter=", ">
-              <text variable="event"/>
-              <text macro="issued-year"/>
-              <text variable="event-place"/>
-            </group>
-            <text variable="container-title" font-style="italic" prefix=". " suffix=". "/>
-            <group delimiter=", ">
-              <text macro="publisher-block"/>
-              <text macro="issued-year"/>
-            </group>
-            <text macro="pages" prefix=". "/>
-            <text macro="doi-url-access" prefix=". "/>
-          </else-if>
-  
-          <else-if type="report webpage post-weblog" match="any">
-            <text macro="author-initials" suffix=". "/>
-            <text variable="title" font-style="italic" suffix=". "/>
-            <group delimiter=", ">
-              <text macro="publisher-block"/>
-              <text macro="issued-year"/>
-            </group>
-            <text macro="doi-url-access" prefix=". "/>
-          </else-if>
-  
-          <else>
-            <text macro="author-initials" suffix=". "/>
-            <text variable="title" suffix=". "/>
-            <group delimiter=", ">
-              <text variable="container-title" font-style="italic"/>
-              <text macro="publisher-block"/>
-              <text macro="issued-year"/>
-            </group>
-            <text macro="doi-url-access" prefix=". "/>
-          </else>
-        </choose>
-      </layout>
-    </bibliography>
+    </layout>
+  </bibliography>
 </style>

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -4,7 +4,7 @@
     <title>Rede de Biodiversidade e Biotecnologia da Amazônia Legal (BIONORTE) - ABNT 2026</title>
     <id>http://www.zotero.org/styles/bionorte-abnt-2026</id>
     <link href="http://www.zotero.org/styles/bionorte-abnt-2026" rel="self"/>
-    <link href="http://www.zotero.org/styles/brazilian-journal-of-microbiology-2026" rel="template"/>
+    <link href="http://www.zotero.org/styles/associacao-brasileira-de-normas-tecnicas-ufmg-face-full" rel="template"/>
     <link href="https://bionorte.org.br/uploads/2025/p12/F334818251668.pdf" rel="documentation"/>
     <author>
       <name>José Carlos Ipuchima da Silva</name>
@@ -86,11 +86,11 @@
       <if is-numeric="edition">
         <group delimiter=" ">
           <number variable="edition" form="numeric"/>
-          <text value="ed."/>
+          <label variable="edition" form="short"/>
         </group>
       </if>
       <else>
-        <text variable="edition" suffix=" ed."/>
+        <text variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -105,10 +105,10 @@
   <macro name="pages">
     <choose>
       <if variable="page">
-        <text variable="page" prefix="p. "/>
+        <group delimiter=" "><label variable="page" form="short"/><text variable="page"/></group>
       </if>
       <else-if variable="number-of-pages">
-        <text variable="number-of-pages" prefix="p. "/>
+        <group delimiter=" "><label variable="page" form="short"/><text variable="number-of-pages"/></group>
       </else-if>
     </choose>
   </macro>
@@ -128,10 +128,10 @@
       </if>
       <else-if variable="URL">
         <group delimiter=". ">
-          <text variable="URL" prefix="Disponível em: "/>
+          <group delimiter=": "><text term="available at"/><text variable="URL"/></group>
           <choose>
             <if variable="accessed">
-              <text macro="accessed-date" prefix="Acesso em: "/>
+              <group delimiter=": "><text term="accessed"/><text macro="accessed-date"/></group>
             </if>
           </choose>
         </group>
@@ -194,8 +194,8 @@
           <text variable="title" suffix=". "/>
           <group delimiter=", ">
             <text variable="container-title" font-style="italic"/>
-            <text variable="volume" prefix="v. "/>
-            <text variable="issue" prefix="n. "/>
+            <group delimiter=" "><label variable="volume" form="short"/><text variable="volume"/></group>
+            <group delimiter=" "><label variable="issue" form="short"/><text variable="issue"/></group>
             <text macro="article-number"/>
             <text macro="pages"/>
             <text macro="issued-year"/>
@@ -218,7 +218,7 @@
         <else-if type="chapter">
           <text macro="author-initials" suffix=". "/>
           <text variable="title" suffix=". "/>
-          <text value="In: " />
+          <text term="in" text-case="capitalize-first" suffix=": "/>
           <text macro="editor"/>
           <text variable="container-title" font-style="italic" suffix=". "/>
           <text macro="edition" suffix=". "/>
@@ -233,7 +233,7 @@
         <else-if type="paper-conference">
           <text macro="author-initials" suffix=". "/>
           <text variable="title" suffix=". "/>
-          <text value="In: "/>
+          <text term="in" text-case="capitalize-first" suffix=": "/>
           <group delimiter=", ">
             <text variable="event"/>
             <text macro="issued-year"/>
@@ -248,7 +248,7 @@
           <text macro="doi-url-access" prefix=". "/>
         </else-if>
 
-        <else-if type="report software webpage post post-weblog" match="any">
+        <else-if type="report software webpage post-weblog" match="any">
           <text macro="author-initials" suffix=". "/>
           <text variable="title" font-style="italic" suffix=". "/>
           <group delimiter=", ">
@@ -272,4 +272,5 @@
     </layout>
   </bibliography>
 </style>
+
 

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -4,7 +4,6 @@
     <title>Rede de Biodiversidade e Biotecnologia da Amazônia Legal (BIONORTE) - ABNT 2026 (Português - Brasil)</title>
     <id>http://www.zotero.org/styles/bionorte-abnt-2026</id>
     <link href="http://www.zotero.org/styles/bionorte-abnt-2026" rel="self"/>
-    <link rel="documentation" href="https://bionorte.org.br/uploads/2025/p12/F334818251668.pdf"/>
     <author>
       <name>José Carlos Ipuchima da Silva</name>
       <email>carlos.silva.jcids@gmail.com</email>

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -15,7 +15,6 @@
     </contributor>
     <category citation-format="author-date"/>
     <category field="biology"/>
-    <summary>Estilo autor-data BIONORTE ABNT 2026 para Mendeley e Zotero, baseado no estilo Associacao Brasileira de Normas Tecnicas.</summary>
     <updated>2026-08-13T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -14,21 +14,12 @@
   <macro name="author-initials">
     <names variable="author" delimiter="; ">
       <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; "/>
-      <substitute>
-        <names variable="editor" delimiter="; "/>
-        <names variable="translator" delimiter="; "/>
-        <text variable="title"/>
-      </substitute>
     </names>
   </macro>
 
   <macro name="author-full">
     <names variable="author" delimiter="; ">
       <name name-as-sort-order="all" sort-separator=", " initialize="false" delimiter="; "/>
-      <substitute>
-        <names variable="editor" delimiter="; "/>
-        <text variable="title"/>
-      </substitute>
     </names>
   </macro>
 
@@ -115,10 +106,6 @@
     <names variable="author" et-al-min="3" et-al-use-first="1">
       <name form="short" and="text" delimiter=" e "/>
       <et-al term="et-al"/>
-      <substitute>
-        <names variable="editor"/>
-        <text variable="title" form="short"/>
-      </substitute>
     </names>
   </macro>
 

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -6,6 +6,7 @@
     <link href="http://www.zotero.org/styles/bionorte-abnt-2026" rel="self"/>
     <category citation-format="author-date"/>
     <updated>2026-08-13T00:00:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
 
   <macro name="authorinitials">

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -111,9 +111,9 @@
       </choose>
     </macro>
   
-    <macro name="citation-author">
-      <names variable="author" et-al-min="3" et-al-use-first="1">
-        <name form="short" and="text" delimiter=" e "/>
+  <macro name="citation-author">
+      <names variable="author">
+        <name form="short" and="text" delimiter=" e " et-al-min="3" et-al-use-first="1"/>
         <et-al term="et-al"/>
       </names>
     </macro>

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -4,7 +4,7 @@
     <title>Rede de Biodiversidade e Biotecnologia da Amazônia Legal (BIONORTE) - ABNT 2026</title>
     <id>http://www.zotero.org/styles/bionorte-abnt-2026</id>
     <link href="http://www.zotero.org/styles/bionorte-abnt-2026" rel="self"/>
-    <link href="https://bionorte.org.br/uploads/2025/p12/F334818251668.pdf" rel="documentation"/>
+    <link rel="documentation" href="https://bionorte.org.br/uploads/2025/p12/F334818251668.pdf"/>
     <author>
       <name>José Carlos Ipuchima da Silva</name>
       <email>carlos.silva.jcids@gmail.com</email>
@@ -257,6 +257,7 @@
     </layout>
   </bibliography>
 </style>
+
 
 
 

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -11,105 +11,7 @@
     <updated>2026-08-13T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <macro name="author-initials">
-    <names variable="author" delimiter="; ">
-      <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; "/>
-    </names>
-  </macro>
-
-  <macro name="author-full">
-    <names variable="author" delimiter="; ">
-      <name name-as-sort-order="all" sort-separator=", " initialize="false" delimiter="; "/>
-    </names>
-  </macro>
-
-  <macro name="editor">
-    <names variable="editor" delimiter="; " suffix=" ">
-      <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; "/>
-      <label form="short" prefix="(" suffix=")."/>
-    </names>
-  </macro>
-
-  <macro name="issued-year">
-    <date variable="issued">
-      <date-part name="year"/>
-    </date>
-  </macro>
-
-  <macro name="accessed-date">
-    <date variable="accessed" delimiter="/">
-      <date-part name="day" form="numeric-leading-zeros"/>
-      <date-part name="month" form="numeric-leading-zeros"/>
-      <date-part name="year"/>
-    </date>
-  </macro>
-
-  <macro name="edition">
-    <choose>
-      <if is-numeric="edition">
-        <group delimiter=" ">
-          <number variable="edition" form="numeric"/>
-          <label variable="edition" form="short"/>
-        </group>
-      </if>
-      <else>
-        <text variable="edition"/>
-      </else>
-    </choose>
-  </macro>
-
-  <macro name="publisher-block">
-    <group delimiter=": ">
-      <text variable="publisher-place"/>
-      <text variable="publisher"/>
-    </group>
-  </macro>
-
-  <macro name="pages">
-    <choose>
-      <if variable="page">
-        <group delimiter=" "><label variable="page" form="short"/><text variable="page"/></group>
-      </if>
-      <else-if variable="number-of-pages">
-        <group delimiter=" "><label variable="page" form="short"/><text variable="number-of-pages"/></group>
-      </else-if>
-    </choose>
-  </macro>
-
-  <macro name="article-number">
-    <choose>
-      <if variable="number">
-        <text variable="number" prefix="Article ID "/>
-      </if>
-    </choose>
-  </macro>
-
-  <macro name="doi-url-access">
-    <choose>
-      <if variable="DOI">
-        <text variable="DOI" prefix="https://doi.org/"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=". ">
-          <group delimiter=": "><text term="available at"/><text variable="URL"/></group>
-          <choose>
-            <if variable="accessed">
-              <group delimiter=": "><text term="accessed"/><text macro="accessed-date"/></group>
-            </if>
-          </choose>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
-
-  <macro name="citation-author">
-    <names variable="author" et-al-min="3" et-al-use-first="1">
-      <name form="short" and="text" delimiter=" e "/>
-      <et-al term="et-al"/>
-    </names>
-  </macro>
-
-  <citation et-al-min="3" et-al-use-first="1" collapse="year">
+<citation et-al-min="3" et-al-use-first="1" collapse="year">
     <sort>
       <key macro="issued-year" sort="ascending"/>
       <key macro="citation-author" sort="ascending"/>
@@ -227,16 +129,102 @@
       </choose>
     </layout>
   </bibliography>
+
+<macro name="author-initials">
+    <names variable="author" delimiter="; ">
+      <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; "/>
+    </names>
+  </macro>
+
+  <macro name="author-full">
+    <names variable="author" delimiter="; ">
+      <name name-as-sort-order="all" sort-separator=", " initialize="false" delimiter="; "/>
+    </names>
+  </macro>
+
+  <macro name="editor">
+    <names variable="editor" delimiter="; " suffix=" ">
+      <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; "/>
+      <label form="short" prefix="(" suffix=")."/>
+    </names>
+  </macro>
+
+  <macro name="issued-year">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
+
+  <macro name="accessed-date">
+    <date variable="accessed" delimiter="/">
+      <date-part name="day" form="numeric-leading-zeros"/>
+      <date-part name="month" form="numeric-leading-zeros"/>
+      <date-part name="year"/>
+    </date>
+  </macro>
+
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="numeric"/>
+          <label variable="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+
+  <macro name="publisher-block">
+    <group delimiter=": ">
+      <text variable="publisher-place"/>
+      <text variable="publisher"/>
+    </group>
+  </macro>
+
+  <macro name="pages">
+    <choose>
+      <if variable="page">
+        <group delimiter=" "><label variable="page" form="short"/><text variable="page"/></group>
+      </if>
+      <else-if variable="number-of-pages">
+        <group delimiter=" "><label variable="page" form="short"/><text variable="number-of-pages"/></group>
+      </else-if>
+    </choose>
+  </macro>
+
+  <macro name="article-number">
+    <choose>
+      <if variable="number">
+        <text variable="number" prefix="Article ID "/>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="doi-url-access">
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix="https://doi.org/"/>
+      </if>
+      <else-if variable="URL">
+        <group delimiter=". ">
+          <group delimiter=": "><text term="available at"/><text variable="URL"/></group>
+          <choose>
+            <if variable="accessed">
+              <group delimiter=": "><text term="accessed"/><text macro="accessed-date"/></group>
+            </if>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+
+  <macro name="citation-author">
+    <names variable="author" et-al-min="3" et-al-use-first="1">
+      <name form="short" and="text" delimiter=" e "/>
+      <et-al term="et-al"/>
+    </names>
+  </macro>
 </style>
-
-
-
-
-
-
-
-
-
-
-
-

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -12,7 +12,19 @@
     <updated>2026-08-13T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <macro name="author-initials">
+  <locale xml:lang="pt-BR">
+    <terms>
+      <term name="et-al">et al.</term>
+      <term name="editor" form="short">
+        <single>Org.</single>
+        <multiple>Orgs.</multiple>
+      </term>
+      <term name="available at">Disponível em</term>
+      <term name="accessed">Acesso em</term>
+    </terms>
+  </locale>
+
+  <macro name="authorinitials">
     <text variable="title"/>
   </macro>
   
@@ -123,7 +135,7 @@
   
     <bibliography hanging-indent="true" entry-spacing="1">
       <sort>
-        <key macro="author-initials"/>
+        <key macro="authorinitials"/>
         <key macro="issued-year"/>
         <key variable="title"/>
       </sort>
@@ -145,7 +157,7 @@
           </if>
   
           <else-if type="article-journal">
-            <text macro="author-initials" suffix=". "/>
+            <text macro="authorinitials" suffix=". "/>
             <text variable="title" suffix=". "/>
             <group delimiter=", ">
               <text variable="container-title" font-style="italic"/>
@@ -159,7 +171,7 @@
           </else-if>
   
           <else-if type="book">
-            <text macro="author-initials" suffix=". "/>
+            <text macro="authorinitials" suffix=". "/>
             <text variable="title" font-style="italic" suffix=". "/>
             <text macro="edition" suffix=". "/>
             <group delimiter=", ">
@@ -171,7 +183,7 @@
           </else-if>
   
           <else-if type="chapter">
-            <text macro="author-initials" suffix=". "/>
+            <text macro="authorinitials" suffix=". "/>
             <text variable="title" suffix=". "/>
             <text term="in" text-case="capitalize-first" suffix=": "/>
             <text macro="editor"/>
@@ -186,7 +198,7 @@
           </else-if>
   
           <else-if type="paper-conference">
-            <text macro="author-initials" suffix=". "/>
+            <text macro="authorinitials" suffix=". "/>
             <text variable="title" suffix=". "/>
             <text term="in" text-case="capitalize-first" suffix=": "/>
             <group delimiter=", ">
@@ -204,7 +216,7 @@
           </else-if>
   
           <else-if type="report software webpage post-weblog" match="any">
-            <text macro="author-initials" suffix=". "/>
+            <text macro="authorinitials" suffix=". "/>
             <text variable="title" font-style="italic" suffix=". "/>
             <group delimiter=", ">
               <text macro="publisher-block"/>
@@ -214,7 +226,7 @@
           </else-if>
   
           <else>
-            <text macro="author-initials" suffix=". "/>
+            <text macro="authorinitials" suffix=". "/>
             <text variable="title" suffix=". "/>
             <group delimiter=", ">
               <text variable="container-title" font-style="italic"/>

--- a/bionorte-abnt-2026.csl
+++ b/bionorte-abnt-2026.csl
@@ -1,0 +1,275 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" default-locale="pt-BR">
+  <info>
+    <title>Rede de Biodiversidade e Biotecnologia da Amazônia Legal (BIONORTE) - ABNT 2026</title>
+    <id>http://www.zotero.org/styles/bionorte-abnt-2026</id>
+    <link href="http://www.zotero.org/styles/bionorte-abnt-2026" rel="self"/>
+    <link href="http://www.zotero.org/styles/brazilian-journal-of-microbiology-2026" rel="template"/>
+    <link href="https://bionorte.org.br/uploads/2025/p12/F334818251668.pdf" rel="documentation"/>
+    <author>
+      <name>José Carlos Ipuchima da Silva</name>
+      <email>carlos.silva.jcids@gmail.com</email>
+    </author>
+    <contributor>
+      <name>Hector Henrique Ferreira Koolen</name>
+      <email>hkoolen@uea.edu.br</email>
+    </contributor>
+    <category citation-format="author-date"/>
+    <category field="biology"/>
+    <summary>Estilo autor-data BIONORTE ABNT 2026 para Mendeley e Zotero.</summary>
+    <updated>2026-08-13T00:00:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+
+  <locale xml:lang="pt-BR">
+    <terms>
+      <term name="et-al">et al.</term>
+      <term name="editor" form="short">
+        <single>Org.</single>
+        <multiple>Orgs.</multiple>
+      </term>
+      <term name="available at">Disponível em</term>
+      <term name="accessed">Acesso em</term>
+    </terms>
+  </locale>
+
+  <macro name="author-initials">
+    <names variable="author" delimiter="; ">
+      <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; "/>
+      <substitute>
+        <names variable="editor" delimiter="; ">
+          <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; "/>
+        </names>
+        <names variable="translator" delimiter="; ">
+          <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; "/>
+        </names>
+        <text variable="title"/>
+      </substitute>
+    </names>
+  </macro>
+
+  <macro name="author-full">
+    <names variable="author" delimiter="; ">
+      <name name-as-sort-order="all" sort-separator=", " initialize="false" delimiter="; "/>
+      <substitute>
+        <names variable="editor" delimiter="; ">
+          <name name-as-sort-order="all" sort-separator=", " initialize="false" delimiter="; "/>
+        </names>
+        <text variable="title"/>
+      </substitute>
+    </names>
+  </macro>
+
+  <macro name="editor">
+    <names variable="editor" delimiter="; " suffix=" ">
+      <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; "/>
+      <label form="short" prefix="(" suffix=")."/>
+    </names>
+  </macro>
+
+  <macro name="issued-year">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
+
+  <macro name="accessed-date">
+    <date variable="accessed">
+      <date-part name="day" form="numeric-leading-zeros" suffix="/"/>
+      <date-part name="month" form="numeric-leading-zeros" suffix="/"/>
+      <date-part name="year"/>
+    </date>
+  </macro>
+
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="numeric"/>
+          <text value="ed."/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix=" ed."/>
+      </else>
+    </choose>
+  </macro>
+
+  <macro name="publisher-block">
+    <group delimiter=": ">
+      <text variable="publisher-place"/>
+      <text variable="publisher"/>
+    </group>
+  </macro>
+
+  <macro name="pages">
+    <choose>
+      <if variable="page">
+        <text variable="page" prefix="p. "/>
+      </if>
+      <else-if variable="number-of-pages">
+        <text variable="number-of-pages" prefix="p. "/>
+      </else-if>
+    </choose>
+  </macro>
+
+  <macro name="article-number">
+    <choose>
+      <if variable="number">
+        <text variable="number" prefix="Article ID "/>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="doi-url-access">
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix="https://doi.org/"/>
+      </if>
+      <else-if variable="URL">
+        <group delimiter=". ">
+          <text variable="URL" prefix="Disponível em: "/>
+          <choose>
+            <if variable="accessed">
+              <text macro="accessed-date" prefix="Acesso em: "/>
+            </if>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+
+  <macro name="citation-author">
+    <names variable="author" et-al-min="3" et-al-use-first="1">
+      <name form="short" and="text" delimiter=" e "/>
+      <et-al term="et-al"/>
+      <substitute>
+        <names variable="editor" et-al-min="3" et-al-use-first="1">
+          <name form="short" and="text" delimiter=" e "/>
+          <et-al term="et-al"/>
+        </names>
+        <text variable="title" form="short"/>
+      </substitute>
+    </names>
+  </macro>
+
+  <citation et-al-min="3" et-al-use-first="1" collapse="year">
+    <sort>
+      <key macro="issued-year" sort="ascending"/>
+      <key macro="citation-author" sort="ascending"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="citation-author"/>
+        <text macro="issued-year"/>
+      </group>
+    </layout>
+  </citation>
+
+  <bibliography hanging-indent="true" entry-spacing="1">
+    <sort>
+      <key macro="author-initials"/>
+      <key macro="issued-year"/>
+      <key variable="title"/>
+    </sort>
+    <layout suffix=".">
+      <choose>
+        <if type="thesis">
+          <text macro="author-full" suffix=". "/>
+          <text variable="title" font-style="italic" suffix=". "/>
+          <text macro="issued-year" suffix=". "/>
+          <group delimiter=" – ">
+            <text variable="genre"/>
+            <group delimiter=", ">
+              <text variable="publisher"/>
+              <text variable="publisher-place"/>
+              <text macro="issued-year"/>
+            </group>
+          </group>
+          <text macro="doi-url-access" prefix=". "/>
+        </if>
+
+        <else-if type="article-journal">
+          <text macro="author-initials" suffix=". "/>
+          <text variable="title" suffix=". "/>
+          <group delimiter=", ">
+            <text variable="container-title" font-style="italic"/>
+            <text variable="volume" prefix="v. "/>
+            <text variable="issue" prefix="n. "/>
+            <text macro="article-number"/>
+            <text macro="pages"/>
+            <text macro="issued-year"/>
+          </group>
+          <text macro="doi-url-access" prefix=". "/>
+        </else-if>
+
+        <else-if type="book">
+          <text macro="author-initials" suffix=". "/>
+          <text variable="title" font-style="italic" suffix=". "/>
+          <text macro="edition" suffix=". "/>
+          <group delimiter=", ">
+            <text macro="publisher-block"/>
+            <text macro="issued-year"/>
+          </group>
+          <text macro="pages" prefix=". "/>
+          <text macro="doi-url-access" prefix=". "/>
+        </else-if>
+
+        <else-if type="chapter">
+          <text macro="author-initials" suffix=". "/>
+          <text variable="title" suffix=". "/>
+          <text value="In: " />
+          <text macro="editor"/>
+          <text variable="container-title" font-style="italic" suffix=". "/>
+          <text macro="edition" suffix=". "/>
+          <group delimiter=", ">
+            <text macro="publisher-block"/>
+            <text macro="issued-year"/>
+          </group>
+          <text macro="pages" prefix=". "/>
+          <text macro="doi-url-access" prefix=". "/>
+        </else-if>
+
+        <else-if type="paper-conference">
+          <text macro="author-initials" suffix=". "/>
+          <text variable="title" suffix=". "/>
+          <text value="In: "/>
+          <group delimiter=", ">
+            <text variable="event"/>
+            <text macro="issued-year"/>
+            <text variable="event-place"/>
+          </group>
+          <text variable="container-title" font-style="italic" prefix=". " suffix=". "/>
+          <group delimiter=", ">
+            <text macro="publisher-block"/>
+            <text macro="issued-year"/>
+          </group>
+          <text macro="pages" prefix=". "/>
+          <text macro="doi-url-access" prefix=". "/>
+        </else-if>
+
+        <else-if type="report software webpage post post-weblog" match="any">
+          <text macro="author-initials" suffix=". "/>
+          <text variable="title" font-style="italic" suffix=". "/>
+          <group delimiter=", ">
+            <text macro="publisher-block"/>
+            <text macro="issued-year"/>
+          </group>
+          <text macro="doi-url-access" prefix=". "/>
+        </else-if>
+
+        <else>
+          <text macro="author-initials" suffix=". "/>
+          <text variable="title" suffix=". "/>
+          <group delimiter=", ">
+            <text variable="container-title" font-style="italic"/>
+            <text macro="publisher-block"/>
+            <text macro="issued-year"/>
+          </group>
+          <text macro="doi-url-access" prefix=". "/>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>
+


### PR DESCRIPTION
### Description

Adds an author-date CSL style for Rede de Biodiversidade e Biotecnologia da Amazônia Legal (BIONORTE), based on the BIONORTE 2026 author-date requirements.

Documentation: https://bionorte.org.br/uploads/2025/p12/F334818251668.pdf

Closes #8196.

### Checklist

- [x] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.
- [x] Check that you've added a link to the style guidelines with `rel="documentation"`.
- [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update.
- [x] Check that you've used the correct terms or labels instead of hardcoding into affixes where CSL terms are available.
- [x] Check that you've not used `<text value="...` if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.