### PR TITLE
Update american-chemical-society.csl

### DIFF
--- a/american-chemical-society.csl
+++ b/american-chemical-society.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="expanded" default-locale="en-US">
   <info>
-    <title>ACS Guide 2022 revision</title>
+    <title>ACS Guide 2026 revision</title>
     <title-short>American Chemical Society</title-short>
     <id>http://www.zotero.org/styles/american-chemical-society</id>
     <link href="http://www.zotero.org/styles/american-chemical-society" rel="self"/>

--- a/american-chemical-society.csl
+++ b/american-chemical-society.csl
@@ -24,7 +24,7 @@
     <category citation-format="numeric"/>
     <category field="chemistry"/>
     <summary>The American Chemical Society style</summary>
-    <updated>2022-09-19T18:32:56+00:00</updated>
+    <updated>2026-08-25T12:37:10+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -56,7 +56,7 @@
     </group>
   </macro>
   <macro name="author">
-    <names variable="author" suffix=".">
+    <names variable="author">
       <name sort-separator=", " initialize-with=". " name-as-sort-order="all" delimiter="; " delimiter-precedes-last="always"/>
       <label form="short" prefix=", " text-case="capitalize-first"/>
     </names>
@@ -64,10 +64,7 @@
   <macro name="publisher">
     <choose>
       <if type="thesis" match="any">
-        <group delimiter=", ">
-          <text variable="publisher"/>
-          <text variable="publisher-place"/>
-        </group>
+        <text variable="publisher"/>
       </if>
       <else>
         <group delimiter=": ">
@@ -89,7 +86,7 @@
   </macro>
   <macro name="volume">
     <group delimiter=" ">
-      <text term="volume" form="short" text-case="capitalize-first"/>
+      <label variable="volume" form="short" text-case="capitalize-first"/>
       <text variable="volume"/>
     </group>
   </macro>
@@ -97,8 +94,10 @@
     <text variable="collection-title"/>
   </macro>
   <macro name="pages">
-    <label variable="page" form="short" suffix=" " strip-periods="true"/>
-    <text variable="page"/>
+    <group delimiter=" ">
+      <label variable="page" form="short" strip-periods="true"/>
+      <text variable="page"/>
+    </group>
   </macro>
   <macro name="book-container">
     <group delimiter=". ">
@@ -174,129 +173,131 @@
     </layout>
   </citation>
   <bibliography second-field-align="flush" entry-spacing="0">
-    <layout suffix=".">
+    <layout>
       <text variable="citation-number" prefix="(" suffix=")"/>
-      <text macro="author" suffix=" "/>
-      <choose>
-        <if type="article-journal review" match="any">
-          <group delimiter=" ">
-            <text macro="title" suffix="."/>
-            <text variable="container-title" font-style="italic" form="short"/>
+      <group delimiter=". " suffix=".">
+        <text macro="author"/>
+        <choose>
+          <if type="article-journal review" match="any">
+            <group delimiter=" ">
+              <text macro="title" suffix="."/>
+              <text variable="container-title" font-style="italic" form="short"/>
+              <group delimiter=", ">
+                <text macro="issued" font-weight="bold"/>
+                <choose>
+                  <if variable="volume">
+                    <group delimiter=" ">
+                      <text variable="volume" font-style="italic"/>
+                      <text variable="issue" prefix="(" suffix=")"/>
+                    </group>
+                  </if>
+                  <else>
+                    <group delimiter=" ">
+                      <text term="issue" form="short" text-case="capitalize-first"/>
+                      <text variable="issue"/>
+                    </group>
+                  </else>
+                </choose>
+                <text variable="page"/>
+              </group>
+            </group>
+          </if>
+          <else-if type="article-magazine article-newspaper article" match="any">
+            <group delimiter=" ">
+              <text macro="title" suffix="."/>
+              <text variable="container-title" font-style="italic" suffix="."/>
+              <text macro="edition"/>
+              <text macro="publisher"/>
+              <group delimiter=", ">
+                <text macro="full-issued"/>
+                <text macro="pages"/>
+              </group>
+            </group>
+          </else-if>
+          <else-if type="thesis">
             <group delimiter=", ">
-              <text macro="issued" font-weight="bold"/>
+              <group delimiter=". ">
+                <text macro="title"/>
+                <text variable="genre"/>
+              </group>
+              <text macro="publisher"/>
+              <text macro="issued"/>
+              <text macro="volume"/>
+              <text macro="pages"/>
+            </group>
+          </else-if>
+          <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+            <group delimiter="; ">
+              <group delimiter=", ">
+                <text macro="title"/>
+                <text macro="edition"/>
+              </group>
+              <text macro="editor" prefix=" "/>
+              <text macro="series"/>
               <choose>
-                <if variable="volume">
+                <if type="report">
                   <group delimiter=" ">
