### PR TITLE
Add STAI Al-Anwar Sarang citation style

### DIFF
--- a/stai-al-anwar-sarang.csl
+++ b/stai-al-anwar-sarang.csl
@@ -1,0 +1,919 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="id-ID">
+  <info>
+    <title>STAI Al-Anwar Sarang - Al-Anwar Citation Style (Bahasa Indonesia)</title>
+    <title-short>ACS; Al-Anwar Citation Style; STAI Al-Anwar Sarang Rembang</title-short>
+    <id>http://www.zotero.org/styles/stai-al-anwar-sarang</id>
+    <link href="http://www.zotero.org/styles/stai-al-anwar-sarang" rel="self"/>
+    <link href="https://staialanwar.ac.id/acs/" rel="documentation"/>
+    <author>
+      <name>STAI Al-Anwar Sarang / IMLA Institute</name>
+    </author>
+    <author>
+      <name>Mohammad Muafi Himam</name>
+      <uri>https://github.com/masmuafi</uri>
+    </author>
+    <category citation-format="note"/>
+    <category field="theology"/>
+    <updated>2026-09-03T07:26:45+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <!-- ============================================================
+       LOCALE — override English defaults with Indonesian/institutional terms
+  ============================================================ -->
+  <locale xml:lang="id">
+    <terms>
+      <term name="in">dalam</term>
+      <term name="editor" form="short">
+        <single>Ed.</single>
+        <multiple>Eds.</multiple>
+      </term>
+      <term name="translator" form="short">
+        <single>terj.</single>
+        <multiple>terj.</multiple>
+      </term>
+      <term name="accessed">diakses pada tanggal</term>
+      <!-- "Ibid" diketik tegak (upright), bukan miring -->
+      <term name="ibid">Ibid</term>
+      <!-- Institutional convention: "et. al." (with period after et) -->
+      <term name="et-al">et. al.</term>
+      <term name="volume" form="short">Jil.</term>
+      <term name="issue" form="short">No.</term>
+      <!-- Label halaman dihilangkan: nomor halaman tampil langsung tanpa "hal." -->
+      <term name="page" form="short">
+        <single/>
+        <multiple/>
+      </term>
+      <term name="no date" form="short">t.th.</term>
+      <term name="interview">Wawancara</term>
+      <term name="folio" form="short">
+        <single>fol.</single>
+        <multiple>fol.</multiple>
+      </term>
+      <!-- Nama bulan Bahasa Indonesia — didefinisikan eksplisit agar tidak
+           bergantung pada kelengkapan locale id-ID bawaan aplikasi (mis. Mendeley) -->
+      <term name="month-01">Januari</term>
+      <term name="month-02">Februari</term>
+      <term name="month-03">Maret</term>
+      <term name="month-04">April</term>
+      <term name="month-05">Mei</term>
+      <term name="month-06">Juni</term>
+      <term name="month-07">Juli</term>
+      <term name="month-08">Agustus</term>
+      <term name="month-09">September</term>
+      <term name="month-10">Oktober</term>
+      <term name="month-11">November</term>
+      <term name="month-12">Desember</term>
+    </terms>
+  </locale>
+  <!-- ============================================================
+       MACROS
+  ============================================================ -->
+  <!-- Nama pengarang TIDAK dibalik — untuk catatan kaki -->
+  <macro name="author-note">
+    <names variable="author">
+      <name and="text" delimiter-precedes-last="never" initialize="false" delimiter=", "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text variable="title" form="short"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- Nama pengarang DIBALIK, pengarang pertama saja — untuk bibliografi -->
+  <macro name="author-bib">
+    <names variable="author">
+      <name and="text" delimiter-precedes-last="never" name-as-sort-order="first" sort-separator=", " initialize="false" delimiter=", "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text variable="title" form="short"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- Nama belakang saja — untuk kutipan berikutnya (subsequent) -->
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="text" delimiter-precedes-last="never" delimiter=", "/>
+      <substitute>
+        <names variable="editor"/>
+        <text variable="title" form="short"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- Nama editor, tidak dibalik — untuk tampilan inline -->
+  <macro name="editor-note">
+    <names variable="editor">
+      <name and="text" delimiter-precedes-last="never" initialize="false" delimiter=", "/>
+    </names>
+  </macro>
+  <!-- Nama penerjemah, tidak dibalik — untuk tampilan inline -->
+  <macro name="translator-note">
+    <names variable="translator">
+      <name and="text" delimiter-precedes-last="never" initialize="false" delimiter=", "/>
+    </names>
+  </macro>
+  <!-- "terj. [Nama]" — kondisi terjemahan; dipakai di buku catatan kaki & bibliografi -->
+  <macro name="translator-block">
+    <choose>
+      <if variable="translator">
+        <group delimiter=" ">
+          <text term="translator" form="short"/>
+          <text macro="translator-note"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <!-- Editor dengan et.al. — untuk ensiklopedi catatan kaki & bibliografi -->
+  <macro name="editor-etal">
+    <names variable="editor">
+      <label form="short" text-case="lowercase" suffix=" "/>
+      <name and="text" et-al-min="2" et-al-use-first="1" delimiter-precedes-last="never" initialize="false"/>
+      <et-al/>
+    </names>
+  </macro>
+  <!-- "Jil. X" — hanya muncul jika field volume diisi -->
+  <macro name="volume">
+    <choose>
+      <if variable="volume">
+        <group delimiter=" ">
+          <text term="volume" form="short"/>
+          <number variable="volume"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <!-- Judul pendek untuk kutipan berikutnya (subsequent/op.cit) -->
+  <macro name="title-short">
+    <choose>
+      <if type="book thesis report manuscript" match="any">
+        <text variable="title" form="short" font-style="italic"/>
+      </if>
+      <else>
+        <text variable="title" form="short" quotes="true"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Locator dengan label dinamis: nomor halaman tampil polos (tanpa "hal.");
+       "fol." tetap tampil untuk locator bertipe Folio. Hanya muncul jika
+       locator diisi. Pilih tipe locator di dropdown Zotero (Page / Folio /
+       Column / dll.) agar label tampil otomatis untuk tipe selain Page. -->
+  <macro name="locator-p">
+    <choose>
+      <if variable="locator">
+        <group delimiter=" ">
+          <label variable="locator" form="short"/>
+          <text variable="locator"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <!-- Blok penerbit sebagai kurung: (Tempat: Penerbit, Tahun)
+       Otomatis pakai t.tp. / t.np. / t.th. jika field kosong -->
+  <macro name="pub-paren">
+    <group>
+      <text value="("/>
+      <choose>
+        <if variable="publisher-place">
+          <text variable="publisher-place"/>
+        </if>
+        <else>
+          <text value="t.tp."/>
+        </else>
+      </choose>
+      <text value=": "/>
+      <choose>
+        <if variable="publisher">
+          <text variable="publisher"/>
+        </if>
+        <else>
+          <text value="t.np."/>
+        </else>
+      </choose>
+      <text value=", "/>
+      <choose>
+        <if variable="issued">
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </if>
+        <else>
+          <text term="no date" form="short"/>
+        </else>
+      </choose>
+      <text value=")"/>
+    </group>
+  </macro>
+  <!-- Blok penerbit untuk bibliografi: Tempat: Penerbit, Tahun -->
+  <macro name="pub-bib">
+    <group>
+      <choose>
+        <if variable="publisher-place">
+          <text variable="publisher-place"/>
+        </if>
+        <else>
+          <text value="t.tp."/>
+        </else>
+      </choose>
+      <text value=": "/>
+      <choose>
+        <if variable="publisher">
+          <text variable="publisher"/>
+        </if>
+        <else>
+          <text value="t.np."/>
+        </else>
+      </choose>
+      <text value=", "/>
+      <choose>
+        <if variable="issued">
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </if>
+        <else>
+          <text term="no date" form="short"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- Tanggal akses URL: (diakses pada tanggal D Bulan YYYY) -->
+  <macro name="access">
+    <group prefix="(" suffix=")">
+      <text term="accessed" suffix=" "/>
+      <date variable="accessed" delimiter=" ">
+        <date-part name="day"/>
+        <date-part name="month" form="long"/>
+        <date-part name="year"/>
+      </date>
+    </group>
+  </macro>
+  <!-- Kunci sort: Al-Qur'an (legislation) selalu teratas di bibliografi -->
+  <macro name="sort-quran-first">
+    <choose>
+      <if type="legislation">
+        <text value="0"/>
+      </if>
+      <else>
+        <text value="1"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- ============================================================
+       CITATION  (CATATAN KAKI)
+       Referensi: Pedoman STAI Al-Anwar Sarang, Dokumen 2 (terbaru)
+  ============================================================ -->
+  <citation>
+    <layout suffix="." delimiter="; ">
+      <choose>
+        <!-- ── IBID dengan halaman: Ibid., [Jil. X, ]Y ──
+             Contoh: Ibid., 12.
+             Vol: Ibid., Jil. 1, 127. -->
+        <if position="ibid-with-locator">
+          <group delimiter=", ">
+            <group>
+              <text term="ibid"/>
+              <text value="."/>
+            </group>
+            <choose>
+              <if variable="volume">
+                <group delimiter=", ">
+                  <group delimiter=" ">
+                    <text term="volume" form="short"/>
+                    <number variable="volume"/>
+                  </group>
+                  <text macro="locator-p"/>
+                </group>
+              </if>
+              <else>
+                <text macro="locator-p"/>
+              </else>
+            </choose>
+          </group>
+        </if>
+        <!-- ── IBID tanpa halaman ──
+             Output: Ibid. (titik dari layout suffix) -->
+        <else-if position="ibid">
+          <text term="ibid"/>
+        </else-if>
+        <!-- ── KUTIPAN BERIKUTNYA (subsequent/op.cit style) ──
+             Contoh: Al-Suyūṭī, al-Itqān, Jil. 1, 127.
+             Format: NamaBelakang, JudulPendek, [Jil. X, ]Y. -->
+        <else-if position="subsequent">
+          <group delimiter=", ">
+            <text macro="author-short"/>
+            <text macro="title-short"/>
+            <choose>
+              <if variable="volume">
+                <group delimiter=", ">
+                  <group delimiter=" ">
+                    <text term="volume" form="short"/>
+                    <number variable="volume"/>
+                  </group>
+                  <text macro="locator-p"/>
+                </group>
+              </if>
+              <else>
+                <text macro="locator-p"/>
+              </else>
+            </choose>
+          </group>
+        </else-if>
+        <!-- ════════════════════════════════════════
+             KUTIPAN PERTAMA — format lengkap per jenis
+        ════════════════════════════════════════ -->
+        <else>
+          <choose>
+            <!-- ─── BUKU (termasuk terjemahan) ───
+                 Contoh: Abdurraḥmān bin Abū Bakar Jalāluddīn al-Suyūṭī,
+                   al-Itqān fi 'Ulūm al-Qur`an, Jil. 1 (Kairo: al-Hay`ah al-Maṣriyah
+                   al-'Āmmah, 1974), 108.
+                 Contoh terjemahan: Hasan Hanafi, Oksidentalisme...,
+                   terj. M. Najib Buchori (Jakarta: Paramadina, 2000), 9. -->
+            <if type="book">
+              <group delimiter=", ">
+                <text macro="author-note"/>
+                <group delimiter=" ">
+                  <group delimiter=", ">
+                    <text variable="title" font-style="italic"/>
+                    <text macro="volume"/>
+                    <text macro="translator-block"/>
+                  </group>
+                  <text macro="pub-paren"/>
+                </group>
+                <text macro="locator-p"/>
+              </group>
+            </if>
+            <!-- ─── ARTIKEL JURNAL ───
+                 Contoh (Doc 2 fn 4): Abdul Wadud Kasful Humam, "Menulusuri Historisitas
+                   Qira'at al-Qur'an", Syahadah, Vol. 3, No. 1 (2010), 89. -->
+            <else-if type="article-journal">
+              <group delimiter=", ">
+                <text macro="author-note"/>
+                <text variable="title" quotes="true"/>
+                <text variable="container-title" font-style="italic"/>
+                <group delimiter=" ">
+                  <group delimiter=", ">
+                    <group delimiter=" ">
+                      <text value="Vol."/>
+                      <number variable="volume"/>
+                    </group>
+                    <group delimiter=" ">
+                      <text term="issue" form="short"/>
+                      <number variable="issue"/>
+                    </group>
+                  </group>
+                  <date variable="issued" prefix="(" suffix=")">
+                    <date-part name="year"/>
+                  </date>
+                </group>
+                <text variable="locator"/>
+              </group>
+            </else-if>
+            <!-- ─── ARTIKEL BUNGA RAMPAI (Book Section) ───
+                 Contoh (Doc 2 fn 5): M. Ridlwan Hambali, "Hassan Hanafi: Dari Islam Kiri,
+                   Revitalisasi Turats", dalam Islam Garda Depan, Mosaik Pemikiran Islam
+                   Timur Tengah, Ed. M. Aunul Abid Shah (Bandung: Kaifa, 2001), 219. -->
+            <else-if type="chapter">
+              <group delimiter=", ">
+                <text macro="author-note"/>
+                <text variable="title" quotes="true"/>
+                <group delimiter=" ">
+                  <text term="in"/>
+                  <text variable="container-title" font-style="italic"/>
+                </group>
+                <group delimiter=" ">
+                  <text term="editor" form="short"/>
+                  <text macro="editor-note"/>
+                  <text macro="pub-paren"/>
+                </group>
+                <text variable="locator"/>
+              </group>
+            </else-if>
+            <!-- ─── SURAT KABAR / MAJALAH ───
+                 Contoh (Doc 2 fn 6): Tsalis Muttaqin, "Puasa dalam Perspektif Hikmah",
+                   Solo Pos (17 Nopember 2001), 4. -->
+            <else-if type="article-newspaper article-magazine" match="any">
+              <group delimiter=", ">
+                <text macro="author-note"/>
+                <text variable="title" quotes="true"/>
+                <group>
+                  <text variable="container-title" font-style="italic" suffix=" "/>
+                  <date variable="issued" prefix="(" suffix=")" delimiter=" ">
+                    <date-part name="day"/>
+                    <date-part name="month" form="long"/>
+                    <date-part name="year"/>
+                  </date>
+                </group>
+                <text variable="locator"/>
+              </group>
+            </else-if>
+            <!-- ─── SKRIPSI / TESIS / DISERTASI ───
+                 Contoh (Doc 2 fn 7): Abdul Ghofur Maimoen, "Ḥāshiyah...", Vol. 1
+                   (Disertasi di Al-Azhar University, Kairo, 2010), 213.
+                 Contoh (Doc 2 fn 8): Muhammad Asif, "Karakteristik Tafsir al-Ibrīz..."
+                   (Skripsi di STAIN Surakarta, 2010), 23.
+                 PANDUAN: Publisher = nama PT; Place = kota jika terpisah dari nama PT -->
+            <else-if type="thesis">
+              <group delimiter=", ">
+                <text macro="author-note"/>
+                <group delimiter=" ">
+                  <group delimiter=", ">
+                    <text variable="title" quotes="true"/>
+                    <text macro="volume"/>
+                  </group>
+                  <group>
+                    <text value="("/>
+                    <text variable="genre" suffix=" di "/>
+                    <text variable="publisher"/>
+                    <choose>
+                      <if variable="publisher-place">
+                        <text variable="publisher-place" prefix=", "/>
+                      </if>
+                    </choose>
+                    <date variable="issued" prefix=", ">
+                      <date-part name="year"/>
+                    </date>
+                    <text value=")"/>
+                  </group>
+                </group>
+                <text macro="locator-p"/>
+              </group>
+            </else-if>
+            <!-- ─── ARTIKEL INTERNET / WEBPAGE ───
+                 Contoh (Doc 2 fn 12): Moh Najib Buchori, "Tafsir Kontemporer, Antara Pro
+                   dan Anti Barat", dalam http://mazinov.wordpress.com/...,
+                   (diakses pada 5 Mei 2014). -->
+            <else-if type="webpage post post-weblog" match="any">
+              <group delimiter=", ">
+                <text macro="author-note"/>
+                <group delimiter=" ">
+                  <text variable="title" quotes="true"/>
+                  <text term="in"/>
+                  <text variable="URL"/>
+                  <text macro="access"/>
+                </group>
+              </group>
+            </else-if>
+            <!-- ─── WAWANCARA ───
+                 Contoh (Doc 2 fn 13): M.A. Haidar Buchori, Wawancara, Semarang, 14 Mei 2013.
+                 PANDUAN: Narasumber = Author; Tempat = Extra: publisher-place: Semarang -->
+            <else-if type="interview">
+              <group delimiter=", ">
+                <text macro="author-note"/>
+                <text term="interview" font-style="italic"/>
+                <text variable="publisher-place"/>
+                <date variable="issued" delimiter=" ">
+                  <date-part name="day"/>
+                  <date-part name="month" form="long"/>
+                  <date-part name="year"/>
+                </date>
+              </group>
+            </else-if>
+            <!-- ─── ENSIKLOPEDI (bentuk buku) ───
+                 Contoh (Doc 2 fn 10): A.J. Wensink, "Kufr", The First Encyclopaedia of Islam,
+                   Vol. 7, ed. M. Th. Houtsma, et. al. (Leiden: E.J Brill, 1987), 234. -->
+            <else-if type="entry-encyclopedia">
+              <group delimiter=", ">
+                <text macro="author-note"/>
+                <text variable="title" quotes="true"/>
+                <text variable="container-title" font-style="italic"/>
+                <text macro="volume"/>
+                <text macro="editor-etal"/>
+                <text macro="pub-paren"/>
+                <text macro="locator-p"/>
+              </group>
+            </else-if>
+            <!-- ─── ENSIKLOPEDI (bentuk aplikasi/software) ───
+                 Contoh (Doc 2 fn 11): Seyyed Hossein Nasr, "Qurʾān.",
+                   Encyclopædia Britannica, Encyclopædia Britannica Ultimate Reference Suite
+                   (Chicago: Encyclopædia Britannica, 2012) -->
+            <else-if type="entry-dictionary">
+              <group delimiter=", ">
+                <text macro="author-note"/>
+                <text variable="title" quotes="true"/>
+                <text variable="container-title" font-style="italic"/>
+                <text variable="edition"/>
+                <text macro="pub-paren"/>
+              </group>
+            </else-if>
+            <!-- ─── PROSIDING / MAKALAH KONFERENSI ───
+                 Contoh: Ahmad Zainul Hamdi, "Agama dan Kekerasan dalam Perspektif Islam",
+                   dalam Prosiding Seminar Nasional Islam dan Kemanusiaan,
+                   Ed. M. Anwar (Surabaya: IAIN Press, 2015), 45.
+                 PANDUAN: Author, Title, Proceedings Title (container-title),
+                   Editor, Publisher, Place, Year. -->
+            <else-if type="paper-conference">
+              <group delimiter=", ">
+                <text macro="author-note"/>
+                <text variable="title" quotes="true"/>
+                <group delimiter=" ">
+                  <text term="in"/>
+                  <text variable="container-title" font-style="italic"/>
+                </group>
+                <group delimiter=" ">
+                  <text term="editor" form="short"/>
+                  <text macro="editor-note"/>
+                  <text macro="pub-paren"/>
+                </group>
+                <text macro="locator-p"/>
+              </group>
+            </else-if>
+            <!-- ─── NASKAH KUNO / MANUSKRIP ARCHIVAL ───
+                 Contoh folio recto/verso:
+                   Anonim, Risālah fī al-Tawḥīd, No. 03.127,
+                   Perpustakaan Nasional RI, Jakarta, t.th., fol. 3r.
+                 Contoh dengan tahun kolofon:
+                   Muḥammad al-Nawawī, Nihāyat al-Zayn, MS Arab 1547,
+                   Leiden University Library, Leiden, 1285 H, 12.
+                 PANDUAN: Author = penulis/penyalin ("Anonim" jika t.d.).
+                   Loc. in Archive = kode/nomor naskah.
+                   Archive = nama koleksi/perpustakaan.
+                   Kota: Extra: archive-place: Jakarta
+                   Tahun kolofon: field Date (kosong → t.th.)
+                   Folio (1r/1v): di dialog sitasi Zotero, ubah dropdown
+                     locator dari "Page" → "Folio", lalu isi "1r" atau "1v".
+                     Output otomatis: fol. 1r / fol. 1v.
+                   Halaman biasa: biarkan "Page", isi angka halaman. -->
+            <else-if type="manuscript">
+              <group delimiter=", ">
+                <text macro="author-note"/>
+                <text variable="title" font-style="italic"/>
+                <text variable="archive_location"/>
+                <text variable="archive"/>
+                <text variable="archive-place"/>
+                <choose>
+                  <if variable="issued">
+                    <date variable="issued">
+                      <date-part name="year"/>
+                    </date>
+                  </if>
+                  <else>
+                    <text term="no date" form="short"/>
+                  </else>
+                </choose>
+                <text macro="locator-p"/>
+              </group>
+            </else-if>
+            <!-- ─── DOKUMEN / LAPORAN PEMERINTAH ───
+                 Contoh: Kementerian Agama RI, Pedoman Kurikulum Pesantren
+                   (Jakarta: Kemenag RI, 2023), 15.
+                 Contoh bernomor: BPS, Statistik Pendidikan 2022, No. 04330.0002
+                   (Jakarta: BPS, 2023), 10.
+                 PANDUAN: Author/Lembaga (Author field), Title,
+                   Report Number (number), Publisher = Institution, Place, Year. -->
+            <else-if type="report">
+              <group delimiter=", ">
+                <text macro="author-note"/>
+                <group delimiter=" ">
+                  <group delimiter=", ">
+                    <text variable="title" font-style="italic"/>
+                    <choose>
+                      <if variable="number">
+                        <group delimiter=" ">
+                          <text value="No."/>
+                          <text variable="number"/>
+                        </group>
+                      </if>
+                    </choose>
+                  </group>
+                  <text macro="pub-paren"/>
+                </group>
+                <text macro="locator-p"/>
+              </group>
+            </else-if>
+            <!-- ─── PIDATO PENGUKUHAN / ORASI ILMIAH ───
+                 Contoh: M. Amin Abdullah, "Rekonstruksi Metodologi Studi Islam",
+                   Pidato Pengukuhan Guru Besar, UIN Sunan Kalijaga,
+                   Yogyakarta, 14 Mei 2000.
+                 PANDUAN: Penyaji = Author. Jenis pidato di Extra: genre: ...
+                   Institusi di Extra: publisher: ... Tempat di field Place. -->
+            <else-if type="speech">
+              <group delimiter=", ">
+                <text macro="author-note"/>
+                <text variable="title" quotes="true"/>
+                <text variable="genre"/>
+                <text variable="publisher"/>
+                <text variable="publisher-place"/>
+                <date variable="issued" delimiter=" ">
+                  <date-part name="day"/>
+                  <date-part name="month" form="long"/>
+                  <date-part name="year"/>
+                </date>
+              </group>
+            </else-if>
+            <!-- ─── AL-QUR'AN (gunakan type "Statute" di Zotero) ───
+                 Contoh (Doc 2 fn 9): QS. al-An'ām [6]: 96.
+                 PANDUAN: Title = nama surah; Number = nomor surah; Section = nomor ayat -->
+            <else-if type="legislation">
+              <group>
+                <text value="QS. "/>
+                <text variable="title"/>
+                <text value=" "/>
+                <number variable="number" prefix="[" suffix="]"/>
+                <text value=": "/>
+                <text variable="section"/>
+              </group>
+            </else-if>
+            <!-- ─── DEFAULT FALLBACK ─── -->
+            <else>
+              <group delimiter=", ">
+                <text macro="author-note"/>
+                <text variable="title" font-style="italic"/>
+                <text macro="pub-paren"/>
+                <text variable="locator"/>
+              </group>
+            </else>
+          </choose>
+        </else>
+      </choose>
+    </layout>
+  </citation>
+  <!-- ============================================================
+       BIBLIOGRAPHY  (DAFTAR PUSTAKA)
+
+       Aturan urutan:
+         1. Al-Qur'an selalu teratas (type=legislation → kunci "0")
+         2. Semua entri lain: abjad berdasarkan nama belakang pengarang
+         3. Nama Arab "al-": masukkan Last Name = "Suyūṭī (al)" di Zotero
+            → tersortir di bawah huruf S
+         4. Pengarang sama, karya berbeda: nama diganti "_______" (7 garis bawah)
+  ============================================================ -->
+  <bibliography hanging-indent="false" subsequent-author-substitute="_______" subsequent-author-substitute-rule="complete-all" entry-spacing="1">
+    <sort>
+      <key macro="sort-quran-first"/>
+      <key variable="author"/>
+      <key variable="title"/>
+    </sort>
+    <layout suffix=".">
+      <choose>
+        <!-- ─── AL-QUR'AN ───
+             Output: Al-Qur`an -->
+        <if type="legislation">
+          <text value="Al-Qur`an"/>
+        </if>
+        <!-- ─── BUKU ───
+             Contoh (Pedoman): Suyūṭī (al), Abdurraḥmān bin Abū Bakar Jalāluddīn.
+               al-Itqān fi 'Ulūm al-Qur`an. Jil. 1. Cairo: al-Hay`ah al-Maṣriyah al-'Āmmah, 1974.
+             Contoh terjemahan (Pedoman): Hanafi, Hasan. Oksidentalisme...,
+               terj. M. Najib Buchori. Jakarta: Paramadina, 2000. -->
+        <else-if type="book">
+          <group>
+            <text macro="author-bib" suffix=". "/>
+            <group delimiter=", ">
+              <text variable="title" font-style="italic"/>
+              <text macro="volume"/>
+              <text macro="translator-block"/>
+            </group>
+            <text value=". "/>
+            <text macro="pub-bib"/>
+          </group>
+        </else-if>
+        <!-- ─── ARTIKEL JURNAL ───
+             Contoh (Pedoman): Muhyiddin, Hazim. "Kitāb al-Tafāsīr...".
+               Thaqāfatunā, 2010. -->
+        <else-if type="article-journal">
+          <group>
+            <text macro="author-bib" suffix=". "/>
+            <text variable="title" quotes="true" suffix=". "/>
+            <text variable="container-title" font-style="italic" suffix=", "/>
+            <group delimiter=", ">
+              <group delimiter=" ">
+                <text value="Vol."/>
+                <number variable="volume"/>
+              </group>
+              <choose>
+                <if variable="issue">
+                  <group delimiter=" ">
+                    <text term="issue" form="short"/>
+                    <number variable="issue"/>
+                  </group>
+                </if>
+              </choose>
+            </group>
+            <text value=", "/>
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+          </group>
+        </else-if>
+        <!-- ─── ARTIKEL BUNGA RAMPAI ───
+             Contoh (Pedoman): Hambali, M. Ridlwan. "Hassan Hanafi: Dari Islam Kiri...",
+               dalam Islam Garda Depan..., Ed. M. Aunul Abid Shah. Bandung: Kaifa, 2001. -->
+        <else-if type="chapter">
+          <group>
+            <text macro="author-bib" suffix=". "/>
+            <text variable="title" quotes="true" suffix=", "/>
+            <text term="in" suffix=" "/>
+            <text variable="container-title" font-style="italic" suffix=", "/>
+            <text term="editor" form="short" suffix=" "/>
+            <text macro="editor-note" suffix=". "/>
+            <text macro="pub-bib"/>
+          </group>
+        </else-if>
+        <!-- ─── SURAT KABAR ───
+             Contoh (Pedoman): Muttaqin, Tsalis. "Puasa dalam Perspektif Hikmah",
+               Solo Pos, 17 Nopember 2001. -->
+        <else-if type="article-newspaper article-magazine" match="any">
+          <group>
+            <text macro="author-bib" suffix=". "/>
+            <text variable="title" quotes="true" suffix=", "/>
+            <text variable="container-title" font-style="italic" suffix=" "/>
+            <date variable="issued" delimiter=" ">
+              <date-part name="day"/>
+              <date-part name="month" form="long"/>
+              <date-part name="year"/>
+            </date>
+          </group>
+        </else-if>
+        <!-- ─── SKRIPSI / TESIS / DISERTASI ───
+             Contoh (Pedoman): Maimoen, Abdul Ghofur. "Ḥāshiyah...".
+               Disertasi Al-Azhar University, Cairo, 2010.
+             Contoh (Pedoman): Asif, Muhammad. "Karakteristik Tafsir Al-Ibrīz...".
+               Skripsi STAIN Surakarta, 2010. -->
+        <else-if type="thesis">
+          <group>
+            <text macro="author-bib" suffix=". "/>
+            <text variable="title" quotes="true" suffix=". "/>
+            <text variable="genre" suffix=" "/>
+            <text variable="publisher"/>
+            <choose>
+              <if variable="publisher-place">
+                <text variable="publisher-place" prefix=", "/>
+              </if>
+            </choose>
+            <text value=", "/>
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+          </group>
+        </else-if>
+        <!-- ─── ARTIKEL INTERNET ───
+             Contoh (Pedoman): Buchori, Moh Najib. "Tafsir Kontemporer...",
+               dalam http://mazinov.wordpress.com/..., (diakses pada 5 Mei 2014). -->
+        <else-if type="webpage post post-weblog" match="any">
+          <group>
+            <text macro="author-bib" suffix=". "/>
+            <text variable="title" quotes="true" suffix=", "/>
+            <text term="in" suffix=" "/>
+            <text variable="URL" suffix=", "/>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <!-- ─── WAWANCARA ───
+             Contoh (Pedoman): M.A. Haidar Buchori, Wawancara, Semarang 14 Mei 2013.
+             CATATAN: nama TIDAK dibalik dalam contoh pedoman; tidak ada koma
+             antara tempat dan tanggal. -->
+        <else-if type="interview">
+          <group>
+            <text macro="author-note" suffix=". "/>
+            <text term="interview" font-style="italic" suffix=", "/>
+            <text variable="publisher-place" suffix=" "/>
+            <date variable="issued" delimiter=" ">
+              <date-part name="day"/>
+              <date-part name="month" form="long"/>
+              <date-part name="year"/>
+            </date>
+          </group>
+        </else-if>
+        <!-- ─── ENSIKLOPEDI (buku) ───
+             Contoh (Pedoman): Wensink, A.J. "Kufr". The First Encyclopaedia of Islam.
+               Vol. 7, ed. M. Th. Houtsma, et. al. Leiden: E.J Brill, 1987. -->
+        <else-if type="entry-encyclopedia">
+          <group>
+            <text macro="author-bib" suffix=". "/>
+            <text variable="title" quotes="true" suffix=". "/>
+            <text variable="container-title" font-style="italic" suffix=". "/>
+            <text macro="volume" suffix=", "/>
+            <text macro="editor-etal"/>
+            <text value=" "/>
+            <text macro="pub-bib"/>
+          </group>
+        </else-if>
+        <!-- ─── ENSIKLOPEDI (aplikasi/software) ───
+             Contoh (Pedoman): Nasr, Seyyed Hossein, "Qur`an". Encyclopædia Britannica,
+               Encyclopædia Britannica Ultimate Reference Suite. Chicago:
+               Encyclopædia Britannica, 2012. -->
+        <else-if type="entry-dictionary">
+          <group>
+            <text macro="author-bib" suffix=". "/>
+            <text variable="title" quotes="true" suffix=". "/>
+            <text variable="container-title" font-style="italic" suffix=", "/>
+            <text variable="edition" suffix=". "/>
+            <text macro="pub-bib"/>
+          </group>
+        </else-if>
+        <!-- ─── PROSIDING / MAKALAH KONFERENSI ───
+             Contoh: Hamdi, Ahmad Zainul. "Agama dan Kekerasan dalam Perspektif Islam".
+               dalam Prosiding Seminar Nasional Islam dan Kemanusiaan,
+               Ed. M. Anwar. Surabaya: IAIN Press, 2015. -->
+        <else-if type="paper-conference">
+          <group>
+            <text macro="author-bib" suffix=". "/>
+            <text variable="title" quotes="true" suffix=". "/>
+            <text term="in" suffix=" "/>
+            <text variable="container-title" font-style="italic" suffix=", "/>
+            <text term="editor" form="short" suffix=" "/>
+            <text macro="editor-note" suffix=". "/>
+            <text macro="pub-bib"/>
+          </group>
+        </else-if>
+        <!-- ─── NASKAH KUNO / MANUSKRIP ARCHIVAL ───
+             Contoh: Anonim. Risālah fī al-Tawḥīd. No. 03.127.
+               Perpustakaan Nasional RI, Jakarta. t.th.
+             Contoh: Nawawī (al), Muḥammad. Nihāyat al-Zayn. MS Arab 1547.
+               Leiden University Library, Leiden. 1285 H. -->
+        <else-if type="manuscript">
+          <group>
+            <text macro="author-bib" suffix=". "/>
+            <text variable="title" font-style="italic" suffix=". "/>
+            <choose>
+              <if variable="archive_location">
+                <text variable="archive_location" suffix=". "/>
+              </if>
+            </choose>
+            <choose>
+              <if variable="archive">
+                <group suffix=". ">
+                  <text variable="archive"/>
+                  <choose>
+                    <if variable="archive-place">
+                      <text variable="archive-place" prefix=", "/>
+                    </if>
+                  </choose>
+                </group>
+              </if>
+            </choose>
+            <choose>
+              <if variable="issued">
+                <date variable="issued">
+                  <date-part name="year"/>
+                </date>
+              </if>
+              <else>
+                <text term="no date" form="short"/>
+              </else>
+            </choose>
+          </group>
+        </else-if>
+        <!-- ─── DOKUMEN / LAPORAN PEMERINTAH ───
+             Contoh: Kementerian Agama RI. Pedoman Kurikulum Pesantren.
+               Jakarta: Kemenag RI, 2023.
+             Contoh bernomor: BPS. Statistik Pendidikan 2022, No. 04330.0002.
+               Jakarta: BPS, 2023. -->
+        <else-if type="report">
+          <group>
+            <text macro="author-bib" suffix=". "/>
+            <group delimiter=", " suffix=". ">
+              <text variable="title" font-style="italic"/>
+              <choose>
+                <if variable="number">
+                  <group delimiter=" ">
+                    <text value="No."/>
+                    <text variable="number"/>
+                  </group>
+                </if>
+              </choose>
+            </group>
+            <text macro="pub-bib"/>
+          </group>
+        </else-if>
+        <!-- ─── PIDATO PENGUKUHAN / ORASI ILMIAH ───
+             Contoh: Abdullah, M. Amin. "Rekonstruksi Metodologi Studi Islam".
+               Pidato Pengukuhan Guru Besar. UIN Sunan Kalijaga,
+               Yogyakarta, 14 Mei 2000. -->
+        <else-if type="speech">
+          <group>
+            <text macro="author-bib" suffix=". "/>
+            <text variable="title" quotes="true" suffix=". "/>
+            <choose>
+              <if variable="genre">
+                <text variable="genre" suffix=". "/>
+              </if>
+            </choose>
+            <text variable="publisher"/>
+            <choose>
+              <if variable="publisher-place">
+                <text variable="publisher-place" prefix=", "/>
+              </if>
+            </choose>
+            <text value=", "/>
+            <date variable="issued" delimiter=" ">
+              <date-part name="day"/>
+              <date-part name="month" form="long"/>
+              <date-part name="year"/>
+            </date>
+          </group>
+        </else-if>
+        <!-- ─── DEFAULT FALLBACK ─── -->
+        <else>
+          <group>
+            <text macro="author-bib" suffix=". "/>
+            <text variable="title" font-style="italic" suffix=". "/>
+            <text macro="pub-bib"/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>

