### PR TITLE
Update transactions-of-the-philological-society.csl

### DIFF
--- a/transactions-of-the-philological-society.csl
+++ b/transactions-of-the-philological-society.csl
@@ -224,7 +224,7 @@
                 <group delimiter=" ">
                   <text term="volume" form="short"/>
                   <text variable="volume"/>
-                </group>                
+                </group>
               </group>
               <text macro="publisher"/>
             </group>
@@ -234,7 +234,7 @@
               <text macro="title"/>
               <text macro="editor"/>
               <group prefix=" ">
-                <text variable="container-title" font-style="italic"/>                
+                <text variable="container-title" font-style="italic"/>
                 <group delimiter=", ">
                   <group prefix=" ">
                     <text variable="volume" strip-periods="false"/>

--- a/transactions-of-the-philological-society.csl
+++ b/transactions-of-the-philological-society.csl
@@ -19,7 +19,7 @@
     <category field="linguistics"/>
     <issn>0079-1636</issn>
     <eissn>1467-968X</eissn>
-    <updated>2025-09-09T10:18:39+00:00</updated>
+    <updated>2025-09-09T10:27:36+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -89,7 +89,7 @@
       </else-if>
       <else-if type="report" match="any">
         <group delimiter=", ">
-          <text variable="title" quotes="true"/>
+          <text variable="title" prefix="‘" suffix="’"/>
           <text variable="collection-title"/>
           <group delimiter=": ">
             <text variable="publisher-place"/>
@@ -98,13 +98,13 @@
         </group>
       </else-if>
       <else>
-        <text variable="title" quotes="true"/>
+        <text variable="title" prefix="‘" suffix="’"/>
       </else>
     </choose>
     <text variable="original-title" prefix=" [" suffix="]"/>
   </macro>
   <macro name="publisher">
-    <group delimiter=". ">
+    <group delimiter=", ">
       <group delimiter=": ">
         <text variable="publisher-place"/>
         <text variable="publisher"/>
@@ -130,6 +130,16 @@
       <date-part name="day" prefix=" "/>
     </date>
   </macro>
+  <macro name="collection-title">
+    <choose>
+      <if variable="collection-title">
+        <group prefix="(" suffix=")">
+          <text variable="collection-title" text-case="title"/>
+          <text variable="collection-number" prefix=", "/>
+        </group>
+      </if>
+    </choose>
+  </macro>
   <macro name="edition">
     <choose>
       <if is-numeric="edition">
@@ -154,7 +164,7 @@
     </group>
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="false" collapse="year">
-    <layout delimiter="; " prefix="(" suffix=")">
+    <layout delimiter="; " prefix="" suffix="">
       <group vertical-align="baseline" delimiter=": ">
         <group delimiter=" ">
           <text macro="author-short"/>
@@ -192,7 +202,7 @@
             <text macro="title"/>
           </else-if>
           <else-if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
-            <group delimiter=". ">
+            <group delimiter=", ">
               <group delimiter=", ">
                 <text macro="title"/>
                 <text macro="edition"/>
@@ -202,7 +212,7 @@
             </group>
           </else-if>
           <else-if type="chapter paper-conference entry-encyclopedia entry-dictionary" match="any">
-            <group delimiter=". ">
+            <group delimiter=", ">
               <group delimiter=", ">
                 <text macro="title"/>
                 <group delimiter=" ">
@@ -210,11 +220,11 @@
                   <text macro="editor"/>
                 </group>
                 <text variable="container-title" font-style="italic"/>
+                <text macro="collection-title"/>
                 <group delimiter=" ">
                   <text term="volume" form="short"/>
                   <text variable="volume"/>
-                </group>
-                <text variable="collection-title" font-style="italic"/>
+                </group>                
               </group>
               <text macro="publisher"/>
             </group>
@@ -224,11 +234,11 @@
               <text macro="title"/>
               <text macro="editor"/>
               <group prefix=" ">
-                <text variable="container-title" font-style="italic"/>
-                <group delimiter=". ">
+                <text variable="container-title" font-style="italic"/>                
+                <group delimiter=", ">
                   <group prefix=" ">
                     <text variable="volume" strip-periods="false"/>
-                    <text variable="issue" prefix="(" suffix=")"/>
+                    <text variable="issue" prefix="/"/>
                   </group>
                   <text variable="page"/>
                 </group>


### PR DESCRIPTION
I updated the style for the Wiley journal 'Transactions of the Philological Society' (TPhS) according to the current stylesheet of the journal (received directly from the editors). There is a minor discrepancy I'm not able to improve (since I'm a noob):

The book series (collection) is preceded with a parasitic comma, e.g.:

LYONS, JOHN, 1963. Structural Semantics, (Publications of the Philological Society, 20), Oxford: Blackwell.

for correct:

LYONS, JOHN, 1963. Structural Semantics (Publications of the Philological Society, 20), Oxford: Blackwell.