-                    <text variable="volume" font-style="italic"/>
-                    <text variable="issue" prefix="(" suffix=")"/>
+                    <text variable="genre"/>
+                    <text variable="number"/>
                   </group>
                 </if>
-                <else>
-                  <group delimiter=" ">
-                    <text term="issue" form="short" text-case="capitalize-first"/>
-                    <text variable="issue"/>
-                  </group>
-                </else>
               </choose>
-              <text variable="page"/>
+              <group delimiter=", ">
+                <text macro="publisher"/>
+                <text macro="issued"/>
+              </group>
+              <group delimiter=", ">
+                <text macro="volume"/>
+                <text macro="pages"/>
+              </group>
             </group>
-          </group>
-        </if>
-        <else-if type="article-magazine article-newspaper article" match="any">
-          <group delimiter=" ">
-            <text macro="title" suffix="."/>
-            <text variable="container-title" font-style="italic" suffix="."/>
-            <text macro="edition"/>
-            <text macro="publisher"/>
+          </else-if>
+          <else-if type="patent">
             <group delimiter=", ">
-              <text macro="full-issued"/>
-              <text macro="pages"/>
+              <group delimiter=". ">
+                <text macro="title"/>
+                <text variable="number"/>
+              </group>
+              <date variable="issued" form="text"/>
             </group>
-          </group>
-        </else-if>
-        <else-if type="thesis">
-          <group delimiter=", ">
+          </else-if>
+          <else-if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
+            <group delimiter="; ">
+              <text macro="book-container"/>
+              <text macro="editor"/>
+              <text macro="series"/>
+              <group delimiter=", ">
+                <text macro="publisher"/>
+                <text macro="issued"/>
+              </group>
+              <group delimiter=", ">
+                <text macro="volume"/>
+                <text macro="pages"/>
+              </group>
+            </group>
+          </else-if>
+          <else-if type="webpage post post-weblog" match="any">
             <group delimiter=". ">
-              <text macro="title"/>
-              <text variable="genre"/>
+              <text variable="title" font-style="italic"/>
+              <text variable="container-title"/>
             </group>
-            <text macro="publisher"/>
-            <text macro="issued"/>
-            <text macro="volume"/>
-            <text macro="pages"/>
-          </group>
-        </else-if>
-        <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <group delimiter="; ">
+          </else-if>
+          <else>
             <group delimiter=", ">
-              <text macro="title"/>
-              <text macro="edition"/>
+              <group delimiter=". ">
+                <text macro="title"/>
+                <text variable="container-title" font-style="italic"/>
+              </group>
+              <group delimiter=", ">
+                <text macro="issued"/>
+                <text variable="volume" font-style="italic"/>
+                <text variable="page"/>
+              </group>
             </group>
-            <text macro="editor" prefix=" "/>
-            <text macro="series"/>
-            <choose>
-              <if type="report">
-                <group delimiter=" ">
-                  <text variable="genre"/>
-                  <text variable="number"/>
-                </group>
-              </if>
-            </choose>
-            <group delimiter=", ">
-              <text macro="publisher"/>
-              <text macro="issued"/>
-            </group>
-            <group delimiter=", ">
-              <text macro="volume"/>
-              <text macro="pages"/>
-            </group>
-          </group>
-        </else-if>
-        <else-if type="patent">
-          <group delimiter=", ">
-            <group delimiter=". ">
-              <text macro="title"/>
-              <text variable="number"/>
-            </group>
-            <date variable="issued" form="text"/>
-          </group>
-        </else-if>
-        <else-if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
-          <group delimiter="; ">
-            <text macro="book-container"/>
-            <text macro="editor"/>
-            <text macro="series"/>
-            <group delimiter=", ">
-              <text macro="publisher"/>
-              <text macro="issued"/>
-            </group>
-            <group delimiter=", ">
-              <text macro="volume"/>
-              <text macro="pages"/>
-            </group>
-          </group>
-        </else-if>
-        <else-if type="webpage post post-weblog" match="any">
-          <group delimiter=". ">
-            <text variable="title" font-style="italic"/>
-            <text variable="container-title"/>
-          </group>
-        </else-if>
-        <else>
-          <group delimiter=", ">
-            <group delimiter=". ">
-              <text macro="title"/>
-              <text variable="container-title" font-style="italic"/>
-            </group>
-            <group delimiter=", ">
-              <text macro="issued"/>
-              <text variable="volume" font-style="italic"/>
-              <text variable="page"/>
-            </group>
-          </group>
-        </else>
-      </choose>
-      <text macro="access" prefix=". "/>
+          </else>
+        </choose>
+      </group>
+      <text macro="access" prefix=" "/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
closes #8295

- Removes publisher-place for thesis
- removes trailing dot for DOI/URLs
- minor cleanup

@adunning and @bwiernik 
You recently made a change to the name of the style, but I'm not sure what the year number was based on. Should I update it to `2026`? I'm not confident since I only fixed some issues, but cannot guarentee there are others.