### PR TITLE
New style: Lingua Aegyptia

### DIFF
--- a/lingua-aegyptia.csl
+++ b/lingua-aegyptia.csl
@@ -1,0 +1,276 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" page-range-format="expanded">
+  <info>
+    <title>Lingua Aegyptia: Journal of Egyptian Language Studies</title>
+    <title-short>LingAeg</title-short>
+    <id>http://www.zotero.org/styles/lingua-aegyptia</id>
+    <link href="http://www.zotero.org/styles/lingua-aegyptia" rel="self"/>
+    <link href="http://widmaier-publishing.de/data/info/LingAeg-Guidelines-Policies_2024-07.pdf" rel="documentation"/>
+    <author>
+      <name>Kierán Meinhardt</name>
+      <uri>https://orcid.org/0009-0000-1250-807X</uri>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="linguistics"/>
+    <category field="humanities"/>
+    <issn>0942-5659</issn>
+    <summary>Author-date style of Lingua Aegyptia (Widmaier Verlag), following its Guidelines and Policies, July 2024, § 7. The journal publishes in English, German and French, and § 7.2.4 (9) requires the bibliography to follow the language of the article, so no default-locale is set.</summary>
+    <updated>2026-09-05T00:00:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <!-- "(eds)", "(Hrsg)", "(éd)": editor labels without a full point, and "&"
+       as the name conjunction. "in:" is spelled the same in all three
+       languages of the journal and is therefore set literally below. -->
+  <locale xml:lang="en">
+    <terms>
+      <term name="editor" form="short">
+        <single>ed</single>
+        <multiple>eds</multiple>
+      </term>
+      <term name="translator" form="short">
+        <single>trans</single>
+        <multiple>trans</multiple>
+      </term>
+      <term name="editortranslator" form="short">
+        <single>ed &amp; trans</single>
+        <multiple>eds &amp; trans</multiple>
+      </term>
+      <term name="and">&amp;</term>
+    </terms>
+  </locale>
+  <locale xml:lang="de">
+    <terms>
+      <term name="editor" form="short">
+        <single>Hrsg</single>
+        <multiple>Hrsg</multiple>
+      </term>
+      <term name="translator" form="short">
+        <single>Übers</single>
+        <multiple>Übers</multiple>
+      </term>
+      <term name="editortranslator" form="short">
+        <single>Hrsg &amp; Übers</single>
+        <multiple>Hrsg &amp; Übers</multiple>
+      </term>
+      <term name="and">&amp;</term>
+    </terms>
+  </locale>
+  <locale xml:lang="fr">
+    <terms>
+      <term name="editor" form="short">
+        <single>éd</single>
+        <multiple>éd</multiple>
+      </term>
+      <term name="translator" form="short">
+        <single>trad</single>
+        <multiple>trad</multiple>
+      </term>
+      <term name="editortranslator" form="short">
+        <single>éd &amp; trad</single>
+        <multiple>éd &amp; trad</multiple>
+      </term>
+      <term name="and">&amp;</term>
+    </terms>
+  </locale>
+  <!-- § 7.2.4 (4): the surname precedes the first name only in the initial
+       position of an entry; § 7.2.4 (3): first names are never abbreviated. -->
+  <macro name="author">
+    <names variable="author">
+      <name and="symbol" delimiter=", " delimiter-precedes-last="never" name-as-sort-order="first" sort-separator=", "/>
+      <label form="short" prefix=" (" suffix=")"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="symbol" delimiter=", " delimiter-precedes-last="never"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- Editors of a containing volume: given name first throughout. -->
+  <macro name="editor-in">
+    <names variable="editor translator" delimiter=", ">
+      <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
+      <label form="short" prefix=" (" suffix=")"/>
+    </names>
+  </macro>
+  <macro name="sort-key-names">
+    <names variable="author">
+      <name form="long" name-as-sort-order="all" sort-separator=", " delimiter=", "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="accessed">
+    <group prefix="(" suffix=")" delimiter=" ">
+      <text term="accessed"/>
+      <date variable="accessed">
+        <date-part name="day" suffix=" "/>
+        <date-part name="month" form="long" suffix=" "/>
+        <date-part name="year"/>
+      </date>
+    </group>
+  </macro>
+  <!-- § 7.2.4 (6): italics are restricted to the titles of monographs, edited
+       volumes and journals; a piece inside a container is set in roman.
+       § 7.2.4 (8): no quotation marks around titles. -->
+  <macro name="title">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper review review-book chapter paper-conference entry entry-dictionary entry-encyclopedia post post-weblog webpage speech" variable="container-title" match="any">
+        <text variable="title"/>
+      </if>
+      <else>
+        <text variable="title" font-style="italic"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- § 7.2.4 (2): series titles are given in full and are not italicised. -->
+  <macro name="collection">
+    <group delimiter=" ">
+      <text variable="collection-title"/>
+      <number variable="collection-number"/>
+    </group>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- § 7.2.4 (7): the place is the last element of the entry. Naming the
+       publisher is optional, but must then be done throughout the whole
+       bibliography ("Wiesbaden: Harrassowitz"), so it is omitted here. -->
+  <macro name="place">
+    <text variable="publisher-place"/>
+  </macro>
+  <macro name="locators">
+    <text variable="page"/>
+  </macro>
+  <macro name="body">
+    <choose>
+      <!-- § 7.2.2 Articles in journals -->
+      <if type="article-journal article-magazine article-newspaper review review-book" match="any">
+        <group delimiter=", ">
+          <text macro="title"/>
+          <group delimiter=" " prefix="in: ">
+            <text variable="container-title" font-style="italic"/>
+            <text variable="volume"/>
+          </group>
+          <text macro="locators"/>
+        </group>
+      </if>
+      <else-if type="thesis">
+        <group delimiter=", ">
+          <text macro="title"/>
+          <text variable="genre"/>
+          <text variable="publisher"/>
+          <text macro="place"/>
+        </group>
+      </else-if>
+      <else-if type="webpage post post-weblog dataset software" match="any">
+        <group delimiter=", ">
+          <text macro="title"/>
+          <text variable="container-title" font-style="italic"/>
+          <text variable="version"/>
+          <text macro="place"/>
+          <group delimiter=" ">
+            <text variable="URL"/>
+            <text macro="accessed"/>
+          </group>
+        </group>
+      </else-if>
+      <!-- § 7.2.3 Articles in edited monographs, and conference papers -->
+      <else-if type="chapter paper-conference entry entry-dictionary entry-encyclopedia" variable="container-title" match="any">
+        <group delimiter=", ">
+          <text macro="title"/>
+          <group delimiter=", " prefix="in: ">
+            <text macro="editor-in"/>
+            <text variable="container-title" font-style="italic"/>
+          </group>
+          <text macro="edition"/>
+          <text macro="collection"/>
+          <text macro="place"/>
+          <text macro="locators"/>
+        </group>
+      </else-if>
+      <!-- § 7.2.1 Monographs -->
+      <else>
+        <group delimiter=", ">
+          <text macro="title"/>
+          <text macro="edition"/>
+          <text macro="collection"/>
+          <group delimiter=" ">
+            <label variable="volume" form="short"/>
+            <text variable="volume"/>
+          </group>
+          <text macro="place"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <!-- § 7.1: Černý (1929) / Černý (1929: 244–245) / (Černý 1929: 244–245) /
+       Černý (1929 & 1930). -->
+  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="all-names" collapse="year" cite-group-delimiter=" &amp; " year-suffix-delimiter=", " after-collapse-delimiter="; ">
+    <sort>
+      <key macro="sort-key-names"/>
+      <key variable="issued"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=": ">
+        <group delimiter=" ">
+          <text macro="author-short"/>
+          <text macro="issued"/>
+        </group>
+        <text variable="locator"/>
+      </group>
+    </layout>
+  </citation>
+  <!-- § 7.2.4 (5): works by the same author are ordered chronologically and
+       the name is repeated in full — no dashes for repeated names, hence no
+       subsequent-author-substitute. All names are given in the bibliography,
+       so no et-al truncation here. -->
+  <bibliography hanging-indent="true" entry-spacing="0" line-spacing="1">
+    <sort>
+      <key macro="sort-key-names"/>
+      <key variable="issued"/>
+      <key variable="title"/>
+    </sort>
+    <layout>
+      <group delimiter=". ">
+        <text macro="author"/>
+        <text macro="issued"/>
+      </group>
+      <text macro="body" prefix=". " suffix="."/>
+    </layout>
+  </bibliography>
+</style>

