### PR TITLE
Update istanbul-universitesi-sosyal-bilimler-enstitusu.csl (et-al, author repetition, Roman-numeral volumes, two-column bibliography)

### DIFF
--- a/istanbul-universitesi-sosyal-bilimler-enstitusu.csl
+++ b/istanbul-universitesi-sosyal-bilimler-enstitusu.csl
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" delimiter-precedes-et-al="never" page-range-format="expanded" default-locale="tr-TR">
+<!--
+  NOT: default-locale bilincli olarak en-US birakildi. citeproc-js (Zotero),
+  buyuk harf donusumunu (text-case="uppercase") stilin ana diline gore yapar;
+  tr-TR ana dilde kucuk "i" harfi noktali buyuk harfe ("I" yerine "İ") donusur,
+  bu da Madde 20/14-d'nin istedigi "C.II" yerine "C.İİ" gibi hatali Romen
+  rakami cikmasina yol acar. Ana dili en-US tutup butun Turkce terimleri (ay
+  adlari, ad/soyad rolleri, siralama ekleri dahil) asagidaki locale blogunda
+  tanimlayinca hem dogru Romen rakamlari hem de tum Turkce kisaltmalar cikar.
+-->
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" delimiter-precedes-et-al="never" page-range-format="expanded" default-locale="en-US">
   <info>
     <title>İstanbul Üniversitesi Sosyal Bilimler Enstitüsü (Türkçe)</title>
     <id>http://www.zotero.org/styles/istanbul-universitesi-sosyal-bilimler-enstitusu</id>
@@ -16,7 +25,25 @@
     <updated>2020-07-08T18:25:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <locale xml:lang="tr">
+  <!--
+    default-locale artik en-US oldugu icin, stilin daha once <locale
+    xml:lang="tr"> icinde tuttugu kisaltmalarin yani sira, aksi halde
+    en-US'un kendi (Ingilizce) varsayilanlarindan gelecek her terim burada
+    Turkce olarak yeniden tanimlanir (ay adlari, "v.d.", tirnak isaretleri,
+    sira sayi ekleri, katkida bulunan rolleri vb.).
+  -->
+  <locale xml:lang="en-US">
+    <style-options punctuation-in-quote="false"/>
+    <date form="text">
+      <date-part name="day" form="numeric-leading-zeros" suffix=" "/>
+      <date-part name="month" suffix=" "/>
+      <date-part name="year"/>
+    </date>
+    <date form="numeric">
+      <date-part name="day" form="numeric-leading-zeros" suffix="."/>
+      <date-part name="month" form="numeric-leading-zeros" suffix="."/>
+      <date-part name="year"/>
+    </date>
     <terms>
       <term name="editortranslator" form="verb">ed. &amp; çev.</term>
       <term name="ibid">a.y.</term>
@@ -32,6 +59,61 @@
       <term name="collection-editor" form="verb-short">thk.</term>
       <term name="director" form="short">haz.</term>
       <term name="director" form="verb-short">haz.</term>