--- a/stai-al-anwar-sarang.csl
+++ b/stai-al-anwar-sarang.csl
@@ -19,7 +19,7 @@
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <!-- ============================================================
-       LOCALE — override English defaults with Indonesian/institutional terms
+       LOCALE &#8212; override English defaults with Indonesian/institutional terms
   ============================================================ -->
   <locale xml:lang="id">
     <terms>
@@ -50,7 +50,7 @@
         <single>fol.</single>
         <multiple>fol.</multiple>
       </term>
-      <!-- Nama bulan Bahasa Indonesia — didefinisikan eksplisit agar tidak
+      <!-- Nama bulan Bahasa Indonesia &#8212; didefinisikan eksplisit agar tidak
            bergantung pada kelengkapan locale id-ID bawaan aplikasi (mis. Mendeley) -->
       <term name="month-01">Januari</term>
       <term name="month-02">Februari</term>
@@ -69,7 +69,7 @@
   <!-- ============================================================
        MACROS
   ============================================================ -->
-  <!-- Nama pengarang TIDAK dibalik — untuk catatan kaki -->
+  <!-- Nama pengarang TIDAK dibalik &#8212; untuk catatan kaki -->
   <macro name="author-note">
     <names variable="author">
       <name and="text" delimiter-precedes-last="never" initialize="false" delimiter=", "/>