--- a/lingua-aegyptia.csl
+++ b/lingua-aegyptia.csl
@@ -238,7 +238,7 @@
       </else>
     </choose>
   </macro>
-  <!-- § 7.1: Černý (1929) / Černý (1929: 244–245) / (Černý 1929: 244–245) /
+  <!-- § 7.1: Černý (1929) / Černý (1929: 244&#8211;245) / (Černý 1929: 244&#8211;245) /
        Černý (1929 & 1930). -->
   <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="all-names" collapse="year" cite-group-delimiter=" &amp; " year-suffix-delimiter=", " after-collapse-delimiter="; ">
     <sort>
@@ -256,7 +256,7 @@
     </layout>
   </citation>
   <!-- § 7.2.4 (5): works by the same author are ordered chronologically and
-       the name is repeated in full — no dashes for repeated names, hence no
+       the name is repeated in full &#8212; no dashes for repeated names, hence no
        subsequent-author-substitute. All names are given in the bibliography,
        so no et-al truncation here. -->
   <bibliography hanging-indent="true" entry-spacing="0" line-spacing="1">


### PR DESCRIPTION
### Description

Adds a style for *Lingua Aegyptia – Journal of Egyptian Language Studies* (Widmaier Verlag, ISSN 0942-5659), the main journal for Egyptian and Coptic linguistics. No CSL style for it existed.

Built from the journal's [Guidelines and Policies, July 2024](http://widmaier-publishing.de/data/info/LingAeg-Guidelines-Policies_2024-07.pdf), § 7. Every worked example in §§ 7.2.1–7.2.4 is reproduced verbatim (monograph, two-author monograph, series volume, journal article, chapter in an edited volume).

Notable features of the style, all from § 7:

* `Černý (1929: 244–245)` / `(Černý 1929: 244–245)` — colon before the locator, not a comma (§ 7.1)
* article and chapter titles in roman, with no quotation marks; italics restricted to monographs, edited volumes and journals (§ 7.2.4 (6), (8))
* `, in:` before the container, with editors given-name-first and `(eds)` without a full point (§ 7.2.3)
* place last, publisher omitted (§ 7.2.4 (7) makes the publisher optional but requires consistency)
* series title in full, unitalicised, after the container title (§ 7.2.4 (2))
* repeated authors written out in full, no `———` substitution (§ 7.2.4 (5))

**On `default-locale`:** deliberately unset. The journal publishes in English, German and French, and § 7.2.4 (9) requires the bibliography's language to follow the *article's* language, not the cited work's. The style therefore carries `en`, `de` and `fr` locale overrides for the editor labels (`(eds)` / `(Hrsg)` / `(éd)`), matching the three worked examples in § 7.2.4 (9).

Validates against `csl-repository.rnc`.

### Checklist

- [ ] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.
  — n/a: written from the journal's guidelines rather than derived from an existing style, so there is no template to credit.
- [x] Check that you've added a link to the style guidelines with `rel="documentation"`.
- [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update.
- [x] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
  — with one deliberate exception: `in:` is set as a literal prefix rather than via the `in` term. It is spelled identically in the journal's three publication languages, and § 7.2.3 requires the colon. Happy to switch it to `<text term="in" suffix=":"/>` if you would rather it went through the locale.
- [x] Check that you've not used `<text value="...` if not absolutely necessary. — not used at all.
- [x] Check that you've not changed line 1 of the style.