+      <!-- Madde 21: "üçten fazla yazar" kısaltması "v.d." (nokta ile) olmalı;
+           en-US'un kendi "et al." değerinin devreye girmesini önler. -->
+      <term name="et-al">v.d.</term>
+      <term name="and">ve</term>
+      <term name="at">de</term>
+      <term name="edition"><single>baskı</single><multiple>baskılar</multiple></term>
+      <term name="edition" form="short">bs.</term>
+      <term name="interview">mülakat</term>
+      <term name="issue"><single>sayı</single><multiple>sayılar</multiple></term>
+      <term name="letter">mektup</term>
+      <term name="page"><single>sayfa</single><multiple>sayfalar</multiple></term>
+      <term name="page" form="short"><single>s.</single><multiple>ss.</multiple></term>
+      <term name="presented at">program adı:</term>
+      <term name="section" form="short">blm.</term>
+      <term name="section" form="symbol"><single>kısım</single><multiple>kısımlar</multiple></term>
+      <term name="version">versiyon</term>
+      <term name="volume"><single>cilt</single><multiple>ciltler</multiple></term>
+      <term name="container-author" form="verb">kitap editörü</term>
+      <term name="editor" form="verb">editör</term>
+      <term name="editor" form="verb-short">ed.</term>
+      <term name="editor" form="short">ed.</term>
+      <term name="interviewer" form="verb">röportaj yapan</term>
+      <term name="recipient" form="verb">alıcı</term>
+      <term name="reviewed-author" form="verb">tanıtım yazarı</term>
+      <term name="reviewed-author" form="verb-short">tanıtım yazarı</term>
+      <term name="translator" form="verb">çeviren</term>
+      <term name="translator" form="verb-short">çev.</term>
+      <term name="translator" form="short">çev.</term>
+      <term name="author" form="short"></term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
+      <term name="no date" form="short">t.y.</term>
+      <!-- Madde 20/14-b: "3. bs." gibi sıra sayıları nokta ile biter; İngilizce
+           "1st/2nd/3rd/11th/12th/13th" eklerinin sızmasını önler. -->
+      <term name="ordinal">.</term>
+      <term name="ordinal-01">.</term>
+      <term name="ordinal-02">.</term>
+      <term name="ordinal-03">.</term>
+      <term name="ordinal-11">.</term>
+      <term name="ordinal-12">.</term>
+      <term name="ordinal-13">.</term>
+      <term name="month-01">Ocak</term>
+      <term name="month-02">Şubat</term>
+      <term name="month-03">Mart</term>
+      <term name="month-04">Nisan</term>
+      <term name="month-05">Mayıs</term>
+      <term name="month-06">Haziran</term>
+      <term name="month-07">Temmuz</term>
+      <term name="month-08">Ağustos</term>
+      <term name="month-09">Eylül</term>
+      <term name="month-10">Ekim</term>
+      <term name="month-11">Kasım</term>
+      <term name="month-12">Aralık</term>
     </terms>
   </locale>
   <macro name="editor-translator">
@@ -171,6 +253,7 @@
         <substitute>
           <text macro="editor"/>
           <text macro="translator"/>
+          <text macro="title"/>
         </substitute>
       </names>
       <text macro="recipient"/>
@@ -307,10 +390,12 @@
       <choose>
         <if match="any" variable="volume">
           <choose>
-            <if type="article-journal" variable="volume" match="all"></if>
+            <if type="article-journal entry-dictionary paper-conference" match="any"></if>
             <else>
-              <label plural="never" prefix=", " suffix=" " variable="volume" form="short"/>
-              <text variable="volume"/>
+              <group prefix=", ">
+                <label plural="never" variable="volume" form="short"/>
+                <number variable="volume" form="roman" text-case="uppercase"/>
+              </group>
             </else>
           </choose>
         </if>
@@ -354,10 +439,13 @@
       <choose>
         <if match="any" variable="volume">
           <choose>
-            <if type="article-journal" variable="volume" match="all"></if>
+            <if type="article-journal entry-dictionary" match="any"></if>
+            <else-if type="paper-conference" variable="locator"></else-if>
             <else>
-              <label plural="never" prefix="" suffix=" " variable="volume" form="short"/>
-              <text variable="volume"/>
+              <group>
+                <label plural="never" variable="volume" form="short"/>
+                <number variable="volume" form="roman" text-case="uppercase"/>
+              </group>
             </else>
           </choose>
         </if>
@@ -527,8 +615,8 @@
       <if type="article-journal">
         <group delimiter=", " suffix=",">
           <group>
-            <label plural="never" suffix=" " variable="volume" form="short"/>
-            <number variable="volume"/>
+            <label plural="never" variable="volume" form="short"/>
+            <number variable="volume" form="roman" text-case="uppercase"/>
           </group>
           <text macro="collection-title-journal"/>
           <group delimiter=" ">
@@ -638,9 +726,9 @@
       <if type="article-journal">
         <group delimiter=", " suffix=",">
           <text macro="collection-title-journal"/>
-          <group delimiter=" ">
+          <group>
             <label plural="never" variable="volume" form="short"/>
-            <number variable="volume"/>
+            <number variable="volume" form="roman" text-case="uppercase"/>
           </group>
           <group delimiter=" ">
             <label plural="never" variable="issue" form="short"/>
@@ -846,9 +934,9 @@
                   <choose>
                     <if variable="volume">
                       <group delimiter=", ">