@@ -80,7 +80,7 @@
       </substitute>
     </names>
   </macro>
-  <!-- Nama pengarang DIBALIK, pengarang pertama saja — untuk bibliografi -->
+  <!-- Nama pengarang DIBALIK, pengarang pertama saja &#8212; untuk bibliografi -->
   <macro name="author-bib">
     <names variable="author">
       <name and="text" delimiter-precedes-last="never" name-as-sort-order="first" sort-separator=", " initialize="false" delimiter=", "/>
@@ -91,7 +91,7 @@
       </substitute>
     </names>
   </macro>
-  <!-- Nama belakang saja — untuk kutipan berikutnya (subsequent) -->
+  <!-- Nama belakang saja &#8212; untuk kutipan berikutnya (subsequent) -->
   <macro name="author-short">
     <names variable="author">
       <name form="short" and="text" delimiter-precedes-last="never" delimiter=", "/>
@@ -101,19 +101,19 @@
       </substitute>
     </names>
   </macro>
-  <!-- Nama editor, tidak dibalik — untuk tampilan inline -->
+  <!-- Nama editor, tidak dibalik &#8212; untuk tampilan inline -->
   <macro name="editor-note">
     <names variable="editor">
       <name and="text" delimiter-precedes-last="never" initialize="false" delimiter=", "/>
     </names>
   </macro>
