### PR TITLE
Add Veterinary Ophthalmology style

### DIFF
--- a/veterinary-ophthalmology.csl
+++ b/veterinary-ophthalmology.csl
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl"
+  class="in-text"
+  version="1.0"
+  default-locale="en-US"
+  demote-non-dropping-particle="sort-only"
+  page-range-format="expanded">
+  <info>
+    <title>Veterinary Ophthalmology</title>
+    <title-short>Vet Ophthalmol/VOP</title-short>
+    <id>http://www.zotero.org/styles/veterinary-ophthalmology</id>
+    <link href="http://www.zotero.org/styles/veterinary-ophthalmology" rel="self"/>
+    <link href="https://onlinelibrary.wiley.com/page/journal/14635224/homepage/forauthors.html" rel="documentation"/>
+    <link href="https://onlinelibrary.wiley.com/doi/10.1111/vop.70038" rel="documentation"/>
+    <author>
+      <name>Ana Ripolles-Garcia</name>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="medicine"/>
+    <issn>1463-5216</issn>
+    <eissn>1463-5224</eissn>
+    <summary>Current production reference style used by Veterinary Ophthalmology, with full journal titles.</summary>
+    <updated>2026-09-03T19:00:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+
+  <locale xml:lang="en">
+    <style-options punctuation-in-quote="true"/>
+    <terms>
+      <term name="page-range-delimiter">–</term>
+      <term name="citation-range-delimiter">–</term>
+    </terms>
+  </locale>
+
+  <macro name="author">
+    <names variable="author">
+      <name and="text"
+        delimiter=", "
+        delimiter-precedes-last="always"
+        delimiter-precedes-et-al="always"
+        initialize-with=". "
+        et-al-min="7"
+        et-al-use-first="3"/>
+      <et-al font-style="normal"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+  </macro>
+
+  <macro name="editor">
+    <names variable="editor">
+      <name and="text"
+        delimiter=", "
+        delimiter-precedes-last="always"
+        initialize-with=". "/>
+    </names>
+  </macro>
+
+  <macro name="year">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+
+  <macro name="access">
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix="https://doi.org/"/>
+      </if>
+      <else-if variable="URL">
+        <text variable="URL"/>
+      </else-if>
+    </choose>
+  </macro>
+
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout prefix="[" suffix="]" delimiter=", ">
+      <text variable="citation-number"/>
+    </layout>
+  </citation>
+
+  <bibliography entry-spacing="0"
+    line-spacing="1"
+    second-field-align="flush">
+    <layout>
+      <text variable="citation-number" suffix=". "/>
+
+      <choose>
+
+        <if type="article-journal article-magazine article-newspaper" match="any">
+          <text macro="author" suffix=", "/>
+          <text variable="title" quotes="true" suffix=", "/>
+          <text variable="container-title" font-style="italic"/>
+          <text variable="volume" font-style="italic" prefix=" "/>
+          <group delimiter=" " prefix=", ">
+            <label variable="issue" form="short"/>
+            <text variable="issue"/>
+          </group>
+          <text macro="year" prefix=" (" suffix=")"/>
+          <text variable="page" prefix=": "/>
+          <text macro="access" prefix=", " suffix="."/>
+        </if>
+
+        <else-if type="chapter entry-dictionary entry-encyclopedia" match="any">
+          <text macro="author" suffix=", "/>
+          <text variable="title" quotes="true" suffix=", "/>
+          <text term="in" suffix=" "/>
+          <text variable="container-title" font-style="italic"/>
+          <group delimiter=" " prefix=", ">
+            <label variable="volume" form="short" text-case="capitalize-first"/>
+            <text variable="volume"/>
+          </group>
+          <text macro="edition" prefix=", "/>
+          <text macro="editor" prefix=", ed. "/>
+          <group delimiter=", " prefix=" (" suffix=")">
+            <text variable="publisher"/>
+            <text macro="year"/>
+          </group>
+          <text variable="page" prefix=", "/>
+          <text macro="access" prefix=", " suffix="."/>
+        </else-if>
+
+        <else-if type="book" match="any">
+          <text macro="author" suffix=", "/>
+          <text variable="title" font-style="italic"/>
+          <text macro="edition" prefix=", "/>
+          <group delimiter=", " prefix=" (" suffix=")">
+            <text variable="publisher"/>
+            <text macro="year"/>
+          </group>
+          <text macro="access" prefix=", " suffix="."/>
+        </else-if>
+
+        <else-if type="paper-conference" match="any">
+          <text macro="author" suffix=", "/>
+          <text variable="title" quotes="true" suffix=", "/>
+          <text variable="container-title" font-style="italic"/>
+          <text variable="volume" font-style="italic" prefix=" "/>
+          <text macro="year" prefix=" (" suffix=")"/>
+          <text variable="page" prefix=": "/>
+          <text macro="access" prefix=", " suffix="."/>
+        </else-if>
+
+        <else-if type="thesis report" match="any">
+          <text macro="author" suffix=", "/>
+          <text variable="title" font-style="italic"/>
+          <text variable="genre" prefix=", "/>
+          <group delimiter=", " prefix=" (" suffix=")">
+            <text variable="publisher"/>
+            <text macro="year"/>
+          </group>
+          <text macro="access" prefix=", " suffix="."/>
+        </else-if>
+
+        <else-if type="webpage post post-weblog" match="any">
+          <text macro="author" suffix=", "/>
+          <text variable="title"/>
+          <text variable="container-title" font-style="italic" prefix=", "/>
+          <text macro="year" prefix=" (" suffix=")"/>
+          <text macro="access" prefix=", " suffix="."/>
+        </else-if>
+
+        <else>
+          <text macro="author" suffix=", "/>
+          <text variable="title" quotes="true"/>
+          <text variable="container-title" font-style="italic" prefix=", "/>
+          <text macro="year" prefix=" (" suffix=")"/>
+          <text macro="access" prefix=", " suffix="."/>
+        </else>
+
+      </choose>
+    </layout>
+  </bibliography>
+</style>

