### PR TITLE
label-gun: fix the awaiting label, stop the reopens, handle reviews

### DIFF
--- a/.github/workflows/label-gun.yml
+++ b/.github/workflows/label-gun.yml
@@ -3,22 +3,93 @@ name: 'Automated tagging for PRs and issues'
 on:
   issues:
     types: [opened, edited, closed]
-  pull_request_target:
-    types: [opened, edited, closed]
   issue_comment:
-    types: [created, edited, closed]
+    types: [created, edited]
+  # label-gun cannot handle these -- src/main.ts hard-rejects any event that
+  # isn't 'issues' or 'issue_comment' -- so they go to the 'review' job below.
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
 
 permissions: {}
 
+env:
+  AWAITING: waiting-for-response-from-contributor
+
 jobs:
   label:
+    if: github.event_name == 'issues' || github.event_name == 'issue_comment'
+
     permissions:
       issues: write # to add label to issues (retorquere/label-gun)
       pull-requests: write # to add label, comment on pull request (retorquere/label-gun)
 
     runs-on: ubuntu-latest
     steps:
+      # label-gun reopens a closed issue/PR when a non-maintainer comments on it
+      # (src/app.ts, 'issue_comment.created' && issue.state === 'closed') or closes
+      # it themselves ('issues.closed'), and neither is switchable off in config.
+      # Both paths are reachable only for non-maintainers acting on a closed item,
+      # so resolve the sender's permission here and skip exactly that case.
+      #
+      # The accepted set below is label-gun's own (src/app.ts Collaborators.isOwner)
+      # read off the same REST field, so this gate cannot disagree with how the
+      # action itself classifies the sender.
+      - name: Is the sender a maintainer?
+        id: sender
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SENDER: ${{ github.event.sender.login }}
+        # non-collaborators return 'none'/'read'; bot accounts and deleted users 404
+        run: |
+          permission=$(gh api "repos/$REPO/collaborators/$SENDER/permission" --jq .permission 2>/dev/null || echo none)
+          echo "$SENDER has $permission permission"
+          case "$permission" in
+            admin|maintain|push|triage|write) maintainer=true ;;
+            *)                                maintainer=false ;;
+          esac
+          echo "maintainer=$maintainer" >> "$GITHUB_OUTPUT"
+
       - uses: retorquere/label-gun@v5.0.0
+        # a maintainer never triggers a reopen, and neither does anyone acting on
+        # an item that is still open. Everything else -- contributor comments on a
+        # closed thread, contributor closing their own PR -- is dropped.
+        if: steps.sender.outputs.maintainer == 'true' || github.event.issue.state == 'open'
         with:
           token: ${{ github.token }}
-          label.awaiting: "waiting-for-response-from-contributor"
+          # v5 renamed the dotted inputs; 'label.awaiting' is silently ignored and
+          # leaves the action on its 'awaiting-user-feedback' default.
+          label-awaiting: ${{ env.AWAITING }}
+
+  # A review, and a reply to an inline review comment, are neither 'issues' nor
+  # 'issue_comment', so label-gun never sees them: maintainer reviews did not set
+  # the label, and contributors answering inline could not clear it. No checkout
+  # happens here, so the write token is never exposed to pull request code.
+  review:
+    if: github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment'
+
+    permissions:
+      pull-requests: write # to add/remove the label on the pull request
+
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      PR: ${{ github.event.pull_request.number }}
+      # exactly one of these is set, depending on the event
+      ASSOCIATION: ${{ github.event.review.author_association || github.event.comment.author_association }}
+    steps:
+      - name: Maintainer asked for something
+        # an approval is not waiting on the contributor, so it is left alone
+        if: >-
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), env.ASSOCIATION)
+          && github.event.review.state != 'approved'
+        run: gh pr edit "$PR" --repo "$REPO" --add-label "$AWAITING"
+
+      - name: Someone else responded
+        # mirrors what label-gun does for a non-maintainer comment on an open item
+        if: ${{ !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), env.ASSOCIATION) }}
+        # '|| true' because the label usually isn't there, which is not a failure
+        run: gh pr edit "$PR" --repo "$REPO" --remove-label "$AWAITING" || true

--- a/.github/workflows/label-gun.yml
+++ b/.github/workflows/label-gun.yml
@@ -1,16 +1,15 @@
 name: 'Automated tagging for PRs and issues'
 
+# Reviews are handled by label-on-review.yml, not here: label-gun rejects any
+# event that isn't 'issues' or 'issue_comment' (src/main.ts), and runs on review
+# events attach a check to the pull request, so they are kept out of this file
+# to stop it appearing in the merge box. Comment events attach to the default
+# branch instead, so this workflow stays invisible on a pull request.
 on:
   issues:
     types: [opened, edited, closed]
   issue_comment:
     types: [created, edited]
-  # label-gun cannot handle these -- src/main.ts hard-rejects any event that
-  # isn't 'issues' or 'issue_comment' -- so they go to the 'review' job below.
-  pull_request_review:
-    types: [submitted]
-  pull_request_review_comment:
-    types: [created]
 
 permissions: {}
 