-  <!-- Nama penerjemah, tidak dibalik — untuk tampilan inline -->
+  <!-- Nama penerjemah, tidak dibalik &#8212; untuk tampilan inline -->
   <macro name="translator-note">
     <names variable="translator">
       <name and="text" delimiter-precedes-last="never" initialize="false" delimiter=", "/>
     </names>
   </macro>
-  <!-- "terj. [Nama]" — kondisi terjemahan; dipakai di buku catatan kaki & bibliografi -->
+  <!-- "terj. [Nama]" &#8212; kondisi terjemahan; dipakai di buku catatan kaki & bibliografi -->
   <macro name="translator-block">
     <choose>
       <if variable="translator">
@@ -124,7 +124,7 @@
       </if>
     </choose>
   </macro>
-  <!-- Editor dengan et.al. — untuk ensiklopedi catatan kaki & bibliografi -->
+  <!-- Editor dengan et.al. &#8212; untuk ensiklopedi catatan kaki & bibliografi -->
   <macro name="editor-etal">
     <names variable="editor">
       <label form="short" text-case="lowercase" suffix=" "/>
@@ -132,7 +132,7 @@
       <et-al/>
     </names>
   </macro>
-  <!-- "Jil. X" — hanya muncul jika field volume diisi -->
+  <!-- "Jil. X" &#8212; hanya muncul jika field volume diisi -->
   <macro name="volume">
     <choose>
       <if variable="volume">