--- a/veterinary-ophthalmology.csl
+++ b/veterinary-ophthalmology.csl
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl"
-  class="in-text"
-  version="1.0"
-  default-locale="en-US"
-  demote-non-dropping-particle="sort-only"
-  page-range-format="expanded">
-
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="expanded" default-locale="en-US">
   <info>
     <title>Veterinary Ophthalmology</title>
     <title-short>Vet Ophthalmol/VOP</title-short>
@@ -24,16 +18,9 @@
     <updated>2026-09-03T19:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-
   <macro name="author">
     <names variable="author">
-      <name and="text"
-        delimiter=", "
-        delimiter-precedes-last="always"
-        delimiter-precedes-et-al="always"
-        initialize-with=". "
-        et-al-min="7"
-        et-al-use-first="3"/>
+      <name and="text" delimiter=", " delimiter-precedes-last="always" delimiter-precedes-et-al="always" initialize-with=". " et-al-min="7" et-al-use-first="3"/>
       <et-al font-style="normal"/>
       <substitute>
         <names variable="editor"/>
@@ -41,16 +28,11 @@
       </substitute>
     </names>
   </macro>
-
   <macro name="editor">
     <names variable="editor">
-      <name and="text"
-        delimiter=", "
-        delimiter-precedes-last="always"
-        initialize-with=". "/>
+      <name and="text" delimiter=", " delimiter-precedes-last="always" initialize-with=". "/>
     </names>
   </macro>
-
   <macro name="year">
     <choose>
       <if variable="issued">
@@ -63,7 +45,6 @@
       </else>
     </choose>
   </macro>
-
   <macro name="edition">
     <choose>
       <if is-numeric="edition">
@@ -77,7 +58,6 @@
       </else>
     </choose>
   </macro>
-
   <macro name="access">
     <choose>
       <if variable="DOI">
@@ -88,7 +68,6 @@
       </else-if>
     </choose>
   </macro>
-
   <citation collapse="citation-number">
     <sort>
       <key variable="citation-number"/>
@@ -97,17 +76,10 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-
-  <bibliography
-    entry-spacing="0"
-    line-spacing="1"
-    second-field-align="flush">
-
+  <bibliography entry-spacing="0" line-spacing="1" second-field-align="flush">
     <layout>
       <text variable="citation-number" suffix=". "/>
-
       <choose>
-
         <if type="article-journal article-magazine article-newspaper" match="any">
           <text macro="author" suffix=", "/>
           <text variable="title" quotes="true" suffix=", "/>