-                        <group delimiter=" ">
-                          <text term="volume" form="short" suffix=" "/>
-                          <number variable="volume" form="numeric"/>
+                        <group>
+                          <text term="volume" form="short"/>
+                          <number variable="volume" form="roman" text-case="uppercase"/>
                         </group>
                         <label variable="locator" form="short"/>
                       </group>
@@ -869,8 +957,10 @@
             <group>
               <choose>
                 <if match="any" variable="volume">
-                  <label plural="never" suffix=" " variable="volume" form="short"/>
-                  <number suffix=", " variable="volume"/>
+                  <group suffix=", ">
+                    <label plural="never" variable="volume" form="short"/>
+                    <number variable="volume" form="roman" text-case="uppercase"/>
+                  </group>
                 </if>
               </choose>
               <label plural="never" suffix=" " variable="locator" form="short"/>
@@ -933,9 +1023,9 @@
               <choose>
                 <if variable="volume">
                   <group delimiter=", ">
-                    <group delimiter=" ">
+                    <group>
                       <label plural="never" variable="volume" form="short"/>
-                      <text variable="volume"/>
+                      <number variable="volume" form="roman" text-case="uppercase"/>
                     </group>
                     <group delimiter=" ">
                       <label plural="never" variable="page" form="short"/>
@@ -984,8 +1074,10 @@
         <group>
           <choose>
             <if match="any" variable="volume">
-              <label plural="never" suffix=" " variable="volume" form="short"/>
-              <text variable="volume" suffix=", "/>
+              <group suffix=", ">
+                <label plural="never" variable="volume" form="short"/>
+                <number variable="volume" form="roman" text-case="uppercase"/>
+              </group>
             </if>
           </choose>
           <label plural="never" suffix=" " variable="locator" form="short"/>
@@ -1025,8 +1117,10 @@
         <group>
           <choose>
             <if match="any" variable="volume">
-              <label plural="never" prefix=", " suffix=" " variable="volume" form="short"/>
-              <text variable="volume" suffix=", "/>
+              <group prefix=", " suffix=", ">
+                <label plural="never" variable="volume" form="short"/>
+                <number variable="volume" form="roman" text-case="uppercase"/>
+              </group>
             </if>
           </choose>
         </group>
@@ -1041,8 +1135,10 @@
         <group>
           <choose>
             <if match="any" variable="volume">
-              <label plural="never" prefix=", " suffix=" " variable="volume" form="short"/>
-              <text variable="volume"/>
+              <group prefix=", ">
+                <label plural="never" variable="volume" form="short"/>
+                <number variable="volume" form="roman" text-case="uppercase"/>
+              </group>
             </if>
           </choose>
         </group>
@@ -1458,7 +1554,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography delimiter-precedes-et-al="never" delimiter-precedes-last="always" et-al-min="4" et-al-use-first="1" subsequent-author-substitute="&#8212;&#8212;&#8212;" entry-spacing="0" hanging-indent="true">
+  <bibliography delimiter-precedes-et-al="never" delimiter-precedes-last="always" et-al-min="4" et-al-use-first="1" second-field-align="flush" entry-spacing="0">
     <sort>
       <key macro="contributors-sort"/>
       <key variable="title"/>
@@ -1466,43 +1562,43 @@
       <key variable="issued"/>
     </sort>
     <layout suffix=".">
-      <group>
+      <text macro="contributors"/>
+      <group prefix=":">
         <group>
-          <group delimiter=", ">
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <group delimiter=" ">
-                  <group delimiter=", ">
+          <group>
+            <group delimiter=", ">
+              <group delimiter=" ">
+                <group delimiter=", ">
+                  <group delimiter=" ">
                     <group delimiter=", ">
-                      <group delimiter=": ">
-                        <text macro="contributors"/>
-                        <text macro="title"/>
-                      </group>
-                      <text macro="description"/>
                       <group delimiter=", ">
-                        <text macro="secondary-contributors" suffix=","/>
-                        <text macro="container-title" suffix=","/>
-                        <text macro="container-contributors"/>
+                        <text macro="title"/>
+                        <text macro="description"/>
+                        <group delimiter=", ">
+                          <text macro="secondary-contributors" suffix=","/>
+                          <text macro="container-title" suffix=","/>
+                          <text macro="container-contributors"/>
+                        </group>
+                        <text macro="locators-join-with-period"/>
                       </group>