@@ -320,7 +320,7 @@
           </group>
         </else-if>
         <!-- ════════════════════════════════════════
-             KUTIPAN PERTAMA — format lengkap per jenis
+             KUTIPAN PERTAMA &#8212; format lengkap per jenis
         ════════════════════════════════════════ -->
         <else>
           <choose>


### PR DESCRIPTION
Adds Al-Anwar Citation Style (ACS) v1.2.1, an Indonesian notes and bibliography style for academic writing at STAI Al-Anwar Sarang Rembang. It covers Islamic studies, humanities, and social-science sources, including classical works and manuscripts, and uses Ibid. for consecutive citations.

Documentation: https://staialanwar.ac.id/acs/

The CSL is licensed under CC BY-SA 3.0. The documentation page currently displays an older release and a general CC BY-NC-ND notice; its release information and the distinction between the manual's license and the CSL license still need updating.

Validation

Passes the official CSL and CSL repository schemas using Jing, and the official Schematron macro checks.

File name, style ID, and self link match.

Local citeproc-js comparisons with the supplied v1.2.1 release produce identical first citations, Ibid., subsequent citations, and bibliographies for 35 sample source records, plus additional Quran, hadith, and mixed-source sequences.

Checklist

Template provenance: the supplied style does not declare a source template; provenance has not been independently verified.

Includes a link to the institution's published documentation.

Includes author information.

Labels and literal strings have been reviewed; institution-specific strings are retained.

Preserves the original first-line XML declaration.