@@ -121,7 +93,6 @@
           <text variable="page" prefix=": "/>
           <text macro="access" prefix=", " suffix="."/>
         </if>
-
         <else-if type="chapter entry-dictionary entry-encyclopedia" match="any">
           <text macro="author" suffix=", "/>
           <text variable="title" quotes="true" suffix=", "/>
@@ -140,7 +111,6 @@
           <text variable="page" prefix=", "/>
           <text macro="access" prefix=", " suffix="."/>
         </else-if>
-
         <else-if type="book" match="any">
           <text macro="author" suffix=", "/>
           <text variable="title" font-style="italic"/>
@@ -151,7 +121,6 @@
           </group>
           <text macro="access" prefix=", " suffix="."/>
         </else-if>
-
         <else-if type="paper-conference" match="any">
           <text macro="author" suffix=", "/>
           <text variable="title" quotes="true" suffix=", "/>
@@ -161,7 +130,6 @@
           <text variable="page" prefix=": "/>
           <text macro="access" prefix=", " suffix="."/>
         </else-if>
-
         <else-if type="thesis report" match="any">
           <text macro="author" suffix=", "/>
           <text variable="title" font-style="italic"/>
@@ -172,7 +140,6 @@
           </group>
           <text macro="access" prefix=", " suffix="."/>
         </else-if>
-
         <else-if type="webpage post post-weblog" match="any">
           <text macro="author" suffix=", "/>
           <text variable="title"/>
@@ -180,7 +147,6 @@
           <text macro="year" prefix=" (" suffix=")"/>
           <text macro="access" prefix=", " suffix="."/>
         </else-if>
-
         <else>
           <text macro="author" suffix=", "/>
           <text variable="title" quotes="true"/>
@@ -188,9 +154,7 @@
           <text macro="year" prefix=" (" suffix=")"/>
           <text macro="access" prefix=", " suffix="."/>
         </else>
-
       </choose>
     </layout>
   </bibliography>
-
 </style>

--- a/veterinary-ophthalmology.csl
+++ b/veterinary-ophthalmology.csl
@@ -5,6 +5,7 @@
   default-locale="en-US"
   demote-non-dropping-particle="sort-only"
   page-range-format="expanded">
+
   <info>
     <title>Veterinary Ophthalmology</title>
     <title-short>Vet Ophthalmol/VOP</title-short>
@@ -23,14 +24,6 @@
     <updated>2026-09-03T19:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-
-  <locale xml:lang="en">
-    <style-options punctuation-in-quote="true"/>
-    <terms>
-      <term name="page-range-delimiter">–</term>
-      <term name="citation-range-delimiter">–</term>
-    </terms>
-  </locale>
 
   <macro name="author">
     <names variable="author">
@@ -105,9 +98,11 @@
     </layout>
   </citation>
 
-  <bibliography entry-spacing="0"
+  <bibliography
+    entry-spacing="0"
     line-spacing="1"
     second-field-align="flush">
+
     <layout>
       <text variable="citation-number" suffix=". "/>
 
@@ -197,4 +192,5 @@
       </choose>
     </layout>
   </bibliography>
+
 </style>


### PR DESCRIPTION
Adds the current Veterinary Ophthalmology citation style based on recent published articles. The style uses numeric citations, full journal titles rather than abbreviated journal names, and the current journal-specific bibliography formatting. This style is not currently available in the CSL repository and would be useful for researchers and clinicians publishing in veterinary ophthalmology.

## CSL Styles Pull Request Template
You're about to create a pull request to the CSL **styles** repository.  
If you haven't done so already, see <https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md> for instructions on how to contribute, and <https://github.com/citation-style-language/styles/blob/master/STYLE_REQUIREMENTS.md> for the requirements a style must meet before acceptance.  
In addition, please fill out the pull request template below.


### Description
Adds a CSL style for Veterinary Ophthalmology based on the current reference formatting used in recently published articles. The style uses numeric citations, full journal titles rather than abbreviated journal names, and current journal-specific bibliography formatting.

The style was created specifically for Veterinary Ophthalmology and was not derived from an existing CSL template.

### Checklist
- [ ] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.
- [x] Check that you've added a link to the style guidelines with `rel="documentation"`.
- [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update.
- [x] Check that you've used the correct terms or labels instead of hardcoding into affixes.
- [x] Check that you've not used `<text value="..."` if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.