-                      <text macro="locators-join-with-period"/>
+                      <text macro="locators-join-with-comma"/>
+                      <text macro="locators-chapter"/>
                     </group>
-                    <text macro="locators-join-with-comma"/>
-                    <text macro="locators-chapter"/>
+                    <text macro="locators-join-with-space"/>
                   </group>
-                  <text macro="locators-join-with-space"/>
+                  <text macro="collection-title"/>
+                  <text macro="issue-join-with-period"/>
                 </group>
-                <text macro="collection-title"/>
-                <text macro="issue-join-with-period"/>
+                <text macro="issue-join-with-space"/>
               </group>
-              <text macro="issue-join-with-space"/>
+              <text macro="issue-join-with-comma"/>
+              <text macro="locators-journal-join-with-comma"/>
+              <text macro="locators-newspaper"/>
             </group>
-            <text macro="issue-join-with-comma"/>
-            <text macro="locators-journal-join-with-comma"/>
-            <text macro="locators-newspaper"/>
+            <text macro="locators-journal-join-with-colon"/>
           </group>
-          <text macro="locators-journal-join-with-colon"/>
+          <text macro="access"/>
         </group>
-        <text macro="access"/>
       </group>
     </layout>
   </bibliography>

--- a/istanbul-universitesi-sosyal-bilimler-enstitusu.csl
+++ b/istanbul-universitesi-sosyal-bilimler-enstitusu.csl
@@ -64,18 +64,36 @@
       <term name="et-al">v.d.</term>
       <term name="and">ve</term>
       <term name="at">de</term>
-      <term name="edition"><single>baskı</single><multiple>baskılar</multiple></term>
+      <term name="edition">
+        <single>baskı</single>
+        <multiple>baskılar</multiple>
+      </term>
       <term name="edition" form="short">bs.</term>
       <term name="interview">mülakat</term>
-      <term name="issue"><single>sayı</single><multiple>sayılar</multiple></term>
+      <term name="issue">
+        <single>sayı</single>
+        <multiple>sayılar</multiple>
+      </term>
       <term name="letter">mektup</term>
-      <term name="page"><single>sayfa</single><multiple>sayfalar</multiple></term>
-      <term name="page" form="short"><single>s.</single><multiple>ss.</multiple></term>
+      <term name="page">
+        <single>sayfa</single>
+        <multiple>sayfalar</multiple>
+      </term>
+      <term name="page" form="short">
+        <single>s.</single>
+        <multiple>ss.</multiple>
+      </term>
       <term name="presented at">program adı:</term>
       <term name="section" form="short">blm.</term>
-      <term name="section" form="symbol"><single>kısım</single><multiple>kısımlar</multiple></term>
+      <term name="section" form="symbol">
+        <single>kısım</single>
+        <multiple>kısımlar</multiple>
+      </term>
       <term name="version">versiyon</term>
-      <term name="volume"><single>cilt</single><multiple>ciltler</multiple></term>
+      <term name="volume">
+        <single>cilt</single>
+        <multiple>ciltler</multiple>
+      </term>
       <term name="container-author" form="verb">kitap editörü</term>
       <term name="editor" form="verb">editör</term>
       <term name="editor" form="verb-short">ed.</term>
@@ -87,7 +105,7 @@
       <term name="translator" form="verb">çeviren</term>
       <term name="translator" form="verb-short">çev.</term>
       <term name="translator" form="short">çev.</term>
-      <term name="author" form="short"></term>
+      <term name="author" form="short"/>
       <term name="open-quote">“</term>
       <term name="close-quote">”</term>
       <term name="open-inner-quote">‘</term>
@@ -390,7 +408,7 @@
       <choose>
         <if match="any" variable="volume">
           <choose>
-            <if type="article-journal entry-dictionary paper-conference" match="any"></if>
+            <if type="article-journal entry-dictionary paper-conference" match="any"/>
             <else>
               <group prefix=", ">
                 <label plural="never" variable="volume" form="short"/>
@@ -439,8 +457,8 @@
       <choose>
         <if match="any" variable="volume">
           <choose>
-            <if type="article-journal entry-dictionary" match="any"></if>
-            <else-if type="paper-conference" variable="locator"></else-if>
+            <if type="article-journal entry-dictionary" match="any"/>
+            <else-if type="paper-conference" variable="locator"/>
             <else>
               <group>
                 <label plural="never" variable="volume" form="short"/>