@@ -19,8 +18,6 @@ env:
 
 jobs:
   label:
-    if: github.event_name == 'issues' || github.event_name == 'issue_comment'
-
     permissions:
       issues: write # to add label to issues (retorquere/label-gun)
       pull-requests: write # to add label, comment on pull request (retorquere/label-gun)
@@ -62,34 +59,3 @@ jobs:
           # v5 renamed the dotted inputs; 'label.awaiting' is silently ignored and
           # leaves the action on its 'awaiting-user-feedback' default.
           label-awaiting: ${{ env.AWAITING }}
-
-  # A review, and a reply to an inline review comment, are neither 'issues' nor
-  # 'issue_comment', so label-gun never sees them: maintainer reviews did not set
-  # the label, and contributors answering inline could not clear it. No checkout
-  # happens here, so the write token is never exposed to pull request code.
-  review:
-    if: github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment'
-
-    permissions:
-      pull-requests: write # to add/remove the label on the pull request
-
-    runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ github.token }}
-      REPO: ${{ github.repository }}
-      PR: ${{ github.event.pull_request.number }}
-      # exactly one of these is set, depending on the event
-      ASSOCIATION: ${{ github.event.review.author_association || github.event.comment.author_association }}
-    steps:
-      - name: Maintainer asked for something
-        # an approval is not waiting on the contributor, so it is left alone
-        if: >-
-          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), env.ASSOCIATION)
-          && github.event.review.state != 'approved'
-        run: gh pr edit "$PR" --repo "$REPO" --add-label "$AWAITING"
-
-      - name: Someone else responded
-        # mirrors what label-gun does for a non-maintainer comment on an open item
-        if: ${{ !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), env.ASSOCIATION) }}
-        # '|| true' because the label usually isn't there, which is not a failure
-        run: gh pr edit "$PR" --repo "$REPO" --remove-label "$AWAITING" || true

--- a/.github/workflows/label-on-review.yml
+++ b/.github/workflows/label-on-review.yml
@@ -1,0 +1,46 @@
+name: 'Awaiting-contributor label on review'
+
+# label-gun never sees reviews -- src/main.ts rejects any event that isn't
+# 'issues' or 'issue_comment' -- so the awaiting label is maintained here for
+# review activity, matching what label-gun does for an ordinary comment.
+#
+# Deliberately NOT subscribed to pull_request_review_comment. Every inline
+# comment and every threaded reply is wrapped by GitHub in an implicit
+# COMMENTED review, so pull_request_review.submitted already fires for them and
+# the second subscription only duplicates runs -- one per inline comment, each
+# one a check on the pull request. Verified on
+# citation-style-language/style-workflow-testing#5.
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions: {}
+
+jobs:
+  # This is an operation, not a test, but any workflow run on a review event
+  # attaches a check run to the pull request head and there is no way to opt
+  # out -- so keep it to a single job with a name that reads as what it does.
+  label:
+    permissions:
+      pull-requests: write # to add/remove the label on the pull request
+
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      PR: ${{ github.event.pull_request.number }}
+      ASSOCIATION: ${{ github.event.review.author_association }}
+      AWAITING: waiting-for-response-from-contributor
+    steps:
+      - name: Maintainer asked for something
+        # an approval is not waiting on the contributor, so it is left alone
+        if: >-
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), env.ASSOCIATION)
+          && github.event.review.state != 'approved'
+        run: gh pr edit "$PR" --repo "$REPO" --add-label "$AWAITING"
+
+      - name: Someone else responded
+        # mirrors what label-gun does for a non-maintainer comment on an open item
+        if: ${{ !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), env.ASSOCIATION) }}
+        # '|| true' because the label usually isn't there, which is not a failure
+        run: gh pr edit "$PR" --repo "$REPO" --remove-label "$AWAITING" || true

--- a/.github/workflows/label-on-review.yml
+++ b/.github/workflows/label-on-review.yml
@@ -1,5 +1,25 @@
 name: 'Awaiting-contributor label on review'
 
+# SECURITY: pull_request_review is a privileged trigger. Like pull_request_target
+# it runs in the base repository's context, with a writable token and access to
+# secrets, including for pull requests from forks. Three properties keep that
+# harmless, and all three have to survive future edits to this file:
+#
+#   1. Nothing is checked out, so pull request code is never fetched, let alone
+#      executed. Do not add actions/checkout here. sheldon.yaml already tests
+#      pull requests and documents what that costs to do safely.
+#   2. There are no 'uses:' at all -- every step is plain 'gh' from the runner
+#      image -- so there is no third-party action here that could reach the
+#      token. Do not add one. The repository action allowlist enforces this, but
+#      that is a setting someone can widen; this comment is the reason not to.
+#   3. No pull-request-controlled text reaches a shell. The review body is never
+#      read; the values that are used -- author_association, the PR number --
+#      are computed by GitHub, not supplied by the author. Interpolating
+#      ${{ github.event.review.body }} into a run: step would be a script
+#      injection with a writable token behind it.
+#
+# https://securitylab.github.com/research/github-actions-preventing-pwn-requests
+
 # label-gun never sees reviews -- src/main.ts rejects any event that isn't
 # 'issues' or 'issue_comment' -- so the awaiting label is maintained here for
 # review activity, matching what label-gun does for an ordinary comment.