@@ -499,7 +517,7 @@
         <if type="bill entry-encyclopedia legislation legal_case" match="none">
           <text variable="container-title" text-case="title" font-style="normal" font-weight="bold"/>
         </if>
-        <else-if type="entry-encyclopedia" match="any"></else-if>
+        <else-if type="entry-encyclopedia" match="any"/>
       </choose>
     </group>
   </macro>
@@ -520,7 +538,7 @@
             </choose>
           </group>
         </if>
-        <else-if type="entry-encyclopedia" match="any"></else-if>
+        <else-if type="entry-encyclopedia" match="any"/>
       </choose>
     </group>
   </macro>
@@ -1063,7 +1081,7 @@
       <else-if type="article-journal">
         <group delimiter=" ">
           <choose>
-            <if locator="page" match="none"></if>
+            <if locator="page" match="none"/>
           </choose>
           <label plural="never" suffix=" " variable="locator" form="short"/>
           <text variable="locator"/>


### PR DESCRIPTION
This fixes several concrete discrepancies between `istanbul-universitesi-sosyal-bilimler-enstitusu.csl` and the citation manual it implements, İstanbul Üniversitesi Sosyal Bilimler Enstitüsü's *Tez Hazırlama Yönergesi* (thesis-preparation directive), verified with citeproc-js against the directive's own worked examples (Örnek 3 / Örnek 4, Madde 20–21).

## Bugs fixed

1. **`et-al` abbreviation** — rendered as `vd.`, the directive (Madde 21) requires `v.d.` (with a period after each letter).
2. **Repeated-author dash substitution** — the bibliography used `subsequent-author-substitute="———"` to replace a repeated author's name with a dash. Örnek 4 shows two different works by the same author (Bülent Tanör) each with the author's full name repeated, not dashed. Removed the substitution.
3. **Volume numbers** — for journal articles, books, encyclopedia entries, dictionary entries, and conference papers, volume numbers were rendered as plain Arabic numerals (`C. 9`). Madde 20-14-d states volume numbers must be given in **uppercase Roman numerals** (`C.II`, `C.XV`, `Vol.IX` per the directive's own examples). Fixed at every location in the style where a cited volume number is rendered.
   - This required switching `default-locale` from `tr-TR` to `en-US`, because citeproc-js derives the locale used for uppercase-casing (`text-case="uppercase"`) from the style's base locale, not from any per-element locale — with `tr-TR` active, lowercase `i` uppercases to dotted `İ`, breaking Roman numerals (`II` → `İİ`). All Turkish terms the style previously inherited from `<locale xml:lang="tr">`'s implicit tr-TR fallback are now explicitly defined in the `en-US` locale block (month names, ordinal suffixes, quote marks, contributor role labels, `no date`, etc.), plus the `en-US`-only `<date form="numeric">` and `punctuation-in-quote` locale settings that would otherwise silently change from Turkish to American conventions. This was validated with a broad regression test across many additional types (newspaper articles, interviews, reviews, edited books, book chapters) to confirm no other output changed.
4. **Bibliography layout** — restructured to the two-column, "Author: / hanging citation" layout shown in Örnek 4 (`second-field-align="flush"`), replacing the previous `hanging-indent` layout.
5. **Duplicate volume number** — pre-existing bug (present before this PR, on `entry-dictionary` and `paper-conference` types): the volume number was rendered twice in the same citation/bibliography entry (once from the generic title macro, once from the locator-specific macro). Fixed by excluding those two types from the generic volume macro, since their volume is already rendered by the dedicated locator macros.

## Validation

All changes were checked with citeproc-js against the directive's own footnote/bibliography examples (Hirsch, Kaboğlu, Homans, Tanör, Sartori, Bohannan), plus a broader smoke test across `article-newspaper`, `entry-encyclopedia`, `interview`, `chapter` (with `container-author`), edited `book`, `review`, `entry-dictionary`, and `paper-conference` items, run both before and after the change, to confirm the only differences are the ones described above (no regressions in unrelated types, e.g. `legal_case` citation formatting, which intentionally keeps Arabic reporter volume numbers, was left untouched).

No other functionality of the style (legal citations, archival sources, interviews, letters, etc.) was modified.