### PR DESCRIPTION
Three separate problems in `label-gun.yml`, plus the review handling that #8269 asked for.

### 1. `label.awaiting` has been a dead input since the v5 bump

e829310 bumped label-gun v4.0.11 → v5.0.0, which renamed every dotted input (`label.awaiting` → `label-awaiting`). Every run since logs:

```
##[warning]Unexpected input(s) 'label.awaiting', valid inputs are [... 'label-awaiting' ...]
  label.awaiting: waiting-for-response-from-contributor   <- ignored
  label-awaiting: awaiting-user-feedback                  <- the default, used
```

So the action has been applying its own `awaiting-user-feedback` default, not ours. That accounts for the grey, description-less `awaiting-user-feedback` label that appeared in the label list; the 12 issues/PRs carrying it have been sorted out separately and the label deleted.

### 2. `pull_request_target` can never work

a25eb6f6 added it, but label-gun's [`src/main.ts`](https://github.com/retorquere/label-gun/blob/v5.0.0/src/main.ts#L95) hard-rejects anything that isn't `issues` or `issue_comment`:

```js
if (!['issues', 'issue_comment'].includes(context.eventName)) {
  throw new Error(`Unexpected event ${context.eventName}`)
}
```

Every PR opened/edited/closed since has been a red cross (e.g. [run 33303759368](https://github.com/citation-style-language/styles/actions/runs/33303759368): `##[error]Unexpected event pull_request_target`). Even past that guard the payload has no `issue` key, so it would throw again. Removed — PR comments already reach the action as `issue_comment`, so nothing is lost.

### 3. The reopens

[`src/app.ts`](https://github.com/retorquere/label-gun/blob/v5.0.0/src/app.ts#L263-L288) reopens a closed thread down two paths, both in the `!sender.owner` branch:

- a non-maintainer comments on a closed issue/PR — unconditional, no config involved
- a non-maintainer closes an issue/PR themselves, unless it carries a `labels.reopened`/`labels.canClose` label or no maintainer ever participated

Neither is switchable off. `labels.exempt`/`labels.active` are the only kill switches and they disable the whole action.

It fires a lot. Over the last 60 issues and 60 PRs: #8252 reopened by `github-actions` five times, #7720 / #7910 / #7854 three or four times each, ~30 more across #7590–#8107. The other recent red run is this too — on #8225 it tried to reopen an **already-merged** PR and got `Validation Failed` back from the API.

Both paths are reachable only for a non-maintainer acting on an already-closed item, so this adds a step that resolves the sender's permission and gates the action on it:

```yaml
if: steps.sender.outputs.maintainer == 'true' || github.event.issue.state == 'open'
```

| | |
|---|---|
| contributor comments, item open | runs — clears the label, as now |
| contributor comments, item closed | **skipped — no reopen** |
| contributor closes their own PR | **skipped — no reopen** |
| maintainer closes | runs — strips the awaiting label |
| maintainer comments, either state | runs, as now |

The permission set the gate accepts (`admin|maintain|push|triage|write`) is copied from label-gun's own `Collaborators.isOwner` and read off the same REST field, so the gate cannot disagree with how the action classifies the sender. That call already happens inside the action under this token, so no permission change was needed.

One thing this gives up: a contributor commenting on a closed thread no longer gets the awaiting label stripped, because the action doesn't run at all. That only affects already-closed items.

### 4. Reviews — supersedes #8269

`pull_request_review` and `pull_request_review_comment` hit the same guard as (2), so label-gun never sees them. Two gaps followed: a maintainer review didn't set the label, and — the less obvious half — a contributor **replying to an inline review comment** fires `pull_request_review_comment`, not `issue_comment`, so it couldn't clear the label either.

Added as a separate `review` job, taking @POBrien333's `author_association` gate from #8269 and adding the reverse direction:

- maintainer review or inline comment → add the label, **except** on `approved` (an approval isn't waiting on the contributor). Easy to flip if you'd rather approvals cleared it.
- anyone else → remove it, mirroring what label-gun does for a non-maintainer comment

No checkout happens in this workflow, so unlike `sheldon.yaml` the write token is never exposed to pull request code.

Note this is chatty: a review with N inline comments fires N+1 runs. They're idempotent, and the alternative is dropping `pull_request_review_comment` and losing the contributor-reply half.

### Also

Dropped `closed` from the `issue_comment` types — not a valid activity type for that event (only `created`/`edited`/`deleted`), so it was a no-op.

### Upstream

(3) and (4) are workarounds for gaps that belong in the action rather than here. Both are worth raising with @retorquere — a switch to opt out of the reopen, and review-event support — and if they land, both the gate step and the `review` job can be deleted.